### PR TITLE
User defined constants

### DIFF
--- a/syntaxes/verilog.tmLanguage
+++ b/syntaxes/verilog.tmLanguage
@@ -93,6 +93,12 @@
 			<array>
 				<dict>
 					<key>match</key>
+					<string>`(?!(celldefine|endcelldefine|default_nettype|define|undef|ifdef|else|endif|include|resetall|timescale|unconnected_drive|nounconnected_drive))[a-z_A-Z][a-zA-Z0-9_$]*</string>
+					<key>name</key>
+					<string>support.constant.verilog</string>
+				</dict>
+				<dict>
+					<key>match</key>
 					<string>[0-9]*'[bBoOdDhH][a-fA-F0-9_xXzZ]+\b</string>
 					<key>name</key>
 					<string>constant.numeric.sized_integer.verilog</string>

--- a/syntaxes/verilog.tmLanguage
+++ b/syntaxes/verilog.tmLanguage
@@ -95,7 +95,7 @@
 					<key>match</key>
 					<string>`(?!(celldefine|endcelldefine|default_nettype|define|undef|ifdef|else|endif|include|resetall|timescale|unconnected_drive|nounconnected_drive))[a-z_A-Z][a-zA-Z0-9_$]*</string>
 					<key>name</key>
-					<string>entity.name.constant.verilog, variable.other.constant.verilog</string>
+					<string>variable.other.constant.verilog</string>
 				</dict>
 				<dict>
 					<key>match</key>

--- a/syntaxes/verilog.tmLanguage
+++ b/syntaxes/verilog.tmLanguage
@@ -95,7 +95,7 @@
 					<key>match</key>
 					<string>`(?!(celldefine|endcelldefine|default_nettype|define|undef|ifdef|else|endif|include|resetall|timescale|unconnected_drive|nounconnected_drive))[a-z_A-Z][a-zA-Z0-9_$]*</string>
 					<key>name</key>
-					<string>support.constant.verilog</string>
+					<string>entity.name.constant.verilog, variable.other.constant.verilog</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
Added a rule to allow highlighting of user-defined constants like
~~~
`define MY_CONSTANT 1'b0;
...
my_reg <= `MY_CONSTANT;  // MY_CONSTANT is now highlighted here
~~~

My regex excludes verilog compiler directives from the match (which I got from: http://verilog.renerta.com/mobile/source/vrg00008.htm). 

I also selected the scope `variable.other.constant` per the Sublime documentation here: https://www.sublimetext.com/docs/3/scope_naming.html
At first I thought `entity.name.constant` would be best, but after testing, most of the color schemes I tried worked better with `variable.other.constant`.