### PR TITLE
Iverilog_linting_bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)\
 
+## Unreleased
+
+### Fixed
+- Fix the issue of keywords being tokenized as entity.name.tag.module.reference.verilog instead of keyword.other.verilog to fix the issue in [#476](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/476)
+
 ## [1.15.2] - 2024-10-19
 
 ### Changed

--- a/syntaxes/verilog.tmLanguage.json
+++ b/syntaxes/verilog.tmLanguage.json
@@ -105,7 +105,7 @@
           "include": "#keywords"
         },
         {
-          "begin": "^\\s*([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
+          "begin": "^\\s*(?!always|and|assign|output|input|inout|wire|module)([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.tag.module.reference.verilog"


### PR DESCRIPTION
Fix #476

Fix the issue of keywords being tokenized as entity.name.tag.module.reference.verilog instead of keyword.other.verilog to fix [#476](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/476). This is done by adding a negative lookahead to the pattern of entity.name.tag.module.reference.verilog.

