### PR TITLE
Add document symbol provider test

### DIFF
--- a/package.json
+++ b/package.json
@@ -592,7 +592,7 @@
     "syntax": "js-yaml ./syntaxes/systemverilog.tmLanguage.yaml >./syntaxes/systemverilog.tmLanguage.json",
     "makeBsv": "antlr4ts -visitor syntaxes/bsv.g4 -o src/bsvjs",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
-    "test": "node ./out/src/test/bsv.js"
+    "test": "node ./out/src/test/runTest.js"
   },
   "dependencies": {
     "antlr4": "^4.13.1-patch-1",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -7,7 +7,7 @@ async function main() {
 	try {
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+                const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
 
 		// The path to test runner
 		// Passed to --extensionTestsPath

--- a/src/test/suite/documentSymbol.test.ts
+++ b/src/test/suite/documentSymbol.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+suite('VerilogDocumentSymbolProvider', () => {
+  test('returns symbols for simple verilog file', async () => {
+    const filePath = path.resolve(__dirname, '../../../language_examples/verilog_building_block/rtl/ram_sp.v');
+    const document = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(document);
+
+    await vscode.workspace.getConfiguration('verilog').update('ctags.path', 'ctags', vscode.ConfigurationTarget.Global);
+
+    const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+      'vscode.executeDocumentSymbolProvider',
+      document.uri
+    );
+
+    assert.ok(symbols && symbols.length > 0, 'Expected at least one document symbol');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for `VerilogDocumentSymbolProvider`
- run tests via `runTest.ts`
- correct extension path in test harness

## Testing
- `npm test` *(fails: SIGSEGV from VS Code due to missing display)*

------
https://chatgpt.com/codex/tasks/task_e_6848e6ea25d88324a2f7dfe40f1f6974