### PR TITLE
Fix false begin/end bracket matching for identifiers

### DIFF
--- a/language_examples/systemverilog/bracket_matching_identifiers.sv
+++ b/language_examples/systemverilog/bracket_matching_identifiers.sv
@@ -1,0 +1,17 @@
+module t;
+  typedef enum logic [1:0] {
+    INIT,
+    END,
+    BEGIN
+  } fsm_t;
+
+  fsm_t fsm;
+
+  initial begin
+    case (fsm)
+      INIT:  begin end
+      END:   begin end
+      BEGIN: begin end
+    endcase
+  end
+endmodule

--- a/package.json
+++ b/package.json
@@ -161,17 +161,53 @@
       {
         "language": "verilog",
         "scopeName": "source.verilog",
-        "path": "./syntaxes/verilog.tmLanguage.json"
+        "path": "./syntaxes/verilog.tmLanguage.json",
+        "balancedBracketScopes": [
+          "*"
+        ],
+        "unbalancedBracketScopes": [
+          "variable.other.identifier.verilog",
+          "variable.other.constant.verilog",
+          "entity.name.type.module.verilog",
+          "entity.name.tag.module.reference.verilog",
+          "entity.name.tag.module.identifier.verilog"
+        ]
       },
       {
         "language": "verilogams",
         "scopeName": "source.verilogams",
-        "path": "./syntaxes/verilogams.tmLanguage.json"
+        "path": "./syntaxes/verilogams.tmLanguage.json",
+        "balancedBracketScopes": [
+          "*"
+        ],
+        "unbalancedBracketScopes": [
+          "variable.other.constant.verilogams",
+          "entity.name.type.module.verilogams",
+          "entity.name.tag.module.reference.verilogams",
+          "entity.name.tag.module.identifier.verilogams"
+        ]
       },
       {
         "language": "systemverilog",
         "scopeName": "source.systemverilog",
-        "path": "./syntaxes/systemverilog.tmLanguage.json"
+        "path": "./syntaxes/systemverilog.tmLanguage.json",
+        "balancedBracketScopes": [
+          "*"
+        ],
+        "unbalancedBracketScopes": [
+          "variable.other.identifier.systemverilog",
+          "variable.other.constant.preprocessor.systemverilog",
+          "entity.name.section.systemverilog",
+          "entity.name.type.module.systemverilog",
+          "entity.name.type.class.systemverilog",
+          "entity.name.function.systemverilog",
+          "entity.name.goto-label.php",
+          "storage.type.user-defined.systemverilog",
+          "storage.type.userdefined.systemverilog",
+          "support.type.scope.systemverilog",
+          "support.function.port.systemverilog",
+          "variable.other.module.systemverilog"
+        ]
       },
       {
         "language": "vhdl",


### PR DESCRIPTION
## Summary
- Add balanced/unbalanced bracket scope metadata for Verilog, SystemVerilog, and Verilog-AMS grammars.
- Exclude identifier-like TextMate scopes from bracket matching so uppercase names such as `END` and `BEGIN` are not counted as `begin`/`end` keywords.
- Add a SystemVerilog language example covering enum values and case labels named `END` and `BEGIN`.

## Why
VS Code treats language-configuration bracket pairs case-insensitively. Because this extension contributes `begin`/`end` as bracket pairs, identifier-like tokens named `END` or `BEGIN` could incorrectly participate in bracket matching.

Fixes #157.

## Validation
- `npm install`
- `npm run compile`

Manual Extension Development Host validation is still required for cursor/highlight behavior.