### PR TITLE
Fix highlighting for $ in Verilog identifiers

### DIFF
--- a/language_examples/systemverilog/dollar_identifier.sv
+++ b/language_examples/systemverilog/dollar_identifier.sv
@@ -1,0 +1,26 @@
+module top$mod (
+  input  wire w$some_net$b,
+  output wire r$some_reg$d
+);
+
+reg r$display$d;
+
+assign r$some_reg$d = w$some_net$b;
+
+sub$mod u$sub$0 (
+  .in$port(w$some_net$b),
+  .out$port(r$some_reg$d)
+);
+
+initial begin
+  $display("ok");
+  r$display$d = w$some_net$b;
+end
+
+endmodule
+
+module sub$mod (
+  input  wire in$port,
+  output wire out$port
+);
+endmodule

--- a/language_examples/verilog/dollar_identifier.v
+++ b/language_examples/verilog/dollar_identifier.v
@@ -1,0 +1,26 @@
+module top$mod (
+  input  wire w$some_net$b,
+  output wire r$some_reg$d
+);
+
+reg r$display$d;
+
+assign r$some_reg$d = w$some_net$b;
+
+sub$mod u$sub$0 (
+  .in$port(w$some_net$b),
+  .out$port(r$some_reg$d)
+);
+
+initial begin
+  $display("ok");
+  r$display$d = w$some_net$b;
+end
+
+endmodule
+
+module sub$mod (
+  input  wire in$port,
+  output wire out$port
+);
+endmodule

--- a/syntaxes/systemverilog.tmLanguage.json
+++ b/syntaxes/systemverilog.tmLanguage.json
@@ -112,7 +112,7 @@
       },
       "patterns": [
         {
-          "match": "[ \\t\\r\\n]*(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?([a-zA-Z_][a-zA-Z0-9_$]*\\b[ \\t\\r\\n]+)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*)(?=\\(|;)",
+          "match": "[ \\t\\r\\n]*(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::))?([a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])[ \\t\\r\\n]+)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \\t\\r\\n]*)(?=\\(|;)",
           "captures": {
             "1": {
               "name": "support.type.scope.systemverilog"
@@ -330,7 +330,7 @@
       "name": "meta.enum-struct-union.systemverilog"
     },
     "module-declaration": {
-      "begin": "[ \\t\\r\\n]*\\b((?:macro)?module|interface|program|package|modport)[ \\t\\r\\n]+(?:(static|automatic)[ \\t\\r\\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "begin": "[ \\t\\r\\n]*\\b((?:macro)?module|interface|program|package|modport)[ \\t\\r\\n]+(?:(static|automatic)[ \\t\\r\\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -371,7 +371,7 @@
       "name": "meta.module.systemverilog"
     },
     "sequence": {
-      "match": "[ \\t\\r\\n]*\\b(sequence)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "match": "[ \\t\\r\\n]*\\b(sequence)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])",
       "captures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -383,7 +383,7 @@
       "name": "meta.sequence.systemverilog"
     },
     "bind-directive": {
-      "match": "[ \\t\\r\\n]*\\b(bind)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)\\b",
+      "match": "[ \\t\\r\\n]*\\b(bind)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)(?![a-zA-Z0-9_$])",
       "captures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -422,7 +422,7 @@
           }
         },
         {
-          "match": "(`)(ifdef|ifndef|elsif|define|undef|pragma)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+          "match": "(`)(ifdef|ifndef|elsif|define|undef|pragma)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])",
           "captures": {
             "1": {
               "name": "punctuation.definition.directive.systemverilog"
@@ -468,7 +468,7 @@
           "name": "meta.crypto.systemverilog"
         },
         {
-          "match": "(`)([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+          "match": "(`)([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])",
           "captures": {
             "1": {
               "name": "punctuation.definition.directive.systemverilog"
@@ -563,7 +563,7 @@
       "name": "support.class.systemverilog"
     },
     "sv-definition": {
-      "match": "[ \\t\\r\\n]*\\b(primitive|package|constraint|interface|covergroup|program)[ \\t\\r\\n]+\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "match": "[ \\t\\r\\n]*\\b(primitive|package|constraint|interface|covergroup|program)[ \\t\\r\\n]+(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])",
       "captures": {
         "1": {
           "name": "keyword.control.systemverilog"
@@ -633,7 +633,7 @@
           }
         },
         {
-          "match": "[ \\t\\r\\n]+\\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]*(#)\\(",
+          "match": "[ \\t\\r\\n]+(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \\t\\r\\n]*(#)\\(",
           "captures": {
             "1": {
               "name": "storage.type.userdefined.systemverilog"
@@ -660,7 +660,7 @@
       "name": "meta.class.systemverilog"
     },
     "system-tf": {
-      "match": "\\$[a-zA-Z0-9_$][a-zA-Z0-9_$]*\\b",
+      "match": "(?<![a-zA-Z0-9_$])\\$[a-zA-Z0-9_$]+(?![a-zA-Z0-9_$])",
       "name": "support.function.systemverilog"
     },
     "cast-operator": {
@@ -727,7 +727,7 @@
       },
       "patterns": [
         {
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*\\()",
+          "match": "(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \\t\\r\\n]*\\()",
           "name": "variable.other.module.systemverilog"
         },
         {
@@ -752,7 +752,7 @@
           "include": "#port-net-parameter"
         },
         {
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*$)",
+          "match": "(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \\t\\r\\n]*$)",
           "name": "variable.other.module.systemverilog"
         },
         {
@@ -810,7 +810,7 @@
           "include": "#port-net-parameter"
         },
         {
-          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*(\\(|$))",
+          "match": "(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \\t\\r\\n]*(\\(|$))",
           "name": "variable.other.module.systemverilog"
         },
         {
@@ -974,7 +974,7 @@
     "port-net-parameter": {
       "patterns": [
         {
-          "match": ",?[ \\t\\r\\n]*(?:\\b(output|input|inout|ref)\\b[ \\t\\r\\n]*)?(?:\\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\\b[ \\t\\r\\n]*)?(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?<!(?<!#)[:&|=+\\-*/%?><^!~\\(][ \\t\\r\\n]*)\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?[ \\t\\r\\n]*(?=,|;|=|\\)|/|$)",
+          "match": ",?[ \\t\\r\\n]*(?:\\b(output|input|inout|ref)\\b[ \\t\\r\\n]*)?(?:\\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\\b[ \\t\\r\\n]*)?(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \\t\\r\\n]*)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?<!(?<!#)[:&|=+\\-*/%?><^!~\\(][ \\t\\r\\n]*)(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?[ \\t\\r\\n]*(?=,|;|=|\\)|/|$)",
           "captures": {
             "1": {
               "name": "support.type.direction.systemverilog"
@@ -1053,7 +1053,7 @@
           "include": "#strings"
         },
         {
-          "match": "[ \\t\\r\\n]*\\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]+[a-zA-Z_][a-zA-Z0-9_,= \\t\\n]*",
+          "match": "[ \\t\\r\\n]*(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \\t\\r\\n]+[a-zA-Z_][a-zA-Z0-9_$,= \\t\\n]*",
           "captures": {
             "1": {
               "name": "storage.type.interface.systemverilog"
@@ -1098,7 +1098,7 @@
       "name": "storage.modifier.systemverilog"
     },
     "storage-scope": {
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::)",
+      "match": "(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::)",
       "captures": {
         "1": {
           "name": "support.type.scope.systemverilog"
@@ -1254,7 +1254,7 @@
     "identifiers": {
       "patterns": [
         {
-          "match": "\\b[a-zA-Z_][a-zA-Z0-9_$]*\\b",
+          "match": "(?<![a-zA-Z0-9_$])[a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])",
           "name": "variable.other.identifier.systemverilog"
         },
         {

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -49,7 +49,7 @@ repository:
         name: punctuation.definition.function.end.systemverilog
     patterns:
       - match: >-
-          [ \t\r\n]*(?:\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?([a-zA-Z_][a-zA-Z0-9_$]*\b[ \t\r\n]+)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?:\b([a-zA-Z_][a-zA-Z0-9_$]*)\b[ \t\r\n]*)(?=\(|;)
+          [ \t\r\n]*(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::))?([a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])[ \t\r\n]+)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*)(?=\(|;)
         captures:
           '1':
             name: support.type.scope.systemverilog
@@ -159,7 +159,7 @@ repository:
       - include: '#identifiers'
     name: meta.enum-struct-union.systemverilog
   module-declaration:
-    begin: '[ \t\r\n]*\b((?:macro)?module|interface|program|package|modport)[ \t\r\n]+(?:(static|automatic)[ \t\r\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)\b'
+    begin: '[ \t\r\n]*\b((?:macro)?module|interface|program|package|modport)[ \t\r\n]+(?:(static|automatic)[ \t\r\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])'
     beginCaptures:
       '1':
         name: keyword.control.systemverilog
@@ -180,7 +180,7 @@ repository:
       - include: '#identifiers'
     name: meta.module.systemverilog
   sequence:
-    match: '[ \t\r\n]*\b(sequence)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\b'
+    match: '[ \t\r\n]*\b(sequence)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])'
     captures:
       '1':
         name: keyword.control.systemverilog
@@ -188,7 +188,7 @@ repository:
         name: entity.name.function.systemverilog
     name: meta.sequence.systemverilog
   bind-directive:
-    match: '[ \t\r\n]*\b(bind)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$\.]*)\b'
+    match: '[ \t\r\n]*\b(bind)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$\.]*)(?![a-zA-Z0-9_$])'
     captures:
       '1':
         name: keyword.control.systemverilog
@@ -213,7 +213,7 @@ repository:
             name: punctuation.definition.directive.systemverilog
           '2':
             name: string.regexp.systemverilog
-      - match: (`)(ifdef|ifndef|elsif|define|undef|pragma)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\b
+      - match: (`)(ifdef|ifndef|elsif|define|undef|pragma)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])
         captures:
           '1':
             name: punctuation.definition.directive.systemverilog
@@ -240,7 +240,7 @@ repository:
           '2':
             name: string.regexp.systemverilog
         name: meta.crypto.systemverilog
-      - match: (`)([a-zA-Z_][a-zA-Z0-9_$]*)\b
+      - match: (`)([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])
         captures:
           '1':
             name: punctuation.definition.directive.systemverilog
@@ -296,7 +296,7 @@ repository:
     name: support.class.systemverilog
   sv-definition:
     match: >-
-      [ \t\r\n]*\b(primitive|package|constraint|interface|covergroup|program)[ \t\r\n]+\b([a-zA-Z_][a-zA-Z0-9_$]*)\b
+      [ \t\r\n]*\b(primitive|package|constraint|interface|covergroup|program)[ \t\r\n]+(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])
     captures:
       '1':
         name: keyword.control.systemverilog
@@ -343,7 +343,7 @@ repository:
             name: entity.name.type.class.systemverilog
           '3':
             name: entity.name.type.class.systemverilog
-      - match: '[ \t\r\n]+\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \t\r\n]*(#)\('
+      - match: '[ \t\r\n]+(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*(#)\('
         captures:
           '1':
             name: storage.type.userdefined.systemverilog
@@ -356,7 +356,7 @@ repository:
       - include: '#identifiers'
     name: meta.class.systemverilog
   system-tf:
-    match: \$[a-zA-Z0-9_$][a-zA-Z0-9_$]*\b
+    match: (?<![a-zA-Z0-9_$])\$[a-zA-Z0-9_$]+(?![a-zA-Z0-9_$])
     name: support.function.systemverilog
   cast-operator:
     match: '[ \t\r\n]*([0-9]+|[a-zA-Z_][a-zA-Z0-9_$]*)('')(?=\()'
@@ -398,7 +398,7 @@ repository:
       '1':
         name: punctuation.module.instantiation.end.systemverilog
     patterns:
-      - match: '\b([a-zA-Z_][a-zA-Z0-9_$]*)\b(?=[ \t\r\n]*\()'
+      - match: '(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \t\r\n]*\()'
         name: variable.other.module.systemverilog
       - include: '#module-binding'
       - include: '#parameters'
@@ -407,7 +407,7 @@ repository:
       - include: '#constants'
       - include: '#strings'
       - include: '#port-net-parameter'
-      - match: '\b([a-zA-Z_][a-zA-Z0-9_$]*)\b(?=[ \t\r\n]*$)'
+      - match: '(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \t\r\n]*$)'
         name: variable.other.module.systemverilog
       - include: '#identifiers'
     name: meta.module.parameters.systemverilog
@@ -437,7 +437,7 @@ repository:
       - include: '#constants'
       - include: '#strings'
       - include: '#port-net-parameter'
-      - match: '\b([a-zA-Z_][a-zA-Z0-9_$]*)\b(?=[ \t\r\n]*(\(|$))'
+      - match: '(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])(?=[ \t\r\n]*(\(|$))'
         name: variable.other.module.systemverilog
       - include: '#identifiers'
     name: meta.module.no_parameters.systemverilog
@@ -524,7 +524,7 @@ repository:
   port-net-parameter:
     patterns:
       - match: >-
-          ,?[ \t\r\n]*(?:\b(output|input|inout|ref)\b[ \t\r\n]*)?(?:\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\b[ \t\r\n]*)?(?:\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)\b[ \t\r\n]*)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?<!(?<!#)[:&|=+\-*/%?><^!~\(][ \t\r\n]*)\b([a-zA-Z_][a-zA-Z0-9_$]*)\b[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?[ \t\r\n]*(?=,|;|=|\)|/|$)
+          ,?[ \t\r\n]*(?:\b(output|input|inout|ref)\b[ \t\r\n]*)?(?:\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\b[ \t\r\n]*)?(?:(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?<!(?<!#)[:&|=+\-*/%?><^!~\(][ \t\r\n]*)(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?[ \t\r\n]*(?=,|;|=|\)|/|$)
         captures:
           '1':
             name: support.type.direction.systemverilog
@@ -560,7 +560,7 @@ repository:
       - include: '#operators'
       - include: '#constants'
       - include: '#strings'
-      - match: '[ \t\r\n]*\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \t\r\n]+[a-zA-Z_][a-zA-Z0-9_,= \t\n]*'
+      - match: '[ \t\r\n]*(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]+[a-zA-Z_][a-zA-Z0-9_$,= \t\n]*'
         captures:
           '1':
             name: storage.type.interface.systemverilog
@@ -590,7 +590,7 @@ repository:
       [ \t\r\n]*\b(?:(?:un)?signed|packed|small|medium|large|supply[01]|strong[01]|pull[01]|weak[01]|highz[01])\b
     name: storage.modifier.systemverilog
   storage-scope:
-    match: '\b([a-zA-Z_][a-zA-Z0-9_$]*)(::)'
+    match: '(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(::)'
     captures:
       '1':
         name: support.type.scope.systemverilog
@@ -677,7 +677,7 @@ repository:
     name: meta.parameters.systemverilog
   identifiers:
     patterns:
-      - match: \b[a-zA-Z_][a-zA-Z0-9_$]*\b
+      - match: (?<![a-zA-Z0-9_$])[a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])
         name: variable.other.identifier.systemverilog
       - match: (?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n])
         name: string.regexp.identifier.systemverilog

--- a/syntaxes/verilog.tmLanguage.json
+++ b/syntaxes/verilog.tmLanguage.json
@@ -23,6 +23,9 @@
     },
     {
       "include": "#operators"
+    },
+    {
+      "include": "#identifiers"
     }
   ],
   "repository": {
@@ -105,7 +108,7 @@
           "include": "#keywords"
         },
         {
-          "begin": "^\\s*(?!always|and|assign|output|input|inout|wire|module)([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
+          "begin": "^\\s*(?!always|and|assign|output|input|inout|wire|module)([a-zA-Z_][a-zA-Z0-9_$]*)\\s+([a-zA-Z_][a-zA-Z0-9_$]*)(?<!begin|if)\\s*(?=\\(|$)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.tag.module.reference.verilog"
@@ -130,11 +133,14 @@
             },
             {
               "include": "#strings"
+            },
+            {
+              "include": "#identifiers"
             }
           ]
         },
         {
-          "begin": "^\\s*([a-zA-Z][a-zA-Z0-9_]*)\\s*(#)(?=\\s*\\()",
+          "begin": "^\\s*([a-zA-Z_][a-zA-Z0-9_$]*)\\s*(#)(?=\\s*\\()",
           "beginCaptures": {
             "1": {
               "name": "entity.name.tag.module.reference.verilog"
@@ -152,7 +158,7 @@
               "include": "#parenthetical_list"
             },
             {
-              "match": "[a-zA-Z][a-zA-Z0-9_]*",
+              "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
               "name": "entity.name.tag.module.identifier.verilog"
             }
           ]
@@ -170,39 +176,47 @@
           "name": "keyword.other.compiler.directive.verilog"
         },
         {
-          "match": "\\$(f(open|close)|readmem(b|h)|timeformat|printtimescale|stop|finish|(s|real)?time|realtobits|bitstoreal|rtoi|itor|(f)?(display|write(h|b)))\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$(f(open|close)|readmem(b|h)|timeformat|printtimescale|stop|finish|(s|real)?time|realtobits|bitstoreal|rtoi|itor|(f)?(display|write(h|b)))(?![a-zA-Z0-9_$])",
           "name": "support.function.system.console.tasks.verilog"
         },
         {
-          "match": "\\$(random|dist_(chi_square|erlang|exponential|normal|poisson|t|uniform))\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$(random|dist_(chi_square|erlang|exponential|normal|poisson|t|uniform))(?![a-zA-Z0-9_$])",
           "name": "support.function.system.random_number.tasks.verilog"
         },
         {
-          "match": "\\$((a)?sync\\$((n)?and|(n)or)\\$(array|plane))\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$((a)?sync\\$((n)?and|(n)or)\\$(array|plane))(?![a-zA-Z0-9_$])",
           "name": "support.function.system.pld_modeling.tasks.verilog"
         },
         {
-          "match": "\\$(q_(initialize|add|remove|full|exam))\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$(q_(initialize|add|remove|full|exam))(?![a-zA-Z0-9_$])",
           "name": "support.function.system.stochastic.tasks.verilog"
         },
         {
-          "match": "\\$(hold|nochange|period|recovery|setup(hold)?|skew|width)\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$(hold|nochange|period|recovery|setup(hold)?|skew|width)(?![a-zA-Z0-9_$])",
           "name": "support.function.system.timing.tasks.verilog"
         },
         {
-          "match": "\\$(dump(file|vars|off|on|all|limit|flush))\\b",
+          "match": "(?<![a-zA-Z0-9_$])\\$(dump(file|vars|off|on|all|limit|flush))(?![a-zA-Z0-9_$])",
           "name": "support.function.system.vcd.tasks.verilog"
         },
         {
-          "match": "\\$(countdrivers|list|input|scope|showscopes|(no)?(key|log)|reset(_count|_value)?|(inc)?save|restart|showvars|getpattern|sreadmem(b|h)|scale)",
+          "match": "(?<![a-zA-Z0-9_$])\\$(countdrivers|list|input|scope|showscopes|(no)?(key|log)|reset(_count|_value)?|(inc)?save|restart|showvars|getpattern|sreadmem(b|h)|scale)(?![a-zA-Z0-9_$])",
           "name": "support.function.non-standard.tasks.verilog"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "match": "(?<![a-zA-Z0-9_$])[a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])",
+          "name": "variable.other.identifier.verilog"
         }
       ]
     },
     "module_pattern": {
       "patterns": [
         {
-          "begin": "\\b(module)\\s+([a-zA-Z][a-zA-Z0-9_]*)",
+          "begin": "\\b(module)\\s+([a-zA-Z_][a-zA-Z0-9_$]*)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.module.verilog"
@@ -236,6 +250,9 @@
             },
             {
               "include": "#operators"
+            },
+            {
+              "include": "#identifiers"
             }
           ]
         }
@@ -280,6 +297,9 @@
             },
             {
               "include": "#strings"
+            },
+            {
+              "include": "#identifiers"
             }
           ]
         }


### PR DESCRIPTION
Fixes #517.

This updates the Verilog/SystemVerilog TextMate grammars so `$` is treated as a valid identifier character after the first character. Identifier matching now avoids `\b` boundaries where `$` is allowed, and system task matching is guarded so tasks like `$display` do not match in the middle of identifiers.

Also adds Verilog and SystemVerilog language examples covering `$` in module names, instance names, port names, signal names, real system tasks, and `$display` embedded inside a larger identifier.

Validation:
- `npm run syntax`
- JSON parse check for `syntaxes/verilog.tmLanguage.json` and `syntaxes/systemverilog.tmLanguage.json`
- `npm run check-types`
- `npm run lint`