### PR TITLE
Fix Verilog port declaration tokenization

### DIFF
--- a/language_examples/verilog/ansi_port_declarations.v
+++ b/language_examples/verilog/ansi_port_declarations.v
@@ -1,0 +1,31 @@
+module xadc(
+    input i_clk_100m,
+    input i_sig_p,
+    input i_sig_n,
+    input i_ref_p,
+    input i_ref_n,
+    input i_RESET
+    );
+endmodule
+
+module port_declaration_examples(
+    input wire i_clk,
+    output reg [7:0] o_data,
+    inout [3:0] bus
+    );
+
+    my_module u0 (
+        .clk(i_clk)
+    );
+
+endmodule
+
+module port_declaration_prefix_module(
+    input wire i_clk
+    );
+
+    input_filter u0 (
+        .clk(i_clk)
+    );
+
+endmodule

--- a/syntaxes/verilog.tmLanguage.json
+++ b/syntaxes/verilog.tmLanguage.json
@@ -108,7 +108,7 @@
           "include": "#keywords"
         },
         {
-          "begin": "^\\s*(?!always|and|assign|output|input|inout|wire|module)([a-zA-Z_][a-zA-Z0-9_$]*)\\s+([a-zA-Z_][a-zA-Z0-9_$]*)(?<!begin|if)\\s*(?=\\(|$)",
+          "begin": "^\\s*(?!\\b(?:always|and|assign|output|input|inout|wire|reg|integer|time|real|realtime|parameter|localparam|signed|unsigned|module)\\b)([a-zA-Z_][a-zA-Z0-9_$]*)\\s+([a-zA-Z_][a-zA-Z0-9_$]*)(?<!begin|if)\\s*(?=\\(|$)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.tag.module.reference.verilog"
@@ -160,6 +160,40 @@
             {
               "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
               "name": "entity.name.tag.module.identifier.verilog"
+            }
+          ]
+        }
+      ]
+    },
+    "port_declarations": {
+      "patterns": [
+        {
+          "begin": "(^|(?<=[(,]))\\s*\\b(input|output|inout)\\b",
+          "beginCaptures": {
+            "2": {
+              "name": "storage.type.port.verilog"
+            }
+          },
+          "end": "(?=,\\s*(?:input|output|inout)\\b|[);]|$)",
+          "name": "meta.block.port-declaration.verilog",
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#identifiers"
             }
           ]
         }
@@ -244,6 +278,9 @@
             },
             {
               "include": "#strings"
+            },
+            {
+              "include": "#port_declarations"
             },
             {
               "include": "#instantiation_patterns"

--- a/syntaxes/verilogams.tmLanguage.json
+++ b/syntaxes/verilogams.tmLanguage.json
@@ -91,7 +91,7 @@
           "include": "#keywords"
         },
         {
-          "begin": "^\\s*([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
+          "begin": "^\\s*(?!\\b(?:always|and|assign|output|input|inout|wire|reg|integer|time|real|realtime|parameter|localparam|signed|unsigned|module)\\b)([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.tag.module.reference.verilogams"


### PR DESCRIPTION
## Summary

Fix #30 by preventing ANSI-style port declarations from being tokenized as module instantiations. The Verilog grammar's parameterless instantiation rule matched two identifiers at end-of-line, causing a final port declaration such as `input i_RESET` to receive module-instantiation scopes.

This adds an explicit Verilog port declaration rule before instantiation matching and tightens reserved-word guards with word boundaries so valid module names like `input_filter` remain supported. The Verilog-AMS grammar receives the same word-boundary guard for its similar broad parameterless instantiation rule.

## Validation

- Parsed `syntaxes/verilog.tmLanguage.json` and `syntaxes/verilogams.tmLanguage.json` as JSON
- Ran targeted grammar-regex checks for `input i_RESET`, `my_module u0 (`, and `input_filter u0 (`
- Ran `npm run lint`
- Ran `npm run compile`