### PR TITLE
Include null check for Verilator regex

### DIFF
--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -90,14 +90,14 @@ export default class VerilatorLinter extends BaseLinter {
             lines.forEach((line, i) => {
                 // Error for our file
                 if (line.startsWith('%') && line.search(docUri) > 0) {
-                    let rex = line.match(/%(\w+):\s*(\w+:)?(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
+                    let rex = line.match(/%(\w+)(-[A-Z0-9_]+)?:\s*(\w+:)?(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
 
                     if (rex && rex[0].length > 0) {
                         let severity = this.getSeverity(rex[1]);
-                        let lineNum = Number(rex[3]) - 1;
-                        let colNum = Number(rex[4]) - 1;
-                        let message = rex[5];
-
+                        let lineNum = Number(rex[4]) - 1;
+                        let colNum = Number(rex[5]) - 1;
+                        let message = rex[6];
+                        // Type of warning is in rex[2]
                         colNum = isNaN(colNum) ? 0 : colNum; // for older Verilator versions (< 4.030 ~ish)
 
                         if (!isNaN(lineNum)) {

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -92,7 +92,7 @@ export default class VerilatorLinter extends BaseLinter {
                 if (line.startsWith('%') && line.search(docUri) > 0) {
                     let rex = line.match(/%(\w+):\s*(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
 
-                    if (rex[0].length > 0) {
+                    if (rex && rex[0].length > 0) {
                         let severity = this.getSeverity(rex[1]);
                         let lineNum = Number(rex[2]) - 1;
                         let colNum = Number(rex[3]) - 1;

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -90,13 +90,13 @@ export default class VerilatorLinter extends BaseLinter {
             lines.forEach((line, i) => {
                 // Error for our file
                 if (line.startsWith('%') && line.search(docUri) > 0) {
-                    let rex = line.match(/%(\w+):\s*(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
+                    let rex = line.match(/%(\w+):\s*(\w+:)?(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
 
                     if (rex && rex[0].length > 0) {
                         let severity = this.getSeverity(rex[1]);
-                        let lineNum = Number(rex[2]) - 1;
-                        let colNum = Number(rex[3]) - 1;
-                        let message = rex[4];
+                        let lineNum = Number(rex[3]) - 1;
+                        let colNum = Number(rex[4]) - 1;
+                        let message = rex[5];
 
                         colNum = isNaN(colNum) ? 0 : colNum; // for older Verilator versions (< 4.030 ~ish)
 


### PR DESCRIPTION
Behaviour: Verilator v3.916 under WSL reports nothing.
Cause: The developer tools show `Cannot read property '0' of null` which indicates a failure to check illegal regex expressions.

Behaviour: Verilator v3.922 under Windows reports nothing.
Cause: The regex fails to match strings like: `%Error: c:/some/path/here/:26: syntax error, unexpected reg, expecting IDENTIFIER`
due to the stray colon by the path `c:`.
It also fails to match: `%Warning-WIDTH: /path/to/something:89:18: Some message here` due to stray `-`.
As per the format specification [here](https://www.veripool.org/wiki/verilator/Manual-verilator#List-of-all-warnings), I added a case for that too.