### PR TITLE
fix onDidChangeActiveTextEditor/onSave  callback `this` is undefined error

### DIFF
--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -231,8 +231,8 @@ export class CtagsManager {
 
     configure() {
         console.log("ctags manager configure");
-        workspace.onDidSaveTextDocument(this.onSave);
-        window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor);
+        workspace.onDidSaveTextDocument(this.onSave.bind(this));
+        window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor.bind(this));
     }
 
     onSave(doc:TextDocument) {


### PR DESCRIPTION
In javascript and typescript, it's not safe to not bound `this` in callback. It will cause undefined error when function callbacked. Here is some references: [Typescript Types and .bind](https://stackoverflow.com/questions/54710927/typescript-types-and-bind)