### PR TITLE
Fix typos in comments and completion item

### DIFF
--- a/src/providers/CompletionItemProvider.ts
+++ b/src/providers/CompletionItemProvider.ts
@@ -37,7 +37,7 @@ export class VerilogCompletionItemProvider implements vscode.CompletionItemProvi
       newItem.detail = symbol.type;
       let doc: string = '```systemverilog\n' + code + '\n```';
       if (symbol.parentScope !== undefined && symbol.parentScope !== '') {
-        doc += '\nHeirarchial Scope: ' + symbol.parentScope;
+        doc += '\nHierarchical Scope: ' + symbol.parentScope;
       }
       newItem.documentation = new vscode.MarkdownString(doc);
       items.push(newItem);

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -59,7 +59,7 @@ export class VerilogDocumentSymbolProvider implements vscode.DocumentSymbolProvi
     return false;
   }
 
-  // find the appropriate container RECURSIVELY and add to its childrem
+  // find the appropriate container RECURSIVELY and add to its children
   // return true: if done
   // return false: if container not found
   findContainer(con: vscode.DocumentSymbol, sym: vscode.DocumentSymbol): boolean {
@@ -79,8 +79,8 @@ export class VerilogDocumentSymbolProvider implements vscode.DocumentSymbolProvi
     return false;
   }
 
-  // Build heiarchial DocumentSymbol[] from linear symbolsList[] using start and end position
-  // TODO: Use parentscope/parenttype of symbol to construct heirarchial vscode.DocumentSymbol []
+  // Build hierarchical DocumentSymbol[] from linear symbolsList[] using start and end position
+  // TODO: Use parentscope/parenttype of symbol to construct hierarchical vscode.DocumentSymbol []
   buildDocumentSymbolList(symbolsList: Symbol[]): vscode.DocumentSymbol[] {
     let list: vscode.DocumentSymbol[] = [];
     symbolsList = symbolsList.sort((a, b): number => {


### PR DESCRIPTION
## Summary
- correct typos in `DocumentSymbolProvider` comments
- show "Hierarchical Scope" in completion item documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848e6e16b748324bfc23ea30f605531