### PR TITLE
Fix split-line SystemVerilog module parameter highlighting

### DIFF
--- a/language_examples/systemverilog/module_instantiation_parameters.sv
+++ b/language_examples/systemverilog/module_instantiation_parameters.sv
@@ -1,0 +1,21 @@
+module top;
+  my_module #(
+      .WIDTH(WIDTH)
+  )
+  u_my_module_same_line (
+      .clk(clk)
+  );
+
+  my_module
+  #(
+      .WIDTH(WIDTH)
+  )
+  u_my_module_split_line
+  (
+      .clk(clk)
+  );
+
+  my_module u_my_module_no_parameters (
+      .clk(clk)
+  );
+endmodule

--- a/syntaxes/systemverilog.tmLanguage.json
+++ b/syntaxes/systemverilog.tmLanguage.json
@@ -707,7 +707,7 @@
       "name": "storage.type.rand.systemverilog"
     },
     "module-parameters": {
-      "begin": "[ \\t\\r\\n]*\\b(?:(bind)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)[ \\t\\r\\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]+(?!intersect|and|or|throughout|within)(?=#[^#])",
+      "begin": "^[ \\t]*\\b(?:(bind)[ \\t]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)[ \\t]+)?(?!\\b(?:intersect|and|or|throughout|within)\\b)([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t]*(?=#[^#]|$)",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.systemverilog"

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -385,7 +385,7 @@ repository:
     name: storage.type.rand.systemverilog
   module-parameters:
     begin: >-
-      [ \t\r\n]*\b(?:(bind)[ \t\r\n]+([a-zA-Z_][a-zA-Z0-9_$\.]*)[ \t\r\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)[ \t\r\n]+(?!intersect|and|or|throughout|within)(?=#[^#])
+      ^[ \t]*\b(?:(bind)[ \t]+([a-zA-Z_][a-zA-Z0-9_$\.]*)[ \t]+)?(?!\b(?:intersect|and|or|throughout|within)\b)([a-zA-Z_][a-zA-Z0-9_$]*)[ \t]*(?=#[^#]|$)
     beginCaptures:
       '1':
         name: keyword.control.systemverilog


### PR DESCRIPTION
## Summary

Fixes #472.

This updates the SystemVerilog TextMate grammar so parameterized module instantiations still highlight correctly when the `#(...)` parameter assignment block starts on the line after the module type name. TextMate grammars match line-by-line, so the previous begin rule could not see `#(` when it appeared on the following line.

The PR also adds `language_examples/systemverilog/module_instantiation_parameters.sv` as a generic manual highlighting example covering same-line parameters, split-line parameters, and a non-parameterized instantiation.

## Validation

- `npm run syntax` passed
- JSON parse check for `syntaxes/systemverilog.tmLanguage.json` passed
- `npm run check-types` passed
- `npm run lint` passed