### PR TITLE
fix ctags indexing error if ctags path is set to none #417

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Fixed
+
+- Fixed ctags indexing error when ctags path is set to none [#417](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/417)
+
 ## [1.13.2] 2024-02-04
 
 ### Added

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -176,7 +176,8 @@ export class Ctags {
         });
       });
     }
-    return undefined;
+    // Return empty promise if ctags path is not set to avoid errors when indexing
+    return Promise.resolve('');
   }
 
   parseTagLine(line: string): Symbol {


### PR DESCRIPTION
Fixes the error reported here when the ctags path is set to none: https://github.com/mshr-h/vscode-verilog-hdl-support/issues/417