### PR TITLE
Linter will now run only verilog/sv files - finally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased] - 2019-01-29
+## [Unreleased]
 ### Changed
 - Replace fixed space with tab on snippets files
+- Properly fixed the bug which caused linter to run on all files
 
 ## [1.0.1] - 2019-01-01
 ### Fixed

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -1,4 +1,4 @@
-import { Disposable, workspace, TextDocument, DiagnosticCollection, Diagnostic, languages, window, QuickPickItem, ProgressLocation } from "vscode";
+import { Disposable, workspace, TextDocument, DiagnosticCollection, Diagnostic, languages, window, QuickPickItem, ProgressLocation, TextEditor } from "vscode";
 
 import BaseLinter from "./BaseLinter";
 import IcarusLinter from "./IcarusLinter";
@@ -53,8 +53,8 @@ export default class LintManager {
 
     lint(doc: TextDocument) {
         // Check for language id
-        let lang : string = window.activeTextEditor.document.languageId;
-        if(this.linter != null && window.activeTextEditor !== undefined && (lang === "verilog" || lang === "systemverilog"))
+        let lang : string = doc.languageId;
+        if(this.linter != null && (lang === "verilog" || lang === "systemverilog"))
             this.linter.startLint(doc);
     }
 

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -1,4 +1,4 @@
-import { Disposable, workspace, TextDocument, DiagnosticCollection, Diagnostic, languages, window, QuickPickItem, ProgressLocation, TextEditor } from "vscode";
+import { Disposable, workspace, TextDocument, window, QuickPickItem, ProgressLocation} from "vscode";
 
 import BaseLinter from "./BaseLinter";
 import IcarusLinter from "./IcarusLinter";
@@ -14,7 +14,7 @@ export default class LintManager {
 
     constructor() {
         workspace.onDidOpenTextDocument(this.lint, this, this.subscriptions);
-		workspace.onDidSaveTextDocument(this.lint, this, this.subscriptions);
+        workspace.onDidSaveTextDocument(this.lint, this, this.subscriptions);
         workspace.onDidCloseTextDocument(this.removeFileDiagnostics, this, this.subscriptions)
 
         workspace.onDidChangeConfiguration(this.configLinter, this, this.subscriptions);


### PR DESCRIPTION
Fixed the bug properly, that caused linter to run on non-verilog/sv files. Should be fine now.