### PR TITLE
fix: escape workspace directory

### DIFF
--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -118,8 +118,9 @@ export default class VerilatorLinter extends BaseLinter {
             ' ' +
             svArgs +
             ' --lint-only -I' +
+            '"' +
             docFolder +
-            ' ' +
+            '" ' +
             this.verilatorArgs +
             ' "' +
             docUri +


### PR DESCRIPTION
If your workspace directory has a space in it, linting with verilator fails because the path is not properly escaped/quoted.

A temporary workaround is moving your workspace to a directory with no spaces in the path, but fixes it at the extension level.

Thanks for making such a useful extension!