### PR TITLE
Fix region folding markers for Verilog comments

### DIFF
--- a/configs/systemverilog.configuration.json
+++ b/configs/systemverilog.configuration.json
@@ -45,8 +45,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*[//]*region",
-			"end": "^\\s*[//]*endregion"
+			"start": "^\\s*//\\s*#?region\\b",
+			"end": "^\\s*//\\s*#?endregion\\b"
 		}
 	}
 }

--- a/configs/verilog.configuration.json
+++ b/configs/verilog.configuration.json
@@ -33,8 +33,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*[//]*region",
-			"end": "^\\s*[//]*endregion"
+			"start": "^\\s*//\\s*#?region\\b",
+			"end": "^\\s*//\\s*#?endregion\\b"
 		}
 	}
 }

--- a/configs/verilogams.configuration.json
+++ b/configs/verilogams.configuration.json
@@ -51,8 +51,8 @@
   "folding": {
     "offSide": true,
     "markers": {
-      "start": "^\\s*[//]*region",
-      "end": "^\\s*[//]*endregion"
+      "start": "^\\s*//\\s*#?region\\b",
+      "end": "^\\s*//\\s*#?endregion\\b"
     }
   },
 

--- a/language_examples/verilog/region_folding.v
+++ b/language_examples/verilog/region_folding.v
@@ -1,0 +1,6 @@
+module sample_coefficients;
+  // region assign coeffs_const values
+  assign coeffs_const[0] = 5'd0;
+  assign coeffs_const[1] = 5'd2;
+  // endregion assign coeffs_const values
+endmodule


### PR DESCRIPTION
Fixes #463.

The existing folding marker regex only matched forms like `//region` and did not match the common `// region` / `// endregion` style from the issue example.

This updates the Verilog, SystemVerilog, and Verilog-AMS language configurations to use a standard region marker pattern:

- `^\\s*//\\s*#?region\\b`
- `^\\s*//\\s*#?endregion\\b`

This supports `// region`, `//region`, `// #region`, and `//#region`.