### PR TITLE
Add experimental support for verible-verilog-ls (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+- Re-added experimental support for verible-verilog-ls Language Server. [#403](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/403)
+
 ## [1.11.0] - 2023-02-02
 
 - Added an experimental support for Slang linting. [#387](https://github.com/mshr-h/vscode-verilog-hdl-support/pull/387)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Install it from [VS Code Marketplace](https://marketplace.visualstudio.com/items
   - [svls](https://github.com/dalance/svls)
   - [veridian](https://github.com/vivekmalneedi/veridian)
   - [HDL Checker](https://github.com/suoto/hdl_checker)
+  - [verible-verilog-ls](https://github.com/chipsalliance/verible)
 - \[Experimental\] Formatting support from:
   - [verilog-format](https://github.com/ericsonj/verilog-format)
   - [istyle-verilog-formatter](https://github.com/thomasrussellmurphy/istyle-verilog-formatter)
@@ -83,7 +84,7 @@ If you encounter any problems even if it's not related to this feature, **deleti
 | [svls](https://github.com/dalance/svls)                        | not supported | enabled       | not supported |
 | [veridian](https://github.com/vivekmalneedi/veridian)          | not supported | enabled       | not supported |
 | [HDL Checker](https://github.com/suoto/hdl_checker)            | enabled       | enabled       | enabled       |
-
+| [verible-verilog-ls](https://github.com/chipsalliance/verible) | not supported | enabled       | not supported |
 ### Formatting (Experimental)
 
 We currently support Verilog-HDL file formatting with the following formatters.
@@ -210,6 +211,14 @@ Use the following settings to configure the extension to your needs.
 - `verilog.languageServer.hdlChecker.path` (Default: `hdl_checker`)
 
     \[Experimental\] A path to the HDL Checker Language Server binary.
+
+- `verilog.languageServer.veribleVerilogLs.enabled` (Default: `false`)
+
+    \[Experimental\] Enable verible-verilog-ls Language Server for SystemVerilog.
+
+- `verilog.languageServer.veribleVerilogLs.path` (Default: `verible-verilog-ls`)
+
+    \[Experimental\] A path to the verible-verilog-ls Language Server binary.
 
 - `verilog.formatting.verilogHDL.formatter` (Default: `verilog-format`)
 

--- a/package.json
+++ b/package.json
@@ -400,6 +400,18 @@
           "default": false,
           "description": "[Experimental] Enable HDL Checker Language Server for Verilog-HDL, SystemVerilog, and VHDL."
         },
+        "verilog.languageServer.veribleVerilogLs.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "[Experimental] Enable verible-verilog-ls Language Server for SystemVerilog."
+        },
+        "verilog.languageServer.veribleVerilogLs.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "verible-verilog-ls",
+          "description": "[Experimental] A path to the verible-verilog-ls Language Server binary."
+        },
         "verilog.languageServer.hdlChecker.path": {
           "scope": "window",
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,6 +224,11 @@ function initAllLanguageClients() {
       { scheme: 'file', language: 'vhdl' },
     ],
   });
+
+  // init verible-verilog-ls
+  setupLanguageClient('veribleVerilogLs', 'verible-verilog-ls', [], [], {
+    documentSelector: [{ scheme: 'file', language: 'systemverilog' }],
+  });
 }
 
 function stopAllLanguageClients(): Promise<any> {


### PR DESCRIPTION
Addresses #403

Tested with verible v0.0-2996-g781744e1 on ubuntu 22.04
