### PR TITLE
Show notification to view Changelog after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# Changelog
+# Verilog HDL Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## Unreleased
+### Added
+- Show notification to view CHANGELOG when the extension gets updated [#14](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/14)
 
 ## [0.3.1] - 2018-05-12
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"vscode": "^1.19.3"
 	},
 	"categories": [
-		"Languages",
+		"Programming Languages",
 		"Snippets",
 		"Linters"
 	],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,14 +26,10 @@ function checkIfUpdated(context: ExtensionContext) {
     let currVersion: string = extensions.getExtension(extensionID).packageJSON.version;
     let cv = currVersion.split('.').map(Number);
     // check if current version > previous version
-    if(pv[0] < cv[0])
-        showUpdatedNotif();
-    else {
-        if(pv[1] < cv[1])
+    for(let i = 0; i < pv.length; i++) {
+        if(pv[i] < cv[i]) {
             showUpdatedNotif();
-        else {
-            if(pv[2] < cv[2])
-                showUpdatedNotif();
+            break;
         }
     }
     // update the value

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,58 @@
 'use strict';
 
 import {workspace, window, commands, Disposable, Range, ExtensionContext,
-     TextDocument, Diagnostic, DiagnosticSeverity, DiagnosticCollection, languages} from "vscode";
+        TextDocument, Diagnostic, DiagnosticSeverity, DiagnosticCollection,
+        languages, extensions, Selection, Uri} from "vscode";
 import BaseLinter from "./linter/BaseLinter";
 import IcarusLinter from "./linter/IcarusLinter";
 import XvlogLinter from "./linter/XvlogLinter";
 
 let diagnosticCollection: DiagnosticCollection;
 var linter: BaseLinter;
-
+let extensionID: string = "mshr-h.veriloghdl";
 
 export function activate(context: ExtensionContext) {
     console.log('"verilog-hdl" is now active!');
+    checkIfUpdated(context);
     workspace.onDidChangeConfiguration(configLinter, this, context.subscriptions);
     configLinter();
 }
 
+function checkIfUpdated(context: ExtensionContext) {
+    // Get previous version
+    let prevVersion: string = context.globalState.get("version", "0.0.0");
+    let pv = prevVersion.split('.').map(Number);
+    // Get current version
+    let currVersion: string = extensions.getExtension(extensionID).packageJSON.version;
+    let cv = currVersion.split('.').map(Number);
+    // check if current version > previous version
+    if(pv[0] < cv[0])
+        showUpdatedNotif();
+    else {
+        if(pv[1] < cv[1])
+            showUpdatedNotif();
+        else {
+            if(pv[2] < cv[2])
+                showUpdatedNotif();
+        }
+    }
+    // update the value
+    context.globalState.update("version", currVersion);
+}
+
+function showUpdatedNotif() {
+    window
+        .showInformationMessage("Verilog HDL extension has been updated", "Open Changelog")
+        .then(function(){
+            // get path of CHANGELOG.md
+            let changelogPath:string = extensions.getExtension(extensionID).extensionPath + "/CHANGELOG.md";
+            let path = Uri.file(changelogPath);
+            // open
+            workspace.openTextDocument(path).then(doc => {
+                window.showTextDocument(doc);
+            });
+        });
+}
 
 function configLinter() {
     let linter_name;


### PR DESCRIPTION
Added a feature to show a notification with an option to open the changelog when the extension gets updated [#14](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/14)