### PR TITLE
added options to the modelsim linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,11 +104,23 @@
 					"default": false,
 					"description": "If enabled, Icarus Verilog will be run at the file location for linting. Else it will be run at workspace folder. Disabled by default."
 				},
+				"verilog.linting.modelsim.runAtFileLocation": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "If enabled, Modelsim will be run at the file location for linting. Else it will be run at workspace folder. Disabled by default."
+				},
 				"verilog.linting.modelsim.arguments": {
 					"scope": "window",
 					"type": "string",
 					"default": "",
 					"description": "Add Modelsim arguments here. They will be added to Modelsim while linting."
+				},
+				"verilog.linting.modelsim.work": {
+					"scope": "window",
+					"type": "string",
+					"default": "",
+					"description": "Add Modelsim work library here."
 				},
 				"verilog.linting.verilator.arguments": {
 					"scope": "window",
@@ -154,5 +166,10 @@
 		"@types/node": "^7.10.0",
 		"typescript": "^3.1.1",
 		"vscode": "^1.1.21"
+	},
+	"__metadata": {
+		"id": "feb7e3b5-7d35-4f95-a3d2-61eeaa12efa5",
+		"publisherDisplayName": "mshr-h",
+		"publisherId": "fcf32c99-a624-437b-9f47-9333ea128623"
 	}
 }

--- a/src/linter/ModelsimLinter.ts
+++ b/src/linter/ModelsimLinter.ts
@@ -2,10 +2,12 @@ import {workspace, window, Disposable, Range, TextDocument, Diagnostic, Diagnost
 import * as child from 'child_process';
 import BaseLinter from "./BaseLinter";
 
-//var isWindows = process.platform === "win32";
+var isWindows = process.platform === "win32";
 
 export default class ModelsimLinter extends BaseLinter {
     private modelsimArgs: string;
+    private modelsimWork: string;
+    private runAtFileLocation: boolean;
 
     constructor() {
         super("modelsim");
@@ -18,12 +20,18 @@ export default class ModelsimLinter extends BaseLinter {
     private getConfig() {
         //get custom arguments
         this.modelsimArgs = <string>workspace.getConfiguration().get('verilog.linting.modelsim.arguments');
+        this.modelsimWork = <string>workspace.getConfiguration().get('verilog.linting.modelsim.work');
+        this.runAtFileLocation = <boolean>workspace.getConfiguration().get('verilog.linting.modelsim.runAtFileLocation')
     }
 
     protected lint(doc: TextDocument) {
+        let docUri: string = doc.uri.fsPath     //path of current doc
+        let lastIndex: number = (isWindows == true) ? docUri.lastIndexOf("\\") : docUri.lastIndexOf("/");
+        let docFolder = docUri.substr(0, lastIndex);    //folder of current doc
+        let runLocation: string = (this.runAtFileLocation == true) ? docFolder : workspace.rootPath;     //choose correct location to run
         // no change needed for systemverilog
-        let command: string = 'vlog -nologo -work work \"' + doc.fileName +'\" ' + this.modelsimArgs;     //command to execute
-        var process: child.ChildProcess = child.exec(command, {cwd:workspace.rootPath}, (error:Error, stdout: string, stderr: string) => {
+        let command: string = 'vlog -nologo -work ' + this.modelsimWork + ' \"' + doc.fileName +'\" ' + this.modelsimArgs;     //command to execute
+        var process: child.ChildProcess = child.exec(command, { cwd: runLocation}, (error:Error, stdout: string, stderr: string) => {
             let diagnostics: Diagnostic[] = [];
             let lines = stdout.split(/\r?\n/g);
 


### PR DESCRIPTION
Modelsim linter now can also be run in the working directory of the file and has an extra option for the default library instead of `work`.