### PR TITLE
fix: When running a linter through WSL, the file where the error occu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Changed
+
+- Fix When running a linter through WSL, the file where the error occurred cannot be correctly indicated [#530](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/530)
+
 ## [1.16.0] - 2025-01-23
 
 ### Added


### PR DESCRIPTION
## [Unreleased]

### Changed

- fix: When running a linter through WSL, the file where the error occu)rred cannot be correctly indicated [#530](https://github.com/mshr-h/vscode-verilog-hdl-support/issues/530)