### PR TITLE
Set the default value of verilog.languageServer.enabled to false (Resolves #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+- Fix [#332](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/332)
+
 ## [1.5.7] - 2022-11-11
 
 - Add toggle option for Language Server in config.

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
         "verilog.languageServer.enabled": {
           "scope": "window",
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "description": "Enable Language Server."
         },
         "verilog.logging.enabled": {


### PR DESCRIPTION
The default value of verilog.languageServer.enabled is changed from string "false" to boolean false.
This will solve the issue #332.

I found this setting is used only in the configLanguage Server function (in `src/extension.ts`).
So I believe any further change is required.