### PR TITLE
Enable verilog/systemverilog syntax highlighting in markdown code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 	"icon": "images/icon.png",
 	"activationEvents": [
 		"onLanguage:verilog",
-		"onLanguage:systemverilog"
+		"onLanguage:systemverilog",
+		"onLanguage:markdown"
 	],
 	"main": "./out/src/extension",
 	"contributes": {
@@ -64,6 +65,17 @@
 				"language": "systemverilog",
 				"scopeName": "source.systemverilog",
 				"path": "./syntaxes/systemverilog.tmLanguage"
+			},
+			{
+				"scopeName": "markdown.verilog.codeblock",
+				"path": "./syntaxes/codeblock.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.verilog": "source.verilog",
+					"meta.embedded.block.systemverilog": "source.systemverilog"
+				}
 			}
 		],
 		"snippets": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,81 @@
+{
+	"fileTypes": [],
+	"scopeName": "markdown.verilog.codeblock",
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#fenced_code_block_verilog"
+		},
+		{
+			"include": "#fenced_code_block_systemverilog"
+		}
+	],
+	"repository": {
+		"fenced_code_block_verilog": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(v|verilog)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.verilog",
+					"patterns": [
+						{
+							"include": "source.verilog"
+						}
+					]
+				}
+			]
+		},
+		"fenced_code_block_systemverilog": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(sv|systemverilog)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.systemverilog",
+					"patterns": [
+						{
+							"include": "source.systemverilog"
+						}
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Add markdown support for verilog and systemverilog syntax highlighting.
This allows you to highlight verilog/systemverilog code in markdown code blocks.