### PR TITLE
Fix glitches caused by Verible LS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)\
 
+## [Unreleased] - 2024-xx-xx
+
+### Fixed
+
+- Fix same warning of Verible LS shows twice [#449](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/449)
+- Fix Verible formatter arguments not working [#487](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/487)
+
 ## [1.15.3] - 2024-10-26
 
 ### Fixed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
+import { LanguageClient, LanguageClientOptions, Message, ServerOptions } from 'vscode-languageclient/node';
 
 import LintManager from './linter/LintManager';
 import { CtagsManager } from './ctags';
@@ -249,6 +249,18 @@ function initAllLanguageClients() {
 
   // init verible-verilog-ls
   setupLanguageClient('veribleVerilogLs', 'verible-verilog-ls', [], [], {
+    connectionOptions: {
+      messageStrategy: {
+        handleMessage: (message, next) => {
+          if (Message.isResponse(message) && message.result['capabilities']) {
+            delete message.result['capabilities']['diagnosticProvider'];
+            delete message.result['capabilities']['documentFormattingProvider'];
+            delete message.result['capabilities']['documentRangeFormattingProvider'];
+          }
+          next(message);
+        }
+      }
+    },
     documentSelector: [
       { scheme: 'file', language: 'verilog' },
       { scheme: 'file', language: 'systemverilog' },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -258,8 +258,8 @@ function initAllLanguageClients() {
             delete message.result['capabilities']['documentRangeFormattingProvider'];
           }
           next(message);
-        }
-      }
+        },
+      },
     },
     documentSelector: [
       { scheme: 'file', language: 'verilog' },


### PR DESCRIPTION
Fix #449 
Fix #487 

Modified the option of `veribleVerilogLs` to include a `messageStrategy` that handles and modifies the language server capabilities by removing unnecessary diagnostic and formatting providers. 

#449 and #487 occurred as the same features are provided twice by *HDL support* and *verible LS*. All things work fine now.

Please notice that this patch does not disable any features of *Verible LS*. Instead, they are just suppressed and letting VSCode  not able to realize that the language server provide these features. VSCode therefore has to turn to our extension for formatter and diagnostics.