### PR TITLE
Add quotation marks around paths for Slang, Verilator and Xvlog

### DIFF
--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -71,8 +71,8 @@ export default class SlangLinter extends BaseLinter {
 
     let binPath = path.join(this.linterInstalledPath, slang);
     let args: string[] = [];
-    args.push(`-I ${docFolder}`);
-    args = args.concat(this.includePath.map((path: string) => `-I ${path}`));
+    args.push(`-I "${docFolder}"`);
+    args = args.concat(this.includePath.map((path: string) => `-I "${path}"`));
     args.push(this.arguments);
     args.push(`"${docUri}"`);
     let command: string = binPath + ' ' + args.join(' ');
@@ -86,6 +86,9 @@ export default class SlangLinter extends BaseLinter {
     this.logger.info('[slang] Execute');
     this.logger.info('[slang]   command: ' + command);
     this.logger.info('[slang]   cwd    : ' + cwd);
+
+
+
 
     var _: child.ChildProcess = child.exec(
       command,

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -87,9 +87,6 @@ export default class SlangLinter extends BaseLinter {
     this.logger.info('[slang]   command: ' + command);
     this.logger.info('[slang]   cwd    : ' + cwd);
 
-
-
-
     var _: child.ChildProcess = child.exec(
       command,
       { cwd: cwd },

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -95,7 +95,7 @@ export default class VerilatorLinter extends BaseLinter {
     }
     args.push('--lint-only');
     args.push(`-I"${docFolder}"`);
-    args = args.concat(this.includePath.map((path: string) => '-I' + path));
+    args = args.concat(this.includePath.map((path: string) => `-I "${path}"`));
     args.push(this.arguments);
     args.push(`"${docUri}"`);
     let command: string = binPath + ' ' + args.join(' ');

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -36,7 +36,7 @@ export default class XvlogLinter extends BaseLinter {
     if (doc.languageId === 'systemverilog') {
       args.push('-sv');
     }
-    args = args.concat(this.includePath.map((path: string) => '-i ' + path));
+    args = args.concat(this.includePath.map((path: string) => `-i "${path}"`));
     this.logger.warn(this.includePath.join(' '));
     args.push(this.arguments);
     args.push(`"${doc.fileName}"`);


### PR DESCRIPTION
Similar issue to #139 for slang, verilator and xvlog.

Note, I only tested with slang and verilator