### PR TITLE
add double quotation marks for xvlog linter script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+- Add double quotation marks to fix path issue for Xvlog Linter
+
 ## [1.3.4] - 2020-10-17
 
 ### Fixed

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -14,7 +14,7 @@ export default class XvlogLinter extends BaseLinter {
     protected lint(doc: TextDocument) {
         this.logger.log('xvlog lint requested');
         let svArgs: string = (doc.languageId == "systemverilog") ? "-sv" : "";         //Systemverilog args
-        let command = "xvlog " + svArgs + " -nolog " + doc.fileName;
+        let command = "xvlog " + svArgs + " -nolog " + "\"" + doc.fileName + "\"";
         this.logger.log(command, Log_Severity.Command);
 
         let process: ChildProcess = exec(command, (error: Error, stdout: string, stderr: string) => {


### PR DESCRIPTION
To avoid crash when some spaces exist in file path.