### PR TITLE
Support module definitions by looking for file name

### DIFF
--- a/src/commands/ModuleInstantiation.ts
+++ b/src/commands/ModuleInstantiation.ts
@@ -14,71 +14,63 @@ export function instantiateModuleInteract() {
   });
 }
 
-function instantiateModule(srcpath: string): Thenable<vscode.SnippetString> {
-  return new Promise<vscode.SnippetString>((resolve, _reject) => {
+async function instantiateModule(srcpath: string): Promise<vscode.SnippetString | undefined> {
     // Using Ctags to get all the modules in the file
     let moduleName: string = '';
     let portsName: string[] = [];
     let parametersName: string[] = [];
-    let ctags: ModuleTags = new ModuleTags(logger);
+    let file: vscode.TextDocument = vscode.window.activeTextEditor.document;
+    let ctags: ModuleTags = new ModuleTags(logger, file);
     logger.info('Executing ctags for module instantiation');
-    ctags
-      .execCtags(srcpath)
-      .then((output) => {
-        ctags.buildSymbolsList(output);
-      })
-      .then(async () => {
-        let module: Symbol;
-        let modules: Symbol[] = ctags.symbols.filter((tag) => tag.type === 'module');
-        // No modules found
-        if (modules.length <= 0) {
-          vscode.window.showErrorMessage('Verilog-HDL/SystemVerilog: No modules found in the file');
-          return;
+    let output = await ctags.execCtags(srcpath);
+    await ctags.buildSymbolsList(output);
+    let module: Symbol;
+    let modules: Symbol[] = ctags.symbols.filter((tag) => tag.type === 'module');
+    // No modules found
+    if (modules.length <= 0) {
+      vscode.window.showErrorMessage('Verilog-HDL/SystemVerilog: No modules found in the file');
+      return undefined;
+    }
+    // Only one module found
+    else if (modules.length === 1) {
+      module = modules[0];
+    }
+    // many modules found
+    else if (modules.length > 1) {
+      moduleName = await vscode.window.showQuickPick(
+        ctags.symbols.filter((tag) => tag.type === 'module').map((tag) => tag.name),
+        {
+          placeHolder: 'Choose a module to instantiate',
         }
-        // Only one module found
-        else if (modules.length === 1) {
-          module = modules[0];
-        }
-        // many modules found
-        else if (modules.length > 1) {
-          moduleName = await vscode.window.showQuickPick(
-            ctags.symbols.filter((tag) => tag.type === 'module').map((tag) => tag.name),
-            {
-              placeHolder: 'Choose a module to instantiate',
-            }
-          );
-          if (moduleName === undefined) {
-            return;
-          }
-          module = modules.filter((tag) => tag.name === moduleName)[0];
-        }
-        let scope = module.parentScope != '' ? module.parentScope + '.' + module.name : module.name;
-        let ports: Symbol[] = ctags.symbols.filter(
-          (tag) => tag.type === 'port' && tag.parentType === 'module' && tag.parentScope === scope
-        );
-        portsName = ports.map((tag) => tag.name);
-        let params: Symbol[] = ctags.symbols.filter(
-          (tag) =>
-            tag.type === 'parameter' && tag.parentType === 'module' && tag.parentScope === scope
-        );
-        parametersName = params.map((tag) => tag.name);
-        logger.info('Module name: ' + module.name);
-        let paramString = ``;
-        if (parametersName.length > 0) {
-          paramString = `\n#(\n${instantiatePort(parametersName)})\n`;
-        }
-        logger.info('portsName: ' + portsName.toString());
-        resolve(
-          new vscode.SnippetString()
-            .appendText(module.name + ' ')
-            .appendText(paramString)
-            .appendPlaceholder('u_')
-            .appendPlaceholder(`${module.name}(\n`)
-            .appendText(instantiatePort(portsName))
-            .appendText(');\n')
-        );
-      });
-  });
+      );
+      if (moduleName === undefined) {
+        return undefined;
+      }
+      module = modules.filter((tag) => tag.name === moduleName)[0];
+    }
+    let scope = module.parentScope != '' ? module.parentScope + '.' + module.name : module.name;
+    let ports: Symbol[] = ctags.symbols.filter(
+      (tag) => tag.type === 'port' && tag.parentType === 'module' && tag.parentScope === scope
+    );
+    portsName = ports.map((tag) => tag.name);
+    let params: Symbol[] = ctags.symbols.filter(
+      (tag) =>
+        tag.type === 'parameter' && tag.parentType === 'module' && tag.parentScope === scope
+    );
+    parametersName = params.map((tag) => tag.name);
+    logger.info('Module name: ' + module.name);
+    let paramString = ``;
+    if (parametersName.length > 0) {
+      paramString = `\n#(\n${instantiatePort(parametersName)})\n`;
+    }
+    logger.info('portsName: ' + portsName.toString());
+    return new vscode.SnippetString()
+        .appendText(module.name + ' ')
+        .appendText(paramString)
+        .appendPlaceholder('u_')
+        .appendPlaceholder(`${module.name}(\n`)
+        .appendText(instantiatePort(portsName))
+        .appendText(');\n');
 }
 
 function instantiatePort(ports: string[]): string {
@@ -103,7 +95,7 @@ function instantiatePort(ports: string[]): string {
   return port;
 }
 
-function selectFile(currentDir?: string): Thenable<string> {
+async function selectFile(currentDir?: string): Promise<string | undefined> {
   currentDir = currentDir || vscode.workspace.rootPath;
 
   let dirs = getDirectories(currentDir);
@@ -129,24 +121,22 @@ function selectFile(currentDir?: string): Thenable<string> {
     });
   });
 
-  return vscode.window
+  let selected = await vscode.window
     .showQuickPick(items, {
       placeHolder: 'Choose the module file',
-    })
-    .then((selected) => {
-      if (!selected) {
-        return undefined;
-      }
-
-      // if is a directory
-      let location = path.join(currentDir, selected.label);
-      if (fs.statSync(location).isDirectory()) {
-        return selectFile(location);
-      }
-
-      // return file path
-      return location;
     });
+  if (!selected) {
+    return undefined;
+  }
+
+  // if is a directory
+  let location = path.join(currentDir, selected.label);
+  if (fs.statSync(location).isDirectory()) {
+    return selectFile(location);
+  }
+
+  // return file path
+  return location;
 }
 
 function getDirectories(srcpath: string): string[] {
@@ -160,7 +150,7 @@ function getFiles(srcpath: string): string[] {
 }
 
 class ModuleTags extends Ctags {
-  buildSymbolsList(tags: string): Thenable<void> {
+  buildSymbolsList(tags: string): Promise<void> {
     if (tags === '') {
       return undefined;
     }

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -257,7 +257,6 @@ export class Ctags {
             }
           }
         }
-        this.logger.info('Symbols: ' + this.symbols.toString());
         this.isDirty = false;
       }
     } catch (e) {
@@ -269,7 +268,6 @@ export class Ctags {
     this.logger.info('indexing ', this.doc.uri.fsPath);
     
     let output = await this.execCtags(this.doc.uri.fsPath)
-    console.log("output", output)
     await this.buildSymbolsList(output);
   }
 }
@@ -294,7 +292,6 @@ export class CtagsManager {
     return ctags;
   }
   onClose(doc: vscode.TextDocument) {
-    this.logger.info('on close');
     this.filemap.delete(doc);
   }
 
@@ -308,7 +305,6 @@ export class CtagsManager {
     let ctags: Ctags = this.getCtags(doc);
     // If dirty, re index and then build symbols
     if (ctags.isDirty) {
-      console.log("indxing ");
       await ctags.index();
     }
     return ctags.symbols;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { ExtensionManager } from './extensionManager';
 import { createLogger, Logger } from './logger';
 
 export var logger: Logger; // Global logger
-var ctagsManager: CtagsManager;
+var ctagsManager = new CtagsManager();
 let extensionID: string = 'mshr-h.veriloghdl';
 
 let lintManager: LintManager;
@@ -36,12 +36,12 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   // Configure ctags
-  ctagsManager = new CtagsManager(logger.getChild('CtagsManager'));
-  ctagsManager.configure();
+  ctagsManager.configure(logger);
 
   // Configure Document Symbol Provider
   let verilogDocumentSymbolProvider = new DocumentSymbolProvider.VerilogDocumentSymbolProvider(
-    logger.getChild('VerilogDocumentSymbolProvider')
+    logger.getChild('VerilogDocumentSymbolProvider'),
+    ctagsManager,
   );
   context.subscriptions.push(
     vscode.languages.registerDocumentSymbolProvider(
@@ -68,7 +68,8 @@ export function activate(context: vscode.ExtensionContext) {
   // Configure Completion Item Provider
   // Trigger on ".", "(", "="
   let verilogCompletionItemProvider = new CompletionItemProvider.VerilogCompletionItemProvider(
-    logger.getChild('VerilogCompletionItemProvider')
+    logger.getChild('VerilogCompletionItemProvider'),
+    ctagsManager,
   );
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
@@ -103,7 +104,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Configure Hover Providers
   let verilogHoverProvider = new HoverProvider.VerilogHoverProvider(
-    logger.getChild('VerilogHoverProvider')
+    logger.getChild('VerilogHoverProvider'),
+    ctagsManager,
   );
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(
@@ -124,7 +126,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Configure Definition Providers
   let verilogDefinitionProvider = new DefinitionProvider.VerilogDefinitionProvider(
-    logger.getChild('VerilogDefinitionProvider')
+    logger.getChild('VerilogDefinitionProvider'),
+    ctagsManager
   );
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(

--- a/src/providers/CompletionItemProvider.ts
+++ b/src/providers/CompletionItemProvider.ts
@@ -6,9 +6,11 @@ import { Logger } from '../logger';
 
 export class VerilogCompletionItemProvider implements vscode.CompletionItemProvider {
   private logger: Logger;
-
-  constructor(logger: Logger) {
+  private ctagsManager: CtagsManager;
+  constructor(logger: Logger,
+    ctagsManager: CtagsManager){
     this.logger = logger;
+    this.ctagsManager = ctagsManager;
   }
 
   //TODO: Better context based completion items
@@ -21,7 +23,7 @@ export class VerilogCompletionItemProvider implements vscode.CompletionItemProvi
     this.logger.info('Completion items requested');
     let items: vscode.CompletionItem[] = [];
 
-    let symbols: Symbol[] = await CtagsManager.getSymbols(document);
+    let symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
     symbols.forEach((symbol) => {
       let newItem: vscode.CompletionItem = new vscode.CompletionItem(
         symbol.name,

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
 import { BsvInfoProviderManger } from '../BsvProvider';
-import { CtagsManager, Symbol } from '../ctags';
+import { CtagsManager } from '../ctags';
 import { Logger } from '../logger';
+
+
 
 export class VerilogDefinitionProvider implements vscode.DefinitionProvider {
   private logger: Logger;
-  constructor(logger: Logger) {
+  private ctagsManager: CtagsManager;
+  constructor(logger: Logger,
+    ctagsManager: CtagsManager){
     this.logger = logger;
+    this.ctagsManager = ctagsManager;
   }
 
   async provideDefinition(
@@ -23,25 +28,8 @@ export class VerilogDefinitionProvider implements vscode.DefinitionProvider {
     }
     // hover word
     let targetText = document.getText(textRange);
-    let symbols: Symbol[] = await CtagsManager.getSymbols(document);
-    let matchingSymbols: Symbol[] = [];
-    let definitions: vscode.DefinitionLink[] = [];
     // find all matching symbols
-    for (let i of symbols) {
-      if (i.name === targetText) {
-        matchingSymbols.push(i);
-      }
-    }
-    for (let i of matchingSymbols) {
-      definitions.push({
-        targetUri: document.uri,
-        targetRange: new vscode.Range(
-          i.startPosition,
-          new vscode.Position(i.startPosition.line, Number.MAX_VALUE)
-        ),
-        targetSelectionRange: new vscode.Range(i.startPosition, i.endPosition),
-      });
-    }
+    let definitions: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, targetText);
     this.logger.info(definitions.length + ' definitions returned');
     return definitions;
   }

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -21,15 +21,8 @@ export class VerilogDefinitionProvider implements vscode.DefinitionProvider {
     _token: vscode.CancellationToken
   ): Promise<vscode.DefinitionLink[] | undefined> {
     this.logger.info('Definitions Requested: ' + document.uri);
-    // get word start and end
-    let textRange = document.getWordRangeAtPosition(position);
-    if (!textRange || textRange.isEmpty) {
-      return undefined;
-    }
-    // hover word
-    let targetText = document.getText(textRange);
     // find all matching symbols
-    let definitions: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, targetText);
+    let definitions: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, position);
     this.logger.info(definitions.length + ' definitions returned');
     return definitions;
   }

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -21,7 +21,6 @@ export class VerilogDocumentSymbolProvider implements vscode.DocumentSymbolProvi
   ): Promise<vscode.DocumentSymbol[]> {
     this.logger.info('[VerilogSymbol] Symbols Requested: ' + document.uri);
     let symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
-    this.logger.info('[VerilogSymbol] Symbols: ' + symbols.toString());
     this.docSymbols = this.buildDocumentSymbolList(symbols);
     this.logger.info(this.docSymbols.length + ' top-level symbols returned');
     return this.docSymbols;

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -8,8 +8,11 @@ export class VerilogDocumentSymbolProvider implements vscode.DocumentSymbolProvi
   public docSymbols: vscode.DocumentSymbol[] = [];
 
   private logger: Logger;
-  constructor(logger: Logger) {
+  private ctagsManager: CtagsManager;
+  constructor(logger: Logger,
+    ctagsManager: CtagsManager){
     this.logger = logger;
+    this.ctagsManager = ctagsManager;
   }
 
   async provideDocumentSymbols(
@@ -17,7 +20,7 @@ export class VerilogDocumentSymbolProvider implements vscode.DocumentSymbolProvi
     _token: vscode.CancellationToken
   ): Promise<vscode.DocumentSymbol[]> {
     this.logger.info('[VerilogSymbol] Symbols Requested: ' + document.uri);
-    let symbols: Symbol[] = await CtagsManager.getSymbols(document);
+    let symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
     this.logger.info('[VerilogSymbol] Symbols: ' + symbols.toString());
     this.docSymbols = this.buildDocumentSymbolList(symbols);
     this.logger.info(this.docSymbols.length + ' top-level symbols returned');

--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -21,14 +21,7 @@ export class VerilogHoverProvider implements vscode.HoverProvider {
     _token: vscode.CancellationToken
   ): Promise<vscode.Hover | undefined> {
     this.logger.info('Hover requested');
-    // get word start and end
-    let textRange = document.getWordRangeAtPosition(position);
-    if (!textRange || textRange.isEmpty) {
-      return undefined;
-    }
-    // hover word
-    let targetText = document.getText(textRange);
-    let matches: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, targetText);
+    let matches: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, position);
     // find symbol
     for (let i of matches) {
       // returns the first found tag. Disregards others


### PR DESCRIPTION
- Looks for symbol.sv in the repo when searching on hover and definition
- Package refs, modports follow their parent and search for that module/package/interface
- switched a bunch of stuff to async/await
- cleaned up logs

TODO (future work):
- This might leave indexed files in longer than they should be
- We should only be searching on module defs, not all symbols. It looks like we only find the kind of symbol defs, not any rhs
- have the async tasks race and cancel the lagging one
