### PR TITLE
Fix Verilator linting include paths

### DIFF
--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -95,7 +95,7 @@ export default class VerilatorLinter extends BaseLinter {
     }
     args.push('--lint-only');
     args.push(`-I"${docFolder}"`);
-    args = args.concat(this.includePath.map((path: string) => `-I "${path}"`));
+    args = args.concat(this.includePath.map((path: string) => `-I"${path}"`));
     args.push(this.arguments);
     args.push(`"${docUri}"`);
     let command: string = binPath + ' ' + args.join(' ');


### PR DESCRIPTION
Removes the space between the `-I` and the quoted include path, which breaks Verilator.

Resolves #421.