### PR TITLE
Add support for Verilator under WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+### Added
+- Support running  Verilator under WSL
+
 ## [1.2.1] - 2020-06-27
 ### Added
 - Tested OSX + iverilog linter

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Use the following settings to configure the extension to your needs
 
     By default, the linter will be run at the workspace directory. Enable this option to run at the file location. If enabled, `` `include`` directives should contain file paths relative to the current file.
 
+* `verilog.linting.verilator.useWSL` (Default: False)
+
+    Run verilator under WSL (use `apg-get install verilator` to install).  Paths generated automatically by the
+    extension (the path to the Verilog file as well as the auto-generated document folder for `-I`) are translated
+    to WSL paths using the `wslpath` program.  Any other paths you specify in `verilog.linting.verilator.arguments`
+    must be manually converted.
+
 * `verilog.ctags.path` (Default: ctags)
 
     Path to your installation of Ctags if it isn't already present in your `PATH` environment variable.

--- a/package.json
+++ b/package.json
@@ -157,6 +157,12 @@
 					"default": false,
 					"description": "If enabled, Verilator will be run at the file location for linting. Else it will be run at workspace folder. Disabled by default."
 				},
+				"verilog.linting.verilator.useWSL": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "If enabled, run verilator in WSL."
+				},
 				"verilog.ctags.path": {
 					"scope": "window",
 					"type": "string",


### PR DESCRIPTION
Thanks for maintaining this great extension.  This adds a config option which, when enabled, rewrites the Verilator command to work correctly under WSL.  Node is not my first (or second or third) programming language and I'm happy to look at this if you don't like the way it's done.