### PR TITLE
Adding and updating snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /node_modules/
 /out
 /package-lock.json
+/.vscode/
+!/.vscode/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Change prefix for module without parameters [#94](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/94)
-- Updated existing snippet prefixes, including always blocks, modules, scalar & vector data types, parameters, directives, typedefs, and the testbench template
+- Updated existing snippet prefixes, including always blocks, modules, scalar & vector data types, directives, typedefs, and the testbench template
+- Updated snippet names for clarity
+- Moved applicable snippets (ex. ```timescale```, ```parameter```) to also support Verilog
+
+### Removed
+
+- Removed redundant snippets
 
 ## [1.3.6] - 2020-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Change prefix for module without parameters [#94](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/94)
+- Updated existing snippet prefixes, including always blocks, modules, scalar & vector data types, parameters, directives, typedefs, and the testbench template
 
 ## [1.3.6] - 2020-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - Add always_latch snippet [#99](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/99)
+- Add new snippets, including casex/casez, compiler directives, procedural blocks, and packages
 
 ### Changed
 
 - Change prefix for module without parameters [#94](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/94)
-- Updated existing snippet prefixes, including always blocks, modules, scalar & vector data types, directives, typedefs, and the testbench template
+- Updated existing snippet prefixes, including always blocks, modules, scalar & vector data types, directives, and the testbench template
 - Updated snippet names for clarity
-- Moved applicable snippets (ex. ```timescale```, ```parameter```) to also support Verilog
+- Moved applicable snippets (ex. `timescale`, `parameter`) to also support Verilog
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Added
+
+- Add always_latch snippet [#99](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/99)
+
+### Changed
+
+- Change prefix for module without parameters [#94](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/94)
+
 ## [1.3.6] - 2020-11-21
 
 ### Added

--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -1,6 +1,6 @@
 {
 	"always_ff block": {
-		"prefix": "ff",
+		"prefix": "always_ff",
 		"body": [
 			"always_ff @( ${1:clock} ) begin : ${2:blockName}",
 			"\t$0",
@@ -9,7 +9,7 @@
 		"description": "Insert an always_ff block"
 	},
 	"always_comb block": {
-		"prefix": "comb",
+		"prefix": "always_comb",
 		"body": [
 			"always_comb begin : ${1:blockName}",
 			"\t$0",
@@ -78,7 +78,7 @@
 		"description": "insert [x:y]"
 	},
 	"typedef struct packed": {
-		"prefix": "typedefstructpacked",
+		"prefix": "typedef struct packed",
 		"body": [
 			"typedef struct packed {",
 			"\t$0",
@@ -98,7 +98,7 @@
 		"description": "class name; ... endclass"
 	},
 	"class extends": {
-		"prefix": "classextends",
+		"prefix": "class extends",
 		"body": [
 			"class ${1:className} extends ${2:superClass};",
 			"\tfunction new();",
@@ -134,20 +134,20 @@
 		"description": "$display(\"...\", params...)"
 	},
 	"timescale": {
-		"prefix": "ts",
+		"prefix": ["ts", "timescale", "`timescale"],
 		"body": [
 			"`timescale ${1:1ps}/${2:1ps}$0"
 		]
 	},
 	"set Module": {
-		"prefix": "setmodule",
+		"prefix": ["set module", "instantiate module"],
 		"body": [
 			"${1:mod_name} ${2:instance_name} (${3:.*}$0);"
 		],
 		"description": "set module, mod i0 (.*);"
 	},
 	"typedef enum": {
-		"prefix": "typedefenum",
+		"prefix": "typedef enum",
 		"body": [
 			"typedef enum ${1:data_type} { $0 } ${2:name};"
 		],
@@ -187,7 +187,7 @@
 		"description": "insert assert() ... else ..."
 	},
 	"fork-join": {
-		"prefix": "forkjoin",
+		"prefix": "fork join",
 		"body": [
 			"fork",
 			"\t$0",

--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -28,23 +28,31 @@
 	},
 	"bit": {
 		"prefix": "bit",
-		"body": "bit"
+		"body": "bit ${1:bit_name}"
 	},
 	"int": {
 		"prefix": "int",
-		"body": "int"
+		"body": "int ${1:int_name}"
+	},
+	"shortint": {
+		"prefix": "shortint",
+		"body": "shortint ${1:name}"
+	},
+	"longint": {
+		"prefix": "longint",
+		"body": "longint ${1:name}"
 	},
 	"byte": {
 		"prefix": "byte",
-		"body": "byte"
+		"body": "byte ${1:byte:_name}"
 	},
 	"logic": {
 		"prefix": "logic",
-		"body": "logic"
+		"body": "logic ${1:logic_name}"
 	},
 	"packed": {
 		"prefix": "packed",
-		"body": "packed"
+		"body": "packed ${1:name}"
 	},
 	"this": {
 		"prefix": "this",
@@ -90,6 +98,20 @@
 		],
 		"description": "task name; ... endtask"
 	},
+	"package": {
+		"prefix": "package",
+		"body": [
+			"package ${1:package_name",
+			"\t$2",
+			"endpackage"
+		],
+		"description": "package name; ... endpackage"
+	},
+	"import": {
+		"prefix": "import",
+		"body": "import ${1:name}::${2:scope}",
+		"description": "import name::scope"
+	},
 	"interface": {
 		"prefix": "interface",
 		"body": [
@@ -98,6 +120,16 @@
 			"endinterface //$1"
 		],
 		"description": "interface name; ... endinterface"
+	},
+	"modport": {
+		"prefix": "modport",
+		"body": [
+			"modport ${1:identifier} (",
+			"input ${2:input_ports},",
+			"output ${3:output_ports}",
+			");"
+		],
+		"description": "modport name (input ports_in, output ports_out); "
 	},
 	"display": {
 		"prefix": "display",

--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -23,30 +23,8 @@
 			"always_latch begin : ${1:blockName}",
 			"\t$0",
 			"end"
-		]
-	},
-	"include": {
-		"prefix": "inc",
-		"body": [
-			"`include \"$1\""
 		],
-		"description": "`include \"..\""
-	},
-	"parameter": {
-		"prefix": "parameter",
-		"body": [
-			"parameter $1 = $2;"
-		],
-		"description": "paramter var = val;"
-	},
-	"initial": {
-		"prefix": "initial",
-		"body": [
-			"initial begin",
-			"\t$0",
-			"end"
-		],
-		"description": "initial begin ... end"
+		"description": "Insert an always_latch block"
 	},
 	"bit": {
 		"prefix": "bit",
@@ -71,11 +49,6 @@
 	"this": {
 		"prefix": "this",
 		"body": "this"
-	},
-	"array": {
-		"prefix": "array",
-		"body": "[${1:8}:${2:0}]$0",
-		"description": "insert [x:y]"
 	},
 	"typedef struct packed": {
 		"prefix": "typedef struct packed",
@@ -133,19 +106,6 @@
 		],
 		"description": "$display(\"...\", params...)"
 	},
-	"timescale": {
-		"prefix": ["ts", "timescale", "`timescale"],
-		"body": [
-			"`timescale ${1:1ps}/${2:1ps}$0"
-		]
-	},
-	"set Module": {
-		"prefix": ["set module", "instantiate module"],
-		"body": [
-			"${1:mod_name} ${2:instance_name} (${3:.*}$0);"
-		],
-		"description": "set module, mod i0 (.*);"
-	},
 	"typedef enum": {
 		"prefix": "typedef enum",
 		"body": [
@@ -173,7 +133,7 @@
 		],
 		"description": "insert mailbox instance"
 	},
-	"Associative array": {
+	"associative array": {
 		"prefix": "AA",
 		"body": "${1:data_type} ${2:name}[${3:index_type}];$0",
 		"description": "insert Associative array(AA)."
@@ -194,14 +154,5 @@
 			"join"
 		],
 		"description": "fork ... join"
-	},
-	"forever": {
-		"prefix": "forever",
-		"body": [
-			"forever begin",
-			"\t$0",
-			"end"
-		],
-		"description": "forever begin ... end"
 	}
 }

--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -17,6 +17,14 @@
 		],
 		"description": "Insert an always_comb block"
 	},
+	"always_latch block": {
+		"prefix": "always_latch",
+		"body": [
+			"always_latch begin : ${1:blockName}",
+			"\t$0",
+			"end"
+		]
+	},
 	"include": {
 		"prefix": "inc",
 		"body": [

--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -28,31 +28,31 @@
 	},
 	"bit": {
 		"prefix": "bit",
-		"body": "bit ${1:bit_name}"
+		"body": "bit ${1:bit_name} = ${2:value};"
 	},
 	"int": {
 		"prefix": "int",
-		"body": "int ${1:int_name}"
+		"body": "int ${1:int_name} = ${2:value};"
 	},
 	"shortint": {
 		"prefix": "shortint",
-		"body": "shortint ${1:name}"
+		"body": "shortint ${1:name} = ${2:value};"
 	},
 	"longint": {
 		"prefix": "longint",
-		"body": "longint ${1:name}"
+		"body": "longint ${1:name} = ${2:value};"
 	},
 	"byte": {
 		"prefix": "byte",
-		"body": "byte ${1:byte:_name}"
+		"body": "byte ${1:byte:_name} = ${2:value};"
 	},
 	"logic": {
 		"prefix": "logic",
-		"body": "logic ${1:logic_name}"
+		"body": "logic ${1:logic_name} = ${2:value};"
 	},
 	"packed": {
 		"prefix": "packed",
-		"body": "packed ${1:name}"
+		"body": "packed"
 	},
 	"this": {
 		"prefix": "this",
@@ -101,7 +101,7 @@
 	"package": {
 		"prefix": "package",
 		"body": [
-			"package ${1:package_name",
+			"package ${1:package_name}",
 			"\t$2",
 			"endpackage"
 		],
@@ -109,7 +109,7 @@
 	},
 	"import": {
 		"prefix": "import",
-		"body": "import ${1:name}::${2:scope}",
+		"body": "import ${1:name}::${2:scope};",
 		"description": "import name::scope"
 	},
 	"interface": {
@@ -146,7 +146,7 @@
 		"description": "typedef enum (data_type) { ... } name"
 	},
 	"enum": {
-		"prefix": "enum",
+		"prefix": ["en", "enum"],
 		"body": [
 			"enum ${1:data_type} { $0 } ${2:name}"
 		],

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -66,6 +66,11 @@
 		],
 		"description": "Insert a begin ... end block"
 	},
+	"end": {
+		"prefix": "end",
+		"body": "end",
+		"description": "Insert end keyword"
+	},
 	"initial": {
 		"prefix": "initial",
 		"body": [

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -13,7 +13,7 @@
 		"description": "Insert a module with parameter"
 	},
 	"module without parameters": {
-		"prefix": "mod",
+		"prefix": "module",
 		"body": [
 			"module ${1:moduleName} (",
 			"\t${2:ports}",

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -48,6 +48,15 @@
 		],
 		"description": "always @(posedge clk)"
 	},
+	"alwaysnegclk": {
+		"prefix": ["alnegclk", "alwaysnegclk"],
+		"body": [
+			"always @(negedge clk $1) begin",
+			"\t$2",
+			"end"
+		],
+		"description": "always @(negedge clk)"
+	},
 	"begin/end": {
 		"prefix": "begin",
 		"body": [
@@ -75,6 +84,26 @@
 			"endcase"
 		],
 		"description": "case () ... endcase"
+	},
+	"casex": {
+		"prefix": "casex",
+		"body": [
+			"casex (${1:param})",
+			"\t$2: $3",
+			"\tdefault: $4",
+			"endcase"
+		],
+		"description": "casex () ... endcase"
+	},
+	"casez": {
+		"prefix": "casez",
+		"body": [
+			"casez (${1:param})",
+			"\t$2: $3",
+			"\tdefault: $4",
+			"endcase"
+		],
+		"description": "casez () ... endcase"
 	},
 	"reg": {
 		"prefix": "reg",
@@ -123,6 +152,21 @@
 		],
 		"description": "paramter var = val;"
 	},
+	"localparam": {
+		"prefix": "localparam",
+		"body": "localparam $1 = $2",
+		"description": "localparam var = val"
+	},
+	"integer": {
+		"prefix": "integer",
+		"body": "integer $1",
+		"description": "integer int_name"
+	},
+	"signed": {
+		"prefix": "signed",
+		"body": "signed $1 $2",
+		"description": "signed datatype name"
+	},
 	"include": {
 		"prefix": ["include", "`include"],
 		"body": [
@@ -133,15 +177,45 @@
 	"define": {
 		"prefix": ["define", "`define"],
 		"body": [
-			"`def $1 = $2"
+			"`define $1"
 		],
-		"description": "`define var = val"
+		"description": "`define macro = val"
+	},
+	"ifdef": {
+		"prefix": ["ifdef", "`ifdef"],
+		"body": "`ifdef $1",
+		"description": "`ifdef macro"
+	},
+	"ifndef": {
+		"prefix": ["ifndef", "`ifndef"],
+		"body": "`ifndef $1",
+		"description": "`ifndef macro"
+	},
+	"elsif": {
+		"prefix": ["elsif", "`elsif"],
+		"body": "`elsif $1",
+		"description": "`elsif macro"
+	},
+	"endif": {
+		"prefix": ["endif", "`endif"],
+		"body": "`endif $1",
+		"description": "`endif macro"
+	},
+	"undef": {
+		"prefix": ["undef", "`undef"],
+		"body": "`undef $1",
+		"description": "`undef macro"
 	},
 	"timescale": {
 		"prefix": ["ts", "timescale", "`timescale"],
 		"body": [
 			"`timescale ${1:1ps}/${2:1ps}$0"
 		]
+	},
+	"default_nettype": {
+		"prefix": ["default_nettype", "`default_nettype"],
+		"body": "`default_nettype ${1:none)",
+		"description": "Set default nettype"
 	},
 	"ternary": {
 		"prefix": "ternary",
@@ -206,6 +280,20 @@
 			"endfunction"
 		],
 		"description": "function (...) ... endfunction"
+	},
+	"generate": {
+		"prefix": "generate",
+		"body": [
+			"generate",
+			"\t$1",
+			"endgenerate"
+		],
+		"description": "generate (...) ... endgenerate"
+	},
+	"genvar": {
+		"prefix": "genvar",
+		"body": "genvar $1",
+		"description": "genvar i"
 	},
 	"testbench template": {
 		"prefix": ["tb", "testbench"],

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -1,6 +1,6 @@
 {
 	"module with parameters": {
-		"prefix": "paramod",
+		"prefix": ["paramod", "module #"],
 		"body": [
 			"module ${1:moduleName} #(",
 			"\t${2:parameters}",
@@ -24,7 +24,7 @@
 		"description": "Insert a module without parameter"
 	},
 	"always": {
-		"prefix": "al",
+		"prefix": "always",
 		"body": [
 			"always @($1) begin",
 			"\t$2",
@@ -33,7 +33,7 @@
 		"description": "always @()"
 	},
 	"alwaysposclk": {
-		"prefix": "alclk",
+		"prefix": ["alclk", "alwaysposclk"],
 		"body": [
 			"always @(posedge clk $1) begin",
 			"\t$2",
@@ -68,14 +68,14 @@
 		"description": "reg reg_name;"
 	},
 	"regarray": {
-		"prefix": "rega",
+		"prefix": ["regarray", "reg ["],
 		"body": [
 			"reg [$1:$2] $3;"
 		],
 		"description": "reg [N:0] reg_name;"
 	},
 	"regmemory": {
-		"prefix": "regm",
+		"prefix": ["regmemory","memory"],
 		"body": [
 			"reg [$1:$2] $3 [$4:$5];"
 		],
@@ -89,35 +89,35 @@
 		"description": "wire wire_name;"
 	},
 	"wirearray": {
-		"prefix": "wirea",
+		"prefix": ["wirearray", "wire ["],
 		"body": [
 			"wire [$1:$2] $3;"
 		],
 		"description": "wire [N:0] wire_name;"
 	},
 	"include": {
-		"prefix": "inc",
+		"prefix": ["include", "`include"],
 		"body": [
 			"`include \"$1\""
 		],
 		"description": "`include \"..\""
 	},
 	"define": {
-		"prefix": "def",
+		"prefix": ["define", "`define"],
 		"body": [
 			"`def $1 = $2"
 		],
 		"description": "`define var = val"
 	},
 	"parameter": {
-		"prefix": "param",
+		"prefix": "parameter",
 		"body": [
 			"parameter $1 = $2;"
 		],
 		"description": "paramter var = val;"
 	},
 	"ternary": {
-		"prefix": "ter",
+		"prefix": "ternary",
 		"body": [
 			"$1 ? $2 : $3"
 		],
@@ -172,7 +172,7 @@
 		"description": "function (...) ... endfunction"
 	},
 	"testbench template": {
-		"prefix": "tb",
+		"prefix": ["tb", "testbench"],
 		"body": [
 			"`include \"$1.v\"",
 			"`default_nettype none",

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -31,7 +31,7 @@
 		"description": "set module, mod i0 (.*);"
 	},
 	"always": {
-		"prefix": "always",
+		"prefix": ["al", "always"],
 		"body": [
 			"always @($1) begin",
 			"\t$2",
@@ -154,17 +154,17 @@
 	},
 	"localparam": {
 		"prefix": "localparam",
-		"body": "localparam $1 = $2",
+		"body": "localparam $1 = $2;",
 		"description": "localparam var = val"
 	},
 	"integer": {
 		"prefix": "integer",
-		"body": "integer $1",
+		"body": "integer $1;",
 		"description": "integer int_name"
 	},
 	"signed": {
 		"prefix": "signed",
-		"body": "signed $1 $2",
+		"body": "signed $1 $2;",
 		"description": "signed datatype name"
 	},
 	"include": {
@@ -175,35 +175,35 @@
 		"description": "`include \"..\""
 	},
 	"define": {
-		"prefix": ["define", "`define"],
+		"prefix": ["def", "define", "`define"],
 		"body": [
-			"`define $1"
+			"`define ${1:macro}"
 		],
-		"description": "`define macro = val"
+		"description": "`define macro"
 	},
 	"ifdef": {
 		"prefix": ["ifdef", "`ifdef"],
-		"body": "`ifdef $1",
+		"body": "`ifdef ${1:macro}",
 		"description": "`ifdef macro"
 	},
 	"ifndef": {
 		"prefix": ["ifndef", "`ifndef"],
-		"body": "`ifndef $1",
+		"body": "`ifndef ${1:macro}",
 		"description": "`ifndef macro"
 	},
 	"elsif": {
 		"prefix": ["elsif", "`elsif"],
-		"body": "`elsif $1",
+		"body": "`elsif ${1:macro}",
 		"description": "`elsif macro"
 	},
 	"endif": {
 		"prefix": ["endif", "`endif"],
-		"body": "`endif $1",
+		"body": "`endif ${1:macro}",
 		"description": "`endif macro"
 	},
 	"undef": {
 		"prefix": ["undef", "`undef"],
-		"body": "`undef $1",
+		"body": "`undef ${1:macro}",
 		"description": "`undef macro"
 	},
 	"timescale": {
@@ -214,7 +214,7 @@
 	},
 	"default_nettype": {
 		"prefix": ["default_nettype", "`default_nettype"],
-		"body": "`default_nettype ${1:none)",
+		"body": "`default_nettype ${1:none}",
 		"description": "Set default nettype"
 	},
 	"ternary": {

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -23,6 +23,13 @@
 		],
 		"description": "Insert a module without parameter"
 	},
+	"instantiate module": {
+		"prefix": ["set module", "instantiate module"],
+		"body": [
+			"${1:mod_name} ${2:instance_name} (${3:.*}$0);"
+		],
+		"description": "set module, mod i0 (.*);"
+	},
 	"always": {
 		"prefix": "always",
 		"body": [
@@ -30,7 +37,7 @@
 			"\t$2",
 			"end"
 		],
-		"description": "always @()"
+		"description": "Insert an always block"
 	},
 	"alwaysposclk": {
 		"prefix": ["alclk", "alwaysposclk"],
@@ -41,14 +48,23 @@
 		],
 		"description": "always @(posedge clk)"
 	},
-	"beginend": {
+	"begin/end": {
 		"prefix": "begin",
 		"body": [
 			"begin",
 			"\t$1",
 			"end"
 		],
-		"description": "begin ... end"
+		"description": "Insert a begin ... end block"
+	},
+	"initial": {
+		"prefix": "initial",
+		"body": [
+			"initial begin",
+			"\t$0",
+			"end"
+		],
+		"description": "initial begin ... end"
 	},
 	"case": {
 		"prefix": "case",
@@ -95,6 +111,18 @@
 		],
 		"description": "wire [N:0] wire_name;"
 	},
+	"array": {
+		"prefix": "array",
+		"body": "[${1:8}:${2:0}]$0",
+		"description": "insert [x:y]"
+	},
+	"parameter": {
+		"prefix": "parameter",
+		"body": [
+			"parameter $1 = $2;"
+		],
+		"description": "paramter var = val;"
+	},
 	"include": {
 		"prefix": ["include", "`include"],
 		"body": [
@@ -109,12 +137,11 @@
 		],
 		"description": "`define var = val"
 	},
-	"parameter": {
-		"prefix": "parameter",
+	"timescale": {
+		"prefix": ["ts", "timescale", "`timescale"],
 		"body": [
-			"parameter $1 = $2;"
-		],
-		"description": "paramter var = val;"
+			"`timescale ${1:1ps}/${2:1ps}$0"
+		]
 	},
 	"ternary": {
 		"prefix": "ternary",
@@ -160,6 +187,15 @@
 			"end"
 		],
 		"description": "while (...) begin ... end"
+	},
+	"forever": {
+		"prefix": "forever",
+		"body": [
+			"forever begin",
+			"\t$0",
+			"end"
+		],
+		"description": "forever begin ... end"
 	},
 	"function": {
 		"prefix": "function",


### PR DESCRIPTION
This pull request reorganizes the snippets included with the extension, making them easier to find, and adding other ones I think would be useful. This closes #128.

Here is a list of changes made:

- Slight update to .gitignore to prevent additional `.vscode` files from appearing.
- Updating prefixes on existing snippets to make them easier to find. For example, the prefix `always_ff` will also recognize `ff` being typed. Prefixes modified can be viewed for Verilog \([1](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/37a516544d382d57e6c8bf7420ba0405abec1466#diff-8816d829a24ac0dd5f607a5a450eda9eaaa837e1b2c4d96331da0c0f1236384c), [2](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/d4bd89b94659d283afd502033052bed30e1fe007#diff-8816d829a24ac0dd5f607a5a450eda9eaaa837e1b2c4d96331da0c0f1236384c)\) and [SystemVerilog](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/37a516544d382d57e6c8bf7420ba0405abec1466#diff-b4f380786cb8721613c17d8193aace02a3735834dd970202c63bece3b12451d2). This also resolves #94.
- Removed redundant snippets (appearing both for Verilog and SystemVerilog), and moved Verilog-compatible snippets out of the SystemVerilog file (ex. `timescale`, `forever`). These can be viewed for [SystemVerilog](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/0bd91ce692ef59771015b3a0c79acd27ff5a123e#diff-b4f380786cb8721613c17d8193aace02a3735834dd970202c63bece3b12451d2) and [Verilog](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/0bd91ce692ef59771015b3a0c79acd27ff5a123e#diff-8816d829a24ac0dd5f607a5a450eda9eaaa837e1b2c4d96331da0c0f1236384c).
- Added  a number of other commonly used snippets. For [Verilog](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/58b26bd77c9828c3b2f214bc43e08149fc175aab#diff-8816d829a24ac0dd5f607a5a450eda9eaaa837e1b2c4d96331da0c0f1236384c), this includes `localparam`, `casex`, `integer`,           
`` `ifdef``,`` `default_nettype``, and generate. For [SystemVerilog](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/58b26bd77c9828c3b2f214bc43e08149fc175aab#diff-b4f380786cb8721613c17d8193aace02a3735834dd970202c63bece3b12451d2), it includes `package`, `import`, and `modport`. [This file](https://github.com/mshr-h/vscode-verilog-hdl-support/commit/d4bd89b94659d283afd502033052bed30e1fe007#diff-b4f380786cb8721613c17d8193aace02a3735834dd970202c63bece3b12451d2) from the first commit resolves #99.

Thanks for maintaining this extension, it's really useful.