### PR TITLE
Add Ctags indexing when switching documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Add Ctags execution when opening document [#132](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/132)
+
 ## [1.3.6] - 2020-11-21
 
 ### Added


### PR DESCRIPTION
To fix issue "Hover and definition jumps stop working" [#132](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/132)

After switching documents in the tab bar, the Ctags symbol was cleared but not generated.
I added ctags.index() when switching documents.