### PR TITLE
use uctag parameter field option for module instantiation (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased] - 2023-12-xx
+
+### Fixed
+
+- Fix [#102](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/102)
+  - requires [Universal Ctags, Oct 22, 2020 version](https://github.com/universal-ctags/ctags/pull/2666) and later.
+
 ## [1.13.0] 2023-08-31
 
 ### Added

--- a/src/commands/ModuleInstantiation.ts
+++ b/src/commands/ModuleInstantiation.ts
@@ -59,7 +59,7 @@ function instantiateModule(srcpath: string): Thenable<vscode.SnippetString> {
         portsName = ports.map((tag) => tag.name);
         let params: Symbol[] = ctags.symbols.filter(
           (tag) =>
-            tag.type === 'constant' && tag.parentType === 'module' && tag.parentScope === scope
+            tag.type === 'parameter' && tag.parentType === 'module' && tag.parentScope === scope
         );
         parametersName = params.map((tag) => tag.name);
         logger.info('Module name: ' + module.name);

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -52,6 +52,7 @@ export class Symbol {
   static isContainer(type: string): boolean {
     switch (type) {
       case 'constant':
+      case 'parameter':
       case 'event':
       case 'net':
       case 'port':
@@ -83,6 +84,8 @@ export class Symbol {
   static getSymbolKind(name: String): vscode.SymbolKind {
     switch (name) {
       case 'constant':
+        return vscode.SymbolKind.Constant;
+      case 'parameter':
         return vscode.SymbolKind.Constant;
       case 'event':
         return vscode.SymbolKind.Event;
@@ -165,7 +168,7 @@ export class Ctags {
       vscode.workspace.getConfiguration().get('verilog.ctags.path', 'none')
     );
     if (binPath !== 'none') {
-      let command: string = binPath + ' -f - --fields=+K --sort=no --excmd=n "' + filepath + '"';
+      let command: string = binPath + ' -f - --fields=+K --sort=no --excmd=n --fields-SystemVerilog=+{parameter} "' + filepath + '"';
       this.logger.info('Executing Command: ' + command);
       return new Promise((resolve, _reject) => {
         child_process.exec(command, (_error: Error, stdout: string, _stderr: string) => {
@@ -185,7 +188,11 @@ export class Ctags {
       name = parts[0];
       // pattern = parts[2];
       type = parts[3];
-      if (parts.length == 5) {
+      // override "type" for parameters (See #102)
+      if (parts.length == 6 && parts[5] === 'parameter:') {
+        type = 'parameter';
+      }
+      if (parts.length >= 5) {
         scope = parts[4].split(':');
         parentType = scope[0];
         parentScope = scope[1];


### PR DESCRIPTION
NOTE: This pull request is not tested, because I don't have environment to test VS code extension.

---

By adding `--fields-SystemVerilog=+{parameter}` option uctag, it emits the 6th field, `parameter:`.

When `parameter:` is emitted, this fix override type as `parameter`.

In the following example `parameter:` are added on `P1` and `P2`.  This fix uses them.

```sh
$ cat with_parameter_port_list.sv 
module with_parameter_port_list #(
        P1,
        localparam L2 = P1+1,
        parameter P2)
        ( /*port list...*/ );
        parameter  L3 = "synonym for the localparam";
        localparam L4 = "localparam";
        // ...
endmodule

$ ctags -o - --fields=+K --sort=no --excmd=n with_parameter_port_list.sv 
with_parameter_port_list        with_parameter_port_list.sv     1;"     module
P1      with_parameter_port_list.sv     2;"     constant        module:with_parameter_port_list
L2      with_parameter_port_list.sv     3;"     constant        module:with_parameter_port_list
P2      with_parameter_port_list.sv     4;"     constant        module:with_parameter_port_list
L3      with_parameter_port_list.sv     6;"     constant        module:with_parameter_port_list
L4      with_parameter_port_list.sv     7;"     constant        module:with_parameter_port_list
$ ctags -o - --fields=+K --sort=no --excmd=n --fields-SystemVerilog=+{parameter} with_parameter_port_list.sv 
with_parameter_port_list        with_parameter_port_list.sv     1;"     module
P1      with_parameter_port_list.sv     2;"     constant        module:with_parameter_port_list parameter:
L2      with_parameter_port_list.sv     3;"     constant        module:with_parameter_port_list
P2      with_parameter_port_list.sv     4;"     constant        module:with_parameter_port_list parameter:
L3      with_parameter_port_list.sv     6;"     constant        module:with_parameter_port_list
L4      with_parameter_port_list.sv     7;"     constant        module:with_parameter_port_list
$ 
```