### PR TITLE
Highlight inactive Verilog preprocessor regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Install it from [VS Code Marketplace](https://marketplace.visualstudio.com/items
   - Synopsys Design Constraints
   - Verilog Filelists (dot-F files)
   - Tcl
+- Inactive Verilog/SystemVerilog preprocessor region highlighting
 - VCD waveform viewer integration:
   - [fliplot](https://github.com/raczben/fliplot) (build-in)
   - [Vaporview](https://marketplace.visualstudio.com/items?itemName=lramseyer.vaporview) (when that extension is installed)
@@ -81,6 +82,22 @@ Install it from [VS Code Marketplace](https://marketplace.visualstudio.com/items
 - On Windows, Vivado `xvlog` can be discovered when it is provided as `xvlog.bat` or `xvlog.cmd` on `PATH` or under `verilog.linting.path`.
 - Set `verilog.linting.linter` to `none` to disable automatic linting without warnings.
 - While using `` `include`` directives, the path to the files should be relative to the workspace directory, unless`runAtFileLocation` is enabled (not supported by all linters)
+
+### Inactive Preprocessor Regions
+
+Inactive Verilog/SystemVerilog preprocessor branches controlled by `` `ifdef``, `` `ifndef``, `` `elsif``, `` `else``, and `` `endif`` are highlighted in the editor. The lightweight scanner uses macros defined in the current document plus any workspace-wide macros configured in `verilog.preprocessor.defines`.
+
+```json
+{
+    "verilog.preprocessor.defines": ["SIMULATION", "USE_VENDOR_IP"],
+    "verilog.preprocessor.inactiveCode.enabled": true,
+    "verilog.preprocessor.inactiveCode.opacity": 0.45,
+    "verilog.preprocessor.inactiveCode.foregroundColor": "",
+    "verilog.preprocessor.inactiveCode.backgroundColor": "rgba(255, 0, 0, 0.12)"
+}
+```
+
+Leave `foregroundColor` or `backgroundColor` empty to use the theme/default styling. This feature does not resolve `` `include`` files, filelists, or simulator arguments such as `+define+FOO` and `-D FOO`.
 
 ### Ctags Integration
 

--- a/language_examples/systemverilog/inactive_preprocessor_regions.sv
+++ b/language_examples/systemverilog/inactive_preprocessor_regions.sv
@@ -1,0 +1,23 @@
+module inactive_preprocessor_regions;
+  logic [7:0] data;
+
+`define ENABLE_FAST_PATH
+
+`ifdef ENABLE_FAST_PATH
+  assign data = 8'hf0;
+`else
+  assign data = 8'h0f;
+`endif
+
+`ifndef ENABLE_DEBUG_OUTPUT
+  localparam bit DebugOutput = 1'b0;
+`elsif ENABLE_VERBOSE_DEBUG
+  localparam bit DebugOutput = 1'b1;
+`else
+  localparam bit DebugOutput = 1'b0;
+`endif
+
+  initial begin
+    $display("data=%h debug=%0d", data, DebugOutput);
+  end
+endmodule

--- a/package.json
+++ b/package.json
@@ -703,6 +703,46 @@
             "markdownDescription": "Maximum number of signals Vaporview should load initially."
           }
         }
+      },
+      {
+        "title": "Verilog: Preprocessor",
+        "properties": {
+          "verilog.preprocessor.defines": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "Macro names to treat as predefined for Verilog/SystemVerilog preprocessor inactive-code highlighting."
+          },
+          "verilog.preprocessor.inactiveCode.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable decorations for inactive Verilog/SystemVerilog preprocessor regions."
+          },
+          "verilog.preprocessor.inactiveCode.opacity": {
+            "scope": "window",
+            "type": "number",
+            "default": 0.45,
+            "minimum": 0,
+            "maximum": 1,
+            "markdownDescription": "Opacity for inactive Verilog/SystemVerilog preprocessor region decorations."
+          },
+          "verilog.preprocessor.inactiveCode.foregroundColor": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Optional CSS color for inactive Verilog/SystemVerilog preprocessor region foreground text. Leave empty to use the theme default."
+          },
+          "verilog.preprocessor.inactiveCode.backgroundColor": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Optional CSS color for inactive Verilog/SystemVerilog preprocessor region backgrounds, for example `rgba(255, 0, 0, 0.12)`. Leave empty to use no custom background."
+          }
+        }
       }
     ],
     "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { bootstrapLogging, disposeLogging, getExtensionLogger } from './logging'
 import { FliplotPanel } from './fliplot/FliplotPanel';
 import { FliplotCustomEditor } from './fliplot/FliplotCustomEditor';
 import { openWaveform } from './waveform/OpenWaveform';
+import { InactivePreprocessorDecorationProvider } from './providers/InactivePreprocessorDecorationProvider';
 
 let ctagsManager: CtagsManager | undefined;
 const extensionID: string = 'mshr-h.veriloghdl';
@@ -127,6 +128,8 @@ export async function activate(context: vscode.ExtensionContext) {
       systemVerilogFormatProvider
     )
   );
+
+  context.subscriptions.push(new InactivePreprocessorDecorationProvider());
 
   // Configure command to instantiate a module
   context.subscriptions.push(

--- a/src/providers/InactivePreprocessorDecorationProvider.ts
+++ b/src/providers/InactivePreprocessorDecorationProvider.ts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+
+interface InactivePreprocessorRange {
+  startLine: number;
+  endLine: number;
+}
+
+interface ConditionalFrame {
+  parentActive: boolean;
+  branchActive: boolean;
+  branchSelected: boolean;
+}
+
+interface Directive {
+  keyword: 'define' | 'undef' | 'ifdef' | 'ifndef' | 'elsif' | 'else' | 'endif';
+  macro?: string;
+}
+
+const VERILOG_LANGUAGE_IDS = new Set(['verilog', 'systemverilog']);
+const MACRO_PATTERN = '[A-Za-z_][A-Za-z0-9_$]*';
+const DIRECTIVE_PATTERN = new RegExp(
+  `^\\s*\`(define|undef|ifdef|ifndef|elsif|else|endif)(?:\\s+(${MACRO_PATTERN}))?\\b`
+);
+
+function getEffectiveActive(stack: readonly ConditionalFrame[]): boolean {
+  const top = stack.at(-1);
+  return top === undefined || (top.parentActive && top.branchActive);
+}
+
+function getDirectiveLineActive(
+  directive: Directive | undefined,
+  stack: readonly ConditionalFrame[]
+): boolean {
+  if (directive === undefined) {
+    return getEffectiveActive(stack);
+  }
+
+  if (
+    directive.keyword === 'elsif' ||
+    directive.keyword === 'else' ||
+    directive.keyword === 'endif'
+  ) {
+    const top = stack.at(-1);
+    return top === undefined || top.parentActive;
+  }
+
+  return getEffectiveActive(stack);
+}
+
+function mergeInactiveLine(
+  ranges: InactivePreprocessorRange[],
+  line: number
+): void {
+  const previous = ranges.at(-1);
+  if (previous !== undefined && previous.endLine + 1 === line) {
+    previous.endLine = line;
+    return;
+  }
+  ranges.push({ startLine: line, endLine: line });
+}
+
+function removeComments(line: string, inBlockComment: boolean): [string, boolean] {
+  let result = '';
+  let index = 0;
+  let blockComment = inBlockComment;
+
+  while (index < line.length) {
+    if (blockComment) {
+      const endIndex = line.indexOf('*/', index);
+      if (endIndex === -1) {
+        return [result, true];
+      }
+      index = endIndex + 2;
+      blockComment = false;
+      continue;
+    }
+
+    const lineCommentIndex = line.indexOf('//', index);
+    const blockCommentIndex = line.indexOf('/*', index);
+
+    if (lineCommentIndex === -1 && blockCommentIndex === -1) {
+      result += line.slice(index);
+      break;
+    }
+
+    if (
+      lineCommentIndex !== -1 &&
+      (blockCommentIndex === -1 || lineCommentIndex < blockCommentIndex)
+    ) {
+      result += line.slice(index, lineCommentIndex);
+      break;
+    }
+
+    result += line.slice(index, blockCommentIndex);
+    index = blockCommentIndex + 2;
+    blockComment = true;
+  }
+
+  return [result, blockComment];
+}
+
+function parseDirective(line: string): Directive | undefined {
+  const match = DIRECTIVE_PATTERN.exec(line);
+  if (match === null) {
+    return undefined;
+  }
+
+  return {
+    keyword: match[1] as Directive['keyword'],
+    macro: match[2],
+  };
+}
+
+export function computeInactivePreprocessorRanges(
+  text: string,
+  initialDefines: readonly string[]
+): InactivePreprocessorRange[] {
+  const defines = new Set(initialDefines);
+  const stack: ConditionalFrame[] = [];
+  const ranges: InactivePreprocessorRange[] = [];
+  const lines = text.split(/\r\n|\r|\n/);
+  let inBlockComment = false;
+
+  for (const [lineNumber, line] of lines.entries()) {
+    const [code, nextInBlockComment] = removeComments(line, inBlockComment);
+    const directive = parseDirective(code);
+
+    if (!getDirectiveLineActive(directive, stack)) {
+      mergeInactiveLine(ranges, lineNumber);
+    }
+
+    switch (directive?.keyword) {
+      case 'define':
+        if (directive.macro !== undefined && getEffectiveActive(stack)) {
+          defines.add(directive.macro);
+        }
+        break;
+
+      case 'undef':
+        if (directive.macro !== undefined && getEffectiveActive(stack)) {
+          defines.delete(directive.macro);
+        }
+        break;
+
+      case 'ifdef': {
+        const parentActive = getEffectiveActive(stack);
+        const condition = directive.macro !== undefined && defines.has(directive.macro);
+        stack.push({
+          parentActive,
+          branchActive: condition,
+          branchSelected: parentActive && condition,
+        });
+        break;
+      }
+
+      case 'ifndef': {
+        const parentActive = getEffectiveActive(stack);
+        const condition = directive.macro === undefined || !defines.has(directive.macro);
+        stack.push({
+          parentActive,
+          branchActive: condition,
+          branchSelected: parentActive && condition,
+        });
+        break;
+      }
+
+      case 'elsif': {
+        const top = stack.at(-1);
+        if (top !== undefined) {
+          const condition = directive.macro !== undefined && defines.has(directive.macro);
+          top.branchActive = !top.branchSelected && condition;
+          top.branchSelected = top.branchSelected || (top.parentActive && condition);
+        }
+        break;
+      }
+
+      case 'else': {
+        const top = stack.at(-1);
+        if (top !== undefined) {
+          top.branchActive = !top.branchSelected;
+          top.branchSelected = true;
+        }
+        break;
+      }
+
+      case 'endif':
+        stack.pop();
+        break;
+    }
+
+    inBlockComment = nextInBlockComment;
+  }
+
+  return ranges;
+}
+
+export class InactivePreprocessorDecorationProvider implements vscode.Disposable {
+  private readonly subscriptions: vscode.Disposable[] = [];
+  private decorationType: vscode.TextEditorDecorationType | undefined;
+
+  constructor() {
+    this.recreateDecorationType();
+    this.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor(() => {
+        this.updateVisibleEditors();
+      }),
+      vscode.workspace.onDidChangeTextDocument((event) => {
+        for (const editor of vscode.window.visibleTextEditors) {
+          if (editor.document === event.document) {
+            this.updateEditor(editor);
+          }
+        }
+      }),
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (!event.affectsConfiguration('verilog.preprocessor')) {
+          return;
+        }
+        this.recreateDecorationType();
+        this.updateVisibleEditors();
+      })
+    );
+    this.updateVisibleEditors();
+  }
+
+  dispose(): void {
+    for (const subscription of this.subscriptions) {
+      subscription.dispose();
+    }
+    this.decorationType?.dispose();
+  }
+
+  private recreateDecorationType(): void {
+    this.decorationType?.dispose();
+
+    const inactiveCodeConfig = vscode.workspace.getConfiguration(
+      'verilog.preprocessor.inactiveCode'
+    );
+    const foregroundColor = inactiveCodeConfig.get('foregroundColor', '');
+    const backgroundColor = inactiveCodeConfig.get('backgroundColor', '');
+    const opacity = inactiveCodeConfig.get('opacity', 0.45);
+    const options: vscode.DecorationRenderOptions = {
+      opacity: String(opacity),
+    };
+
+    if (foregroundColor !== '') {
+      options.color = foregroundColor;
+    }
+    if (backgroundColor !== '') {
+      options.backgroundColor = backgroundColor;
+    }
+
+    this.decorationType = vscode.window.createTextEditorDecorationType(options);
+  }
+
+  private updateEditor(editor: vscode.TextEditor | undefined): void {
+    if (editor === undefined || this.decorationType === undefined) {
+      return;
+    }
+
+    if (!VERILOG_LANGUAGE_IDS.has(editor.document.languageId) || !this.isEnabled()) {
+      editor.setDecorations(this.decorationType, []);
+      return;
+    }
+
+    const ranges = computeInactivePreprocessorRanges(
+      editor.document.getText(),
+      vscode.workspace.getConfiguration('verilog.preprocessor').get('defines', [])
+    ).map((range) => this.toVscodeRange(editor.document, range));
+    editor.setDecorations(this.decorationType, ranges);
+  }
+
+  private updateVisibleEditors(): void {
+    for (const editor of vscode.window.visibleTextEditors) {
+      this.updateEditor(editor);
+    }
+  }
+
+  private isEnabled(): boolean {
+    return vscode.workspace
+      .getConfiguration('verilog.preprocessor.inactiveCode')
+      .get('enabled', true);
+  }
+
+  private toVscodeRange(
+    document: vscode.TextDocument,
+    range: InactivePreprocessorRange
+  ): vscode.Range {
+    const start = new vscode.Position(range.startLine, 0);
+    const endLine = document.lineAt(range.endLine);
+    const end = new vscode.Position(range.endLine, endLine.text.length);
+    return new vscode.Range(start, end);
+  }
+}

--- a/src/test/inactivePreprocessor.test.ts
+++ b/src/test/inactivePreprocessor.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import {
+  computeInactivePreprocessorRanges,
+} from '../providers/InactivePreprocessorDecorationProvider';
+
+suite('Inactive Preprocessor Ranges', () => {
+  test('undefined macro makes ifdef body inactive', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      ['`ifdef FOO', 'assign a = 1;', '`endif'].join('\n'),
+      []
+    );
+
+    assert.deepStrictEqual(ranges, [{ startLine: 1, endLine: 1 }]);
+  });
+
+  test('defined macro keeps ifdef body active and else body inactive', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      ['`ifdef FOO', 'assign a = 1;', '`else', 'assign a = 0;', '`endif'].join('\n'),
+      ['FOO']
+    );
+
+    assert.deepStrictEqual(ranges, [{ startLine: 3, endLine: 3 }]);
+  });
+
+  test('ifndef treats a defined macro as inactive', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      ['`ifndef FOO', 'assign a = 0;', '`else', 'assign a = 1;', '`endif'].join('\n'),
+      ['FOO']
+    );
+
+    assert.deepStrictEqual(ranges, [{ startLine: 1, endLine: 1 }]);
+  });
+
+  test('elsif chain selects only the first true branch', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '`ifdef FIRST',
+        'assign selected = 0;',
+        '`elsif SECOND',
+        'assign selected = 1;',
+        '`elsif THIRD',
+        'assign selected = 2;',
+        '`else',
+        'assign selected = 3;',
+        '`endif',
+      ].join('\n'),
+      ['SECOND', 'THIRD']
+    );
+
+    assert.deepStrictEqual(ranges, [
+      { startLine: 1, endLine: 1 },
+      { startLine: 5, endLine: 5 },
+      { startLine: 7, endLine: 7 },
+    ]);
+  });
+
+  test('define inside inactive branch does not affect later conditionals', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '`ifdef OUTER',
+        '`define INNER',
+        '`endif',
+        '`ifdef INNER',
+        'assign a = 1;',
+        '`else',
+        'assign a = 0;',
+        '`endif',
+      ].join('\n'),
+      []
+    );
+
+    assert.deepStrictEqual(ranges, [
+      { startLine: 1, endLine: 1 },
+      { startLine: 4, endLine: 4 },
+    ]);
+  });
+
+  test('undef inside inactive branch does not affect later conditionals', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '`ifdef OUTER',
+        '`undef INNER',
+        '`endif',
+        '`ifdef INNER',
+        'assign a = 1;',
+        '`else',
+        'assign a = 0;',
+        '`endif',
+      ].join('\n'),
+      ['INNER']
+    );
+
+    assert.deepStrictEqual(ranges, [
+      { startLine: 1, endLine: 1 },
+      { startLine: 6, endLine: 6 },
+    ]);
+  });
+
+  test('directives inside comments are ignored', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '// `define FOO',
+        '/* `define BAR */',
+        '`ifdef FOO',
+        'assign a = 1;',
+        '`endif',
+        '`ifdef BAR',
+        'assign b = 1;',
+        '`endif',
+      ].join('\n'),
+      []
+    );
+
+    assert.deepStrictEqual(ranges, [
+      { startLine: 3, endLine: 3 },
+      { startLine: 6, endLine: 6 },
+    ]);
+  });
+
+  test('nested conditionals honor inactive parents', () => {
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '`ifdef OUTER',
+        'assign a = 1;',
+        '`ifdef INNER',
+        'assign b = 1;',
+        '`else',
+        'assign b = 0;',
+        '`endif',
+        '`else',
+        'assign a = 0;',
+        '`endif',
+      ].join('\n'),
+      ['INNER']
+    );
+
+    assert.deepStrictEqual(ranges, [
+      { startLine: 1, endLine: 6 },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #430.
Related to #170.

This adds a lightweight decoration provider for inactive Verilog/SystemVerilog preprocessor regions controlled by `ifdef, `ifndef, `elsif, `else, and `endif.

The provider scans macros defined in the current document and optional `verilog.preprocessor.defines` settings, then applies editor decorations to inactive ranges. Users can customize opacity, foreground color, and background color, or disable the feature entirely.

Also included:
- Unit tests for inactive range computation, nested conditionals, comments, and branch selection.
- A generic SystemVerilog language example for inactive preprocessor regions.
- README documentation for the new settings.

Validation:
- `npm run check-types`
- `npm run lint`
- `npm test` (`174 passing`, `3 pending`)