### PR TITLE
Fix state explosion during backtracking in variable regex

### DIFF
--- a/syntaxes/tcl.tmlanguage.json
+++ b/syntaxes/tcl.tmlanguage.json
@@ -74,7 +74,7 @@
         "variable": {
             "patterns": [
                 {
-                    "begin": "(\\$(?:(?:\\:\\:)?[a-zA-Z0-9_]+)+)\\(",
+                    "begin": "(\\$(?:(?:\\:\\:)?[a-zA-Z0-9_]++)+)\\(",
                     "beginCaptures": {
                         "1": {
                             "name": "variable.other.tcl"
@@ -92,7 +92,7 @@
                 },
                 {
                     "name": "variable.other.tcl",
-                    "match": "\\$(?:(?:\\:\\:)?[a-zA-Z0-9_]+)+"
+                    "match": "\\$(?:(?:\\:\\:)?[a-zA-Z0-9_]++)+"
                 },
                 {
                     "name": "variable.other.tcl",


### PR DESCRIPTION
The variable patterns in `tcl.tmlanguage.json` use nested quantifiers that cause catastrophic backtracking in oniguruma

When a variable name isn't followed by `(` , the engine backtracks through 2^(N-1) possible partitions of the character class match. VS Code's oniguruma has a ~1M state limit, so variable names longer than 21 characters cause the tokenizer to abort, breaking all syntax highlighting for the rest of the file.

Using possessive quantifiers (++) on the inner character class prevents backtracking.

**Steps to reproduce:**

- Open any .tcl file
- Add `puts $abcdefghijklmnopqrstu` (21 char variable name). This should syntax highlight correctly
- Add `puts $abcdefghijklmnopqrstuv` (22 char variable name). This breaks syntax highlighting from that line onward 

Observed on version 1.22.2 in VS Code 1.116.0