### PR TITLE
Added support for verilator on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+### Added
+- Added support for verilator on windows
+
 ## [1.0.4] - 2019-11-09
 ### Added
 - Added logging to Output pane

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Basics (like Syntax highlighting) | Yes | Yes | Should work
 Icarus Verilog | Windows 10 | Ubuntu 18.04 | Not Tested
 Vivado Logical Simulation | Yes | Not Tested | Not Tested
 Modelsim | Windows 10 | Not Tested | Not Tested
-Verilator | Not available | Debian 9 | Not Tested
+Verilator | Windows 10 | Debian 9 | Not Tested
 Ctags Integration | Windows 10 | Ubuntu 18.10 | Not Tested
 
 If you have tested the linters in new platforms or have issues with them, feel free to file an issue.

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -63,7 +63,13 @@ export default class VerilatorLinter extends BaseLinter {
         let docFolder = docUri.substr(0, lastIndex);    //folder of current doc
         let runLocation: string = (this.runAtFileLocation == true)? docFolder : workspace.rootPath;     //choose correct location to run
         let svArgs : string = (doc.languageId == "systemverilog") ? "-sv" : "";                         //Systemverilog args
-        let command: string = 'verilator ' + svArgs + ' --lint-only -I'+docFolder+ ' ' + this.verilatorArgs + ' \"' + doc.fileName +'\"';     //command to execute
+        let verilator: string = "verilator";
+        if(isWindows) {
+            verilator = verilator + "_bin.exe";
+            docUri = docUri.replace(/\\/g, "/");
+            docFolder = docFolder.replace(/\\/g, "/");
+        }
+        let command: string = verilator + ' ' + svArgs + ' --lint-only -I'+docFolder+ ' ' + this.verilatorArgs + ' \"' + docUri +'\"';     //command to execute
         this.logger.log(command, Log_Severity.Command);
 
         var foo: child.ChildProcess = child.exec(command,{cwd:runLocation},(error:Error, stdout:string, stderr:string) => {
@@ -77,10 +83,10 @@ export default class VerilatorLinter extends BaseLinter {
                     line = line.substr(1)
 
                     // was it for a submodule
-                    if (line.search(doc.fileName) > 0)
+                    if (line.search(docUri) > 0)
                     {
                         // remove the filename
-                        line = line.replace(doc.fileName, '');
+                        line = line.replace(docUri, '');
                         line = line.replace(/\s+/g,' ').trim();
 
                         let terms = this.splitTerms(line);


### PR DESCRIPTION
Added support for verilator on windows.
Verilator binaries for Windows are available at MSYS2 packages.
https://packages.msys2.org/base/mingw-w64-verilator