### PR TITLE
Fix linters and some errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
 					"scope": "window",
 					"type": "string",
 					"default": "",
-					"description": "Add Modelsim arguments here. They will be added to xvlog while linting."
+					"description": "Add xvlog arguments here. They will be added to xvlog while linting."
 				},
 				"verilog.linting.iverilog.arguments": {
 					"scope": "window",

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -244,8 +244,8 @@ export class CtagsManager {
         commands.executeCommand('vscode.executeDocumentSymbolProvider', doc.uri);
     }
 
-    onDidChangeActiveTextEditor(editor: TextEditor) {
-        if (!this.isOutputPanel(editor.document.uri)) {
+    onDidChangeActiveTextEditor(editor: TextEditor | undefined) {
+        if (editor && !this.isOutputPanel(editor.document.uri)) {
             console.log("on open");
             CtagsManager.ctags.setDocument(editor.document);
             CtagsManager.ctags.index();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export function activate(context: ExtensionContext) {
     // Configure command to instantiate a module
     commands.registerCommand("verilog.instantiateModule", ModuleInstantiation.instantiateModuleInteract);
     // Register command for manual linting
-    commands.registerCommand("verilog.lint", lintManager.RunLintTool);
+    commands.registerCommand("verilog.lint", lintManager.RunLintTool, lintManager);
 
     // Configure svls language server
     configLanguageServer();

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -22,6 +22,11 @@ export default class LintManager {
 
         workspace.onDidChangeConfiguration(this.configLinter, this, this.subscriptions);
         this.configLinter();
+
+        // Run linting for open documents on launch
+        window.visibleTextEditors.forEach(editor => {
+            this.lint(editor.document);
+        });
     }
 
     configLinter() {

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -89,7 +89,7 @@ export default class VerilatorLinter extends BaseLinter {
             // Parse output lines
             lines.forEach((line, i) => {
                 // Error for our file
-                if (line.startsWith('%') && line.search(docUri) > 0) {
+                if (line.startsWith('%') && line.indexOf(docUri) > 0) {
                     let rex = line.match(/%(\w+)(-[A-Z0-9_]+)?:\s*(\w+:)?(?:[^:]+):\s*(\d+):(?:\s*(\d+):)?\s*(\s*.+)/);
 
                     if (rex && rex[0].length > 0) {

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -15,7 +15,7 @@ export default class VerilogDefinitionProvider implements DefinitionProvider {
         return new Promise((resolve, reject) => {
             // get word start and end
             let textRange = document.getWordRangeAtPosition(position);
-            if (textRange.isEmpty)
+            if (!textRange || textRange.isEmpty)
                 return;
             // hover word
             let targetText = document.getText(textRange);

--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -15,7 +15,7 @@ export default class VerilogHoverProvider implements HoverProvider {
         this.logger.log("Hover requested");
         // get word start and end
         let textRange = document.getWordRangeAtPosition(position);
-        if (textRange.isEmpty)
+        if (!textRange || textRange.isEmpty)
             return;
         // hover word
         let targetText = document.getText(textRange);


### PR DESCRIPTION
Hi.
This PR will fix following.

* `package.json`
  - Fix description of `xvlog arguments` setting.
* `XvlogLinter.ts`
  - Fix `xvlog arguments` setting requiring additional whitespace.
  - Fix error message not being detected correctly if it contains brackets `[]`.
  - Add support for warning messages.
* `VerilatorLinter.ts`
  - Fix file paths being treated as regular expressions.
* `LintManager.ts`
  - Add linting for open documents on launch.
* `extension.ts`
  - Fix `Verilog: Rerun lint tool` command not working.
* `ctags.ts`, `DefinitionProvider.ts`, `HoverProvider.ts`
  - Fix errors reported in the Developer Tools that the variable is undefined.