### PR TITLE
Bug: linter runs on all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [1.0.0] -2018-12-18
+## [UNRELEASED]
+- Fixed a bug which caused linter to run on all files
+
+## [1.0.0] - 2018-12-18
 ### Added
 - First Major Release
 - Added support for **SystemVerilog**

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -52,7 +52,9 @@ export default class LintManager {
     }
 
     lint(doc: TextDocument) {
-        if(this.linter != null)
+        // Check for language id
+        let lang : string = window.activeTextEditor.document.languageId;
+        if(this.linter != null && window.activeTextEditor !== undefined && (lang === "verilog" || lang === "systemverilog"))
             this.linter.startLint(doc);
     }
 


### PR DESCRIPTION
Fixing a bug that caused linter to run on all files. Now only runs on verilog/systemverilog files.