### PR TITLE
Fix ctags and linters

### DIFF
--- a/src/linter/BaseLinter.ts
+++ b/src/linter/BaseLinter.ts
@@ -6,8 +6,8 @@ export default abstract class BaseLinter {
 	name: string;
 	protected logger: Logger;
 
-	constructor(name: string, logger: Logger) {
-		this.diagnostic_collection = languages.createDiagnosticCollection();
+	constructor(name: string, diagnostic_collection: DiagnosticCollection, logger: Logger) {
+		this.diagnostic_collection = diagnostic_collection;
 		this.name = name;
 		this.logger = logger;
 	}

--- a/src/linter/IcarusLinter.ts
+++ b/src/linter/IcarusLinter.ts
@@ -9,8 +9,8 @@ export default class IcarusLinter extends BaseLinter {
     private iverilogArgs: string;
     private runAtFileLocation: boolean;
 
-    constructor(logger: Logger) {
-        super("iverilog", logger);
+    constructor(diagnostic_collection: DiagnosticCollection, logger: Logger) {
+        super("iverilog", diagnostic_collection, logger);
         workspace.onDidChangeConfiguration(() => {
             this.getConfig();
         })

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -1,4 +1,4 @@
-import { Disposable, workspace, TextDocument, window, QuickPickItem, ProgressLocation } from "vscode";
+import { Disposable, workspace, TextDocument, DiagnosticCollection, languages, window, QuickPickItem, ProgressLocation } from "vscode";
 
 import BaseLinter from "./BaseLinter";
 import IcarusLinter from "./IcarusLinter";
@@ -12,9 +12,11 @@ export default class LintManager {
     private subscriptions: Disposable[];
 
     private linter: BaseLinter;
+	private diagnostic_collection: DiagnosticCollection;
     private logger: Logger;
 
     constructor(logger: Logger) {
+        this.diagnostic_collection = languages.createDiagnosticCollection();
         this.logger = logger;
         workspace.onDidOpenTextDocument(this.lint, this, this.subscriptions);
         workspace.onDidSaveTextDocument(this.lint, this, this.subscriptions);
@@ -36,16 +38,16 @@ export default class LintManager {
         if (this.linter == null || this.linter.name != linter_name) {
             switch (linter_name) {
                 case "iverilog":
-                    this.linter = new IcarusLinter(this.logger);
+                    this.linter = new IcarusLinter(this.diagnostic_collection, this.logger);
                     break;
                 case "xvlog":
-                    this.linter = new XvlogLinter(this.logger);
+                    this.linter = new XvlogLinter(this.diagnostic_collection, this.logger);
                     break;
                 case "modelsim":
-                    this.linter = new ModelsimLinter(this.logger);
+                    this.linter = new ModelsimLinter(this.diagnostic_collection, this.logger);
                     break;
                 case "verilator":
-                    this.linter = new VerilatorLinter(this.logger);
+                    this.linter = new VerilatorLinter(this.diagnostic_collection, this.logger);
                     break;
                 default:
                     console.log("Invalid linter name.")
@@ -106,10 +108,10 @@ export default class LintManager {
             // Create and run the linter with progress bar
             let tempLinter: BaseLinter;
             switch (linterStr.label) {
-                case "iverilog": tempLinter = new IcarusLinter(this.logger); break;
-                case "xvlog": tempLinter = new XvlogLinter(this.logger); break;
-                case "modelsim": tempLinter = new ModelsimLinter(this.logger); break;
-                case "verilator": tempLinter = new VerilatorLinter(this.logger); break;
+                case "iverilog": tempLinter = new IcarusLinter(this.diagnostic_collection, this.logger); break;
+                case "xvlog": tempLinter = new XvlogLinter(this.diagnostic_collection, this.logger); break;
+                case "modelsim": tempLinter = new ModelsimLinter(this.diagnostic_collection, this.logger); break;
+                case "verilator": tempLinter = new VerilatorLinter(this.diagnostic_collection, this.logger); break;
                 default:
                     return;
             }

--- a/src/linter/ModelsimLinter.ts
+++ b/src/linter/ModelsimLinter.ts
@@ -10,8 +10,8 @@ export default class ModelsimLinter extends BaseLinter {
     private modelsimWork: string;
     private runAtFileLocation: boolean;
 
-    constructor(logger: Logger) {
-        super("modelsim", logger);
+    constructor(diagnostic_collection: DiagnosticCollection, logger: Logger) {
+        super("modelsim", diagnostic_collection, logger);
         workspace.onDidChangeConfiguration(() => {
             this.getConfig();
         })

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -11,8 +11,8 @@ export default class VerilatorLinter extends BaseLinter {
     private runAtFileLocation: boolean;
     private useWSL: boolean;
 
-    constructor(logger: Logger) {
-        super("verilator", logger);
+    constructor(diagnostic_collection: DiagnosticCollection, logger: Logger) {
+        super("verilator", diagnostic_collection, logger);
 
         workspace.onDidChangeConfiguration(() => {
             this.getConfig();

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -7,8 +7,8 @@ import { Logger, Log_Severity } from "../Logger";
 export default class XvlogLinter extends BaseLinter {
     private xvlogArgs: string;
 
-    constructor(logger: Logger) {
-        super("xvlog", logger);
+    constructor(diagnostic_collection: DiagnosticCollection, logger: Logger) {
+        super("xvlog", diagnostic_collection, logger);
         workspace.onDidChangeConfiguration(() => {
             this.getConfig();
         })

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -10,39 +10,32 @@ export default class VerilogDefinitionProvider implements DefinitionProvider {
     }
 
 
-    provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<DefinitionLink[]> {
+    async provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<DefinitionLink[] | undefined> {
         this.logger.log("Definitions Requested: " + document.uri)
-        return new Promise((resolve, reject) => {
-            // get word start and end
-            let textRange = document.getWordRangeAtPosition(position);
-            if (!textRange || textRange.isEmpty)
-                return;
-            // hover word
-            let targetText = document.getText(textRange);
-            let ctags: Ctags = CtagsManager.ctags;
-            if (ctags.doc === undefined || ctags.doc.uri !== document.uri) { // systemverilog keywords
-                return;
+        // get word start and end
+        let textRange = document.getWordRangeAtPosition(position);
+        if (!textRange || textRange.isEmpty)
+            return;
+        // hover word
+        let targetText = document.getText(textRange);
+        let symbols: Symbol[] = await CtagsManager.getSymbols(document);
+        let matchingSymbols: Symbol[] = [];
+        let definitions: DefinitionLink[] = [];
+        // find all matching symbols
+        for (let i of symbols) {
+            if (i.name === targetText) {
+                matchingSymbols.push(i)
             }
-            else {
-                let matchingSymbols: Symbol[] = [];
-                let definitions: DefinitionLink[] = [];
-                // find all matching symbols
-                for (let i of ctags.symbols) {
-                    if (i.name === targetText) {
-                        matchingSymbols.push(i)
-                    }
-                }
-                for (let i of matchingSymbols) {
-                    definitions.push({
-                        targetUri: document.uri,
-                        targetRange: new Range(i.startPosition, new Position(i.startPosition.line, Number.MAX_VALUE)),
-                        targetSelectionRange: new Range(i.startPosition, i.endPosition)
-                    });
-                }
-                this.logger.log(definitions.length + " definitions returned")
-                resolve(definitions);
-            }
-        })
+        }
+        for (let i of matchingSymbols) {
+            definitions.push({
+                targetUri: document.uri,
+                targetRange: new Range(i.startPosition, new Position(i.startPosition.line, Number.MAX_VALUE)),
+                targetSelectionRange: new Range(i.startPosition, i.endPosition)
+            });
+        }
+        this.logger.log(definitions.length + " definitions returned")
+        return definitions;
     }
 
 }

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -11,31 +11,14 @@ export default class VerilogDocumentSymbolProvider implements DocumentSymbolProv
         this.logger = logger
     }
 
-    provideDocumentSymbols(document: TextDocument, token: CancellationToken): Thenable<DocumentSymbol[]> {
-        return new Promise((resolve) => {
-            this.logger.log("Symbols Requested: " + document.uri)
-            let symbols: Symbol[] = [];
-            console.log("symbol provider");
-            let activeDoc: TextDocument = window.activeTextEditor.document;
-            if (CtagsManager.ctags.doc === undefined || CtagsManager.ctags.doc.uri.fsPath !== activeDoc.uri.fsPath)
-                CtagsManager.ctags.setDocument(activeDoc);
-            let ctags: Ctags = CtagsManager.ctags;
-            // If dirty, re index and then build symbols
-            if (ctags.isDirty) {
-                ctags.index()
-                    .then(() => {
-                        symbols = ctags.symbols;
-                        console.log(symbols);
-                        this.docSymbols = this.buildDocumentSymbolList(symbols);
-                        this.logger.log(this.docSymbols.length + " top-level symbols returned", (this.docSymbols.length > 0) ? Log_Severity.Info : Log_Severity.Warn)
-                        resolve(this.docSymbols);
-                    })
-            }
-            else {
-                this.logger.log(this.docSymbols.length + " top-level symbols returned")
-                resolve(this.docSymbols);
-            }
-        })
+    async provideDocumentSymbols(document: TextDocument, token: CancellationToken): Promise<DocumentSymbol[]> {
+        this.logger.log("Symbols Requested: " + document.uri)
+        console.log("symbol provider");
+        let symbols: Symbol[] = await CtagsManager.getSymbols(document);
+        console.log(symbols);
+        this.docSymbols = this.buildDocumentSymbolList(symbols);
+        this.logger.log(this.docSymbols.length + " top-level symbols returned", (this.docSymbols.length > 0) ? Log_Severity.Info : Log_Severity.Warn)
+        return this.docSymbols;
     }
 
     isContainer(type: SymbolKind): boolean {


### PR DESCRIPTION
Hi.
Thanks for merging #146!
This is additional fix that I mentioned in #146.

This PR contains two fixes:

* Fix ctags symbols not being updated in some cases.
  For example, Hover does not work right after saving a document.
  This fix adds the `getSymbols` function to the `CtagsManager` class to provide the correct symbols to all providers.
  I have removed the `onDidChangeActiveTextEditor` event in `CtagsManager` as it is no longer needed.

* Share `DiagnosticCollection` between linters.
  After executing the `Verilog: Rerun lint tool` command, error/warning messages will remain on the screen and cannot be erased.
  This fix improves it by moving the `DiagnosticCollection` to the `LintManager`.
