### PR TITLE
Fix slang warning message with square brackets

### DIFF
--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -93,7 +93,7 @@ export default class SlangLinter extends BaseLinter {
       { cwd: cwd },
       (_error: Error, _stdout: string, stderr: string) => {
         let diagnostics: vscode.Diagnostic[] = [];
-        const re = /(.+?):(\d+):(\d+):\s(note|warning|error):\s([^[\]]*)(\[-W(.*)\])?/;
+        const re = /(.+?):(\d+):(\d+):\s(note|warning|error):\s(.*?)(\[-W(.*)\]|$)/;
         stderr.split(/\r?\n/g).forEach((line, _) => {
           if (line.search(re) === -1) {
             return;


### PR DESCRIPTION
Fixes #426. Changed the regex so instead of searching for the longest string without "[" or "]", it will search for the smallest string which ends with the warning indicator (e.g. [-Wrange-oob]) or the end of the string (in the case of an error)