### PR TITLE
fix iVerilog linter arguments not loaded at startup

### DIFF
--- a/src/linter/IcarusLinter.ts
+++ b/src/linter/IcarusLinter.ts
@@ -10,8 +10,13 @@ export default class IcarusLinter extends BaseLinter {
         super("iverilog");
 
         workspace.onDidChangeConfiguration(() => {
-             this.iverilogArgs = <string>workspace.getConfiguration().get('verilog.linting.iverilog.arguments');
+            this.getArgs();
         })
+        this.getArgs();
+    }
+
+    private getArgs() {
+        this.iverilogArgs = <string>workspace.getConfiguration().get('verilog.linting.iverilog.arguments');
     }
 
     protected lint(doc: TextDocument) {


### PR DESCRIPTION
Dear maintainers,

Because reading custom Icarus Verilog arguments only happens when the configuration file was changed, custom arguments become `undefined` rather than the value on configuration files.

Please consider my changes and accept it if appropriate.

Thank you.