### PR TITLE
Add simple ucf (UserConstraintFile) syntax coloration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Verilog HDL support based on [https://github.com/textmate/verilog.tmbundle](http
    * `wire`
    * testbench template
    * etc...
+- simple syntax highlighting for `.ucf` files
 
+
+   
 ### In progress
 
 ### In the future

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "VerilogHDL",
-	"description": "Verilog HDL support for VS Code",
-	"version": "0.0.13",
+	"description": "Verilog HDL/UCF support for VS Code",
+	"version": "0.0.14",
 	"publisher": "mshr-h",
-    "homepage": "https://github.com/mshr-h/vscode-verilog-hdl-support",
+	"homepage": "https://github.com/mshr-h/vscode-verilog-hdl-support",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/mshr-h/vscode-verilog-hdl-support.git"
@@ -19,20 +19,53 @@
 		"Snippets"
 	],
 	"contributes": {
-		"languages": [{
-			"id": "verilog",
-			"aliases": ["Verilog", "verilog"],
-			"extensions": [".v",".vh"],
-			"configuration": "./verilog.configuration.json"
-		}],
-		"grammars": [{
-			"language": "verilog",
-			"scopeName": "source.verilog",
-			"path": "./syntaxes/verilog.tmLanguage"
-		}],
-		"snippets": [{
-			"language": "verilog",
-			"path": "./snippets/verilog.json"
-		}]
+		"languages": [
+			{
+				"id": "verilog",
+				"aliases": [
+					"Verilog",
+					"verilog"
+				],
+				"extensions": [
+					".v",
+					".vh"
+				],
+				"configuration": "./verilog.configuration.json"
+			},
+			{
+				"id": "ucf",
+				"aliases": [
+					"UCF",
+					"Ucf"
+				],
+				"extensions": [
+					".ucf"
+				],
+				"configuration": "./ucf.configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "verilog",
+				"scopeName": "source.verilog",
+				"path": "./syntaxes/verilog.tmLanguage"
+			},
+			{
+				"language": "ucf",
+				"scopeName": "source.ucf",
+				"path": "./syntaxes/ucf.tmLanguage"
+			}
+		],
+		"snippets": [
+			{
+				"language": "verilog",
+				"path": "./snippets/verilog.json"
+			}
+		]
+	},
+	"__metadata": {
+		"id": "feb7e3b5-7d35-4f95-a3d2-61eeaa12efa5",
+		"publisherId": "fcf32c99-a624-437b-9f47-9333ea128623",
+		"publisherDisplayName": "mshr-h"
 	}
 }

--- a/syntaxes/ucf.tmLanguage
+++ b/syntaxes/ucf.tmLanguage
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC '-//Apple//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+<plist>
+    <dict>
+        <key>fileTypes</key>
+        <array>
+            <string>ucf</string>
+            <string>UCF</string>
+        </array>
+        <key>name</key>
+        <string>ucfconstraints</string>
+        <key>patterns</key>
+        <array>
+
+            <dict>
+                <key>name</key>
+                <string>keyword.other</string>
+                <key>match</key>
+                <string>\b(NET|TIMESPEC|TIMEGRP|INST|AREA_GROUP|RANGE|LOC|TNM|TIG|TNM_NET)\b</string>
+            </dict>
+
+            <dict>
+                <key>match</key>
+                <string>(#).*$\n?</string>
+                <key>name</key>
+                <string>comment.line</string>
+            </dict>
+
+            <dict>
+                <key>match</key>
+                <string>(=)</string>
+                <key>name</key>
+                <string>keyword.other</string>
+            </dict>
+        </array>
+        <key>scopeName</key>
+        <string>source.ucf</string>
+        <key>uuid</key>
+        <string>443130c7-cdc8-4a90-836c-a530d3b17266</string>
+    </dict>
+</plist>

--- a/ucf.configuration.json
+++ b/ucf.configuration.json
@@ -1,0 +1,14 @@
+{
+	"comments": {
+		// symbol used for single line comment. Remove this entry if your language does not support line comments
+		"lineComment": "//",
+		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+		"blockComment": [ "/*", "*/" ]
+	},
+	// symbols used as brackets
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	]
+}


### PR DESCRIPTION
I added syntax coloration for UCF file. (based on  https://github.com/al8/sublimetext-Verilog/blob/master/ucfconstraints.tmLanguage).
