### PR TITLE
Rerun lint tool was left out

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,10 +130,14 @@
 				}
 			}
 		},
-		"commands":[
+		"commands": [
 			{
 				"command": "verilog.instantiateModule",
 				"title": "Verilog: Instantiate Module"
+			},
+			{
+				"command": "verilog.lint",
+				"title": "Verilog: Rerun lint tool"
 			}
 		]
 	},
@@ -144,15 +148,11 @@
 		"update-vscode": "node ./node_modules/vscode/bin/install",
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
-	"dependencies": {
-		"code-generator": "^1.0.7",
-		"vsce": "^1.49.2",
-		"yo": "^2.0.5"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@types/mocha": "^2.2.45",
-		"@types/node": "^7.0.51",
-		"typescript": "^2.9.2",
-		"vscode": "^1.1.14"
+		"@types/node": "^7.10.0",
+		"typescript": "^3.1.1",
+		"vscode": "^1.1.21"
 	}
 }

--- a/src/commands/ModuleInstantiation.ts
+++ b/src/commands/ModuleInstantiation.ts
@@ -62,10 +62,10 @@ function instantiateModule(srcpath: string) : Thenable<SnippetString> {
             }
             console.log(portsName)
             resolve(new SnippetString()
-          .appendText(moduleName + " ")
+          .appendText(module.name + " ")
           .appendText(paramString)
           .appendPlaceholder("u_")
-          .appendPlaceholder(`${moduleName}(\n`)
+          .appendPlaceholder(`${module.name}(\n`)
           .appendText(instantiatePort(portsName))
           .appendText(');\n'));
         })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,8 @@ export function activate(context: ExtensionContext) {
 
     // Configure command to instantiate a module
     commands.registerCommand("verilog.instantiateModule", ModuleInstantiation.instantiateModuleInteract);
+    // Register command for manual linting
+    commands.registerCommand("verilog.lint", lintManager.RunLintTool);
 }
 
 function checkIfUpdated(context: ExtensionContext) {


### PR DESCRIPTION
While merging `sv` to `master`, the **Rerun Lint tool** command was left out. So, adding it back now.

Also a bug fix in **Module Instantiation** command where the module name is left out while instantiating.