### PR TITLE
Added a command to manually run the linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
-### Nothing
+### Added
+- Added a command **Rerun lint tool** to manually run the lint tool [#29](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/29)
+
+### Fixed
+- Update notification opens the CHANGELOG only when the "Open Changelog" button is clicked
 
 ## [0.3.4] - 2018-09-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Use the following settings to configure the extension to your needs
 
     By default, the linter will be run at the workspace directory. Enable this option to run at the file location. If enabled, `` `include`` directives should contain file paths relative to the current file.
 
+## Commands
+
+* **Rerun lint tool**
+
+    Choose a lint tool from the list and run it manually. Useful if the code was changed by an external script or version control system.
+
 ## Usage Instructions
 
 * All linters expect the executable binary (`iverilog`, `verilator`...) to be present in the `PATH` environment variable, unless otherwise specified.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/mshr-h/vscode-verilog-hdl-support/issues"
 	},
 	"engines": {
-		"vscode": "^1.19.3"
+		"vscode": "^1.28.1"
 	},
 	"categories": [
 		"Programming Languages",
@@ -102,10 +102,12 @@
 				}
 			}
 		},
-		"commands": [{
-			"command":	"verilog.lint",
-			"title":	"Verilog: Rerun lint tool"
-		}]
+		"commands": [
+			{
+				"command": "verilog.lint",
+				"title": "Verilog: Rerun lint tool"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "tsc -p ./",
@@ -117,8 +119,8 @@
 	"dependencies": {},
 	"devDependencies": {
 		"@types/mocha": "^2.2.45",
-		"@types/node": "^7.0.51",
-		"typescript": "^2.9.2",
-		"vscode": "^1.1.14"
+		"@types/node": "^7.10.0",
+		"typescript": "^3.1.1",
+		"vscode": "^1.1.21"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,11 @@
 					"description": "If enabled, Verilator will be ran at the file location for linting. Else it will be run at workspace folder. Disabled by default."
 				}
 			}
-		}
+		},
+		"commands": [{
+			"command":	"verilog.lint",
+			"title":	"Verilog: Rerun lint tool"
+		}]
 	},
 	"scripts": {
 		"vscode:prepublish": "tsc -p ./",

--- a/src/linter/BaseLinter.ts
+++ b/src/linter/BaseLinter.ts
@@ -12,13 +12,13 @@ export default abstract class BaseLinter {
 		workspace.onDidCloseTextDocument(this.removeFileDiagnostics, this, this.subscriptions)
 	}
 
-	private startLint(doc: TextDocument) {
+	public startLint(doc: TextDocument) {
 		if (doc.languageId == "verilog") {
 			this.lint(doc);
 		}
 	}
 
-	private removeFileDiagnostics(doc: TextDocument) {
+	public removeFileDiagnostics(doc: TextDocument) {
 		this.diagnostic_collection.delete(doc.uri);
 	}
 


### PR DESCRIPTION
Added a command "Rerun lint tool" to manually run the linter #29 
Updated the README and CHANGELOG accordingly
Fixed a bug in the update notification

@terriblefire Your request to run a particular linter for a file can be partially fulfilled by this command, although you have to run in manually.