### PR TITLE
Update syntax for markdown codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
 	"icon": "images/icon.png",
 	"activationEvents": [
 		"onLanguage:verilog",
-		"onLanguage:systemverilog",
-		"onLanguage:markdown"
+		"onLanguage:systemverilog"
 	],
 	"main": "./out/src/extension",
 	"contributes": {
@@ -138,8 +137,7 @@
 				],
 				"embeddedLanguages": {
 					"meta.embedded.block.verilog": "source.verilog",
-					"meta.embedded.block.systemverilog": "source.systemverilog",
-					"meta.embedded.block.sdc": "source.sdc"
+					"meta.embedded.block.systemverilog": "source.systemverilog"
 				}
 			}
 		],

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -12,18 +12,18 @@
 	],
 	"repository": {
 		"fenced_code_block_verilog": {
-			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(v|verilog)(\\s+[^`~]*)?$)",
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(v|verilog)((\\s+|:|\\{)[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 			"beginCaptures": {
 				"3": {
 					"name": "punctuation.definition.markdown"
 				},
-				"5": {
-					"name": "fenced_code.block.language"
+				"4": {
+					"name": "fenced_code.block.language.markdown"
 				},
-				"6": {
-					"name": "fenced_code.block.language.attributes"
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
 				}
 			},
 			"endCaptures": {
@@ -45,18 +45,18 @@
 			]
 		},
 		"fenced_code_block_systemverilog": {
-			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(sv|systemverilog)(\\s+[^`~]*)?$)",
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(sv|systemverilog)((\\s+|:|\\{)[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 			"beginCaptures": {
 				"3": {
 					"name": "punctuation.definition.markdown"
 				},
-				"5": {
-					"name": "fenced_code.block.language"
+				"4": {
+					"name": "fenced_code.block.language.markdown"
 				},
-				"6": {
-					"name": "fenced_code.block.language.attributes"
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
 				}
 			},
 			"endCaptures": {


### PR DESCRIPTION
* Remove unnecessary markdown activation event. (This is my mistake in #101)
* Update markdown codeblock syntax to match the latest [VSCode markdown syntax](https://github.com/microsoft/vscode-markdown-basics/blob/main/syntaxes/markdown.tmLanguage.json).
* ~~Add support for bsv, ucf, sdc, and xdc syntax to markdown codeblocks.~~
