### PR TITLE
fix README.md for ctags-companion v2023.8.0 or later (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ by adding the following settings on `.vscode/settings.json` in your workspace.
 
 ```json
 {
-    "ctags-companion.command": "ctags -R --fields=+nKz -f .vscode/.tags --langmap=SystemVerilog:+.v -R rtl /opt/uvm-1.2/src",
-    "ctags-companion.readtagsEnabled": true,
+    "ctags-companion.command": "ctags -R --fields=+nKz --langmap=SystemVerilog:+.v -R rtl /opt/uvm-1.2/src",
 }
 ```
 


### PR DESCRIPTION
From https://github.com/gediminasz/ctags-companion/releases/tag/v2023.8.0

- Switched to using the default tags file location rather than .vscode/.tags
- Replaced in-memory symbol index with more efficient readtags.