### PR TITLE
Added the ability to disable Ctag

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
         "verilog.ctags.path": {
           "scope": "window",
           "type": "string",
-          "default": "ctags",
+          "default": "none",
           "description": "A path to the installation of Universal Ctags."
         },
         "verilog.languageServer": {

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -171,20 +171,23 @@ export class Ctags {
         console.log('executing ctags');
 
         let ctags: string = <string>(
-            workspace.getConfiguration().get('verilog.ctags.path')
+            workspace.getConfiguration().get('verilog.ctags.path', 'none')
         );
-        let command: string =
-            ctags + ' -f - --fields=+K --sort=no --excmd=n "' + filepath + '"';
-        console.log(command);
-        this.logger.log(command, Log_Severity.Command);
-        return new Promise((resolve, reject) => {
-            child.exec(
-                command,
-                (error: Error, stdout: string, stderr: string) => {
-                    resolve(stdout);
-                }
-            );
-        });
+        if(ctags != 'none')
+        {
+            let command: string =
+                ctags + ' -f - --fields=+K --sort=no --excmd=n "' + filepath + '"';
+            console.log(command);
+            this.logger.log(command, Log_Severity.Command);
+            return new Promise((resolve, reject) => {
+                child.exec(
+                    command,
+                    (error: Error, stdout: string, stderr: string) => {
+                        resolve(stdout);
+                    }
+                );
+            });
+        }
     }
 
     parseTagLine(line: string): Symbol {


### PR DESCRIPTION
Added the ability to disable CTAG
To turn off, it is enough to write `none`, by analogy with Language Server.
I consider this function necessary, because not all users have CTAG. This also allows the extension not to create potentially disastrous requests.