### PR TITLE
Add .svh files for SystemVerilog parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         ],
         "extensions": [
           ".sv",
+          ".svh",
           ".SV"
         ],
         "configuration": "./systemverilog.configuration.json"


### PR DESCRIPTION
Include .svh extension for System Verilog.  This extension is often used for SystemVerilog header files.