### PR TITLE
Integrate project index into HDL features

### DIFF
--- a/package.json
+++ b/package.json
@@ -760,6 +760,17 @@
         }
       },
       {
+        "title": "Verilog: Module Instantiation",
+        "properties": {
+          "verilog.instantiate.useProjectIndex": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Use the project index for module instantiation when project modules are available. Falls back to the ctags file picker when disabled or when the project index has no modules."
+          }
+        }
+      },
+      {
         "title": "Verilog: Preprocessor",
         "properties": {
           "verilog.preprocessor.defines": {

--- a/src/commands/ModuleInstantiation.ts
+++ b/src/commands/ModuleInstantiation.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Ctags, Symbol } from '../ctags';
+import type { InstantiationService } from '../hdl/InstantiationService';
 import { getExtensionLogger } from '../logging';
 import { getWorkspaceRootForDocument } from '../utils/workspace';
 
@@ -32,6 +33,12 @@ export function instantiateModuleInteract() {
       }
     });
   });
+}
+
+export function instantiateModuleInteractWithProjectIndex(
+  instantiationService: InstantiationService
+) {
+  void instantiationService.instantiateModuleInteract(instantiateModuleInteract);
 }
 
 export async function instantiateModule(srcpath: string): Promise<vscode.SnippetString | undefined> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,10 +17,13 @@ import { FliplotPanel } from './fliplot/FliplotPanel';
 import { FliplotCustomEditor } from './fliplot/FliplotCustomEditor';
 import { openWaveform } from './waveform/OpenWaveform';
 import { InactivePreprocessorDecorationProvider } from './providers/InactivePreprocessorDecorationProvider';
+import { DefinitionService } from './hdl/DefinitionService';
+import { InstantiationService } from './hdl/InstantiationService';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
 import { IndexService } from './semantic/IndexService';
+import { VerilogWorkspaceSymbolProvider } from './providers/WorkspaceSymbolProvider';
 
 let ctagsManager: CtagsManager | undefined;
 const extensionID: string = 'mshr-h.veriloghdl';
@@ -44,6 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const projectService = new ProjectService();
   const indexService = new IndexService(projectService);
+  const definitionService = new DefinitionService(projectService, indexService, ctagsManager);
+  const instantiationService = new InstantiationService(indexService);
   context.subscriptions.push(projectService, indexService, new ProjectWatcher(projectService));
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
   void projectService.reload('activation');
@@ -108,7 +113,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Configure Definition Providers
   const verilogDefinitionProvider = new DefinitionProvider.VerilogDefinitionProvider(
-    ctagsManager
+    definitionService
   );
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(
@@ -120,6 +125,11 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerDefinitionProvider(
       { scheme: 'file', language: 'systemverilog' },
       verilogDefinitionProvider
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerWorkspaceSymbolProvider(
+      new VerilogWorkspaceSymbolProvider(indexService)
     )
   );
 
@@ -145,7 +155,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'verilog.instantiateModule',
-      ModuleInstantiation.instantiateModuleInteract
+      () => ModuleInstantiation.instantiateModuleInteractWithProjectIndex(instantiationService)
     )
   );
 

--- a/src/hdl/DefinitionService.ts
+++ b/src/hdl/DefinitionService.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import { CtagsManager } from '../ctags';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+
+const HDL_LANGUAGES = new Set(['verilog', 'systemverilog']);
+const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/;
+const MODULE_CONTEXT_KEYWORDS = new Set([
+  'assign',
+  'begin',
+  'end',
+  'endmodule',
+  'function',
+  'if',
+  'import',
+  'localparam',
+  'logic',
+  'parameter',
+  'reg',
+  'return',
+  'wire',
+]);
+
+export class DefinitionService {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly ctagsManager: CtagsManager
+  ) {}
+
+  async provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.DefinitionLink[]> {
+    if (!HDL_LANGUAGES.has(document.languageId)) {
+      return this.ctagsManager.findSymbol(document, position);
+    }
+
+    const includeLink = this.findIncludeDefinition(document, position);
+    if (includeLink) {
+      return [includeLink];
+    }
+
+    const wordRange = document.getWordRangeAtPosition(position, WORD_PATTERN);
+    if (!wordRange || wordRange.isEmpty) {
+      return this.ctagsManager.findSymbol(document, position);
+    }
+
+    const word = document.getText(wordRange);
+    if (isModuleContext(document, wordRange, word)) {
+      const moduleLinks = this.indexService
+        .getIndex()
+        .findModules(word)
+        .map(moduleRecordToDefinitionLink);
+      if (moduleLinks.length > 0) {
+        return moduleLinks;
+      }
+    }
+
+    return this.ctagsManager.findSymbol(document, position);
+  }
+
+  private findIncludeDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.DefinitionLink | undefined {
+    const include = getIncludeAtPosition(document.lineAt(position.line).text, position.character);
+    if (!include) {
+      return undefined;
+    }
+
+    const context = this.projectService.getPreferredFileContext(document.uri) ?? createLocalFileContext(document.uri);
+    const uri = this.indexService.getIndex().resolveInclude(include.includeText, context);
+    if (!uri) {
+      return undefined;
+    }
+
+    const targetRange = new vscode.Range(0, 0, 0, 0);
+    return {
+      originSelectionRange: new vscode.Range(
+        position.line,
+        include.pathStart,
+        position.line,
+        include.pathEnd
+      ),
+      targetUri: uri,
+      targetRange,
+      targetSelectionRange: targetRange,
+    };
+  }
+}
+
+export function moduleRecordToDefinitionLink(moduleRecord: ModuleRecord): vscode.DefinitionLink {
+  return {
+    targetUri: moduleRecord.uri,
+    targetRange: moduleRecord.range,
+    targetSelectionRange: moduleRecord.selectionRange,
+  };
+}
+
+export function isModuleContext(
+  document: vscode.TextDocument,
+  wordRange: vscode.Range,
+  word: string
+): boolean {
+  if (MODULE_CONTEXT_KEYWORDS.has(word)) {
+    return false;
+  }
+
+  const line = stripLineComment(document.lineAt(wordRange.start.line).text);
+  const beforeWord = line.slice(0, wordRange.start.character);
+  const afterWord = line.slice(wordRange.end.character);
+  const previousChar = beforeWord.at(-1);
+  if (previousChar === '.' || previousChar === ':') {
+    return false;
+  }
+  if (isInsideLineString(line, wordRange.start.character)) {
+    return false;
+  }
+  if (/\bmodule\s+$/.test(beforeWord)) {
+    return true;
+  }
+  if (beforeWord.trim().length > 0) {
+    return false;
+  }
+  return /^\s*(?:#\s*\(|[A-Za-z_][A-Za-z0-9_$]*\s*(?:#\s*)?[;(])/.test(afterWord);
+}
+
+interface IncludeAtPosition {
+  includeText: string;
+  pathStart: number;
+  pathEnd: number;
+}
+
+function getIncludeAtPosition(line: string, character: number): IncludeAtPosition | undefined {
+  const includePattern = /`include\s*(["<])([^">]+)[">]/g;
+  for (const match of line.matchAll(includePattern)) {
+    const fullMatch = match[0];
+    const quote = match[1] ?? '"';
+    const pathText = match[2] ?? '';
+    const start = match.index ?? 0;
+    const pathStart = start + fullMatch.indexOf(quote) + 1;
+    const pathEnd = pathStart + pathText.length;
+    if (character >= pathStart && character <= pathEnd) {
+      return {
+        includeText: `${quote}${pathText}${quote === '<' ? '>' : quote}`,
+        pathStart,
+        pathEnd,
+      };
+    }
+  }
+  return undefined;
+}
+
+function createLocalFileContext(uri: vscode.Uri): FileContext {
+  return {
+    file: uri,
+    compileUnitId: '',
+    includeDirs: [],
+    defines: {},
+  };
+}
+
+function stripLineComment(line: string): string {
+  const commentIndex = line.indexOf('//');
+  return commentIndex < 0 ? line : line.slice(0, commentIndex);
+}
+
+function isInsideLineString(line: string, character: number): boolean {
+  let inString = false;
+  for (let i = 0; i < character; i += 1) {
+    const current = line[i];
+    if (current === '\\') {
+      i += 1;
+      continue;
+    }
+    if (current === '"') {
+      inString = !inString;
+    }
+  }
+  return inString;
+}

--- a/src/hdl/InstantiationService.ts
+++ b/src/hdl/InstantiationService.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { IndexService } from '../semantic/IndexService';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+
+export type InstantiationFallback = () => void | Promise<void>;
+
+interface ModuleQuickPickItem extends vscode.QuickPickItem {
+  module: ModuleRecord;
+}
+
+export class InstantiationService {
+  constructor(private readonly indexService: IndexService) {}
+
+  async instantiateModuleInteract(fallback: InstantiationFallback): Promise<void> {
+    if (!useProjectIndex()) {
+      await fallback();
+      return;
+    }
+
+    const modules = this.indexService.getIndex().getAllModules();
+    if (modules.length === 0) {
+      await fallback();
+      return;
+    }
+
+    const selected = await vscode.window.showQuickPick(
+      modules.map((moduleRecord): ModuleQuickPickItem => ({
+        label: moduleRecord.name,
+        description: moduleRecord.compileUnitId,
+        detail: moduleRecord.uri.fsPath,
+        module: moduleRecord,
+      })),
+      { placeHolder: 'Choose a module to instantiate' }
+    );
+    if (!selected) {
+      await fallback();
+      return;
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('No active text editor found');
+      return;
+    }
+    await editor.insertSnippet(buildModuleInstantiationSnippet(selected.module));
+  }
+}
+
+export function buildModuleInstantiationSnippet(moduleRecord: ModuleRecord): vscode.SnippetString {
+  const parameterNames = moduleRecord.parameters.map((parameter) => parameter.name);
+  const portNames = moduleRecord.ports.map((port) => port.name);
+  let paramString = '';
+  if (parameterNames.length > 0) {
+    paramString = `\n#(\n${instantiatePortNames(parameterNames)})\n`;
+  }
+  return new vscode.SnippetString()
+    .appendText(`${moduleRecord.name} `)
+    .appendText(paramString)
+    .appendPlaceholder('u_')
+    .appendPlaceholder(`${moduleRecord.name}(\n`)
+    .appendText(instantiatePortNames(portNames))
+    .appendText(');\n');
+}
+
+export function instantiatePortNames(names: string[]): string {
+  let port = '';
+  let maxLen = 0;
+  const indent = getIndentationString();
+
+  for (const name of names) {
+    if (name.length > maxLen) {
+      maxLen = name.length;
+    }
+  }
+
+  for (let i = 0; i < names.length; i += 1) {
+    const name = names[i] ?? '';
+    const element = `${name}${' '.repeat(maxLen - name.length + 1)}`;
+    port += indent;
+    port += `.${element}(${element})`;
+    if (i !== names.length - 1) {
+      port += ',';
+    }
+    port += '\n';
+  }
+  return port;
+}
+
+function useProjectIndex(): boolean {
+  return vscode.workspace
+    .getConfiguration('verilog.instantiate')
+    .get<boolean>('useProjectIndex', true);
+}
+
+function getIndentationString(): string {
+  const editorConfig = vscode.workspace.getConfiguration('editor');
+  const useSpaces = editorConfig.get<boolean>('insertSpaces', true);
+  const tabSize = editorConfig.get<number>('tabSize', 4);
+  return useSpaces ? ' '.repeat(tabSize) : '\t';
+}

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { CtagsManager } from '../ctags';
+import type { DefinitionService } from '../hdl/DefinitionService';
 import { getExtensionLogger } from '../logging';
 
 
 
 export class VerilogDefinitionProvider implements vscode.DefinitionProvider {
   private readonly logger = getExtensionLogger('Provider', 'Definition');
-  private ctagsManager: CtagsManager;
-  constructor(ctagsManager: CtagsManager) {
-    this.ctagsManager = ctagsManager;
+  constructor(private readonly definitionService: DefinitionService) {
   }
 
   async provideDefinition(
@@ -18,8 +16,7 @@ export class VerilogDefinitionProvider implements vscode.DefinitionProvider {
     _token: vscode.CancellationToken
   ): Promise<vscode.DefinitionLink[] | undefined> {
     this.logger.info("Definitions requested", { uri: document.uri.toString() });
-    // find all matching symbols
-    const definitions: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, position);
+    const definitions: vscode.DefinitionLink[] = await this.definitionService.provideDefinition(document, position);
     this.logger.info("Definitions returned", { count: definitions.length });
     return definitions;
   }

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { IndexService } from '../semantic/IndexService';
+import type { SymbolRecord, SymbolRecordKind } from '../semantic/SymbolRecords';
+
+const WORKSPACE_SYMBOL_KINDS = new Set<SymbolRecordKind>([
+  'module',
+  'package',
+  'interface',
+  'class',
+  'typedef',
+  'macro',
+]);
+
+export class VerilogWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
+  constructor(private readonly indexService: IndexService) {}
+
+  provideWorkspaceSymbols(
+    query: string,
+    _token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.SymbolInformation[]> {
+    const normalizedQuery = query.toLowerCase();
+    return this.indexService
+      .getIndex()
+      .getAllSymbols()
+      .filter((symbol) => WORKSPACE_SYMBOL_KINDS.has(symbol.kind))
+      .filter((symbol) => normalizedQuery.length === 0 || symbol.name.toLowerCase().includes(normalizedQuery))
+      .map(symbolRecordToWorkspaceSymbol);
+  }
+}
+
+export function symbolRecordToWorkspaceSymbol(symbol: SymbolRecord): vscode.SymbolInformation {
+  return new vscode.SymbolInformation(
+    symbol.name,
+    toWorkspaceSymbolKind(symbol.kind),
+    symbol.containerName ?? symbol.compileUnitId,
+    new vscode.Location(symbol.uri, symbol.selectionRange)
+  );
+}
+
+function toWorkspaceSymbolKind(kind: SymbolRecordKind): vscode.SymbolKind {
+  switch (kind) {
+    case 'module':
+      return vscode.SymbolKind.Module;
+    case 'interface':
+      return vscode.SymbolKind.Interface;
+    case 'package':
+      return vscode.SymbolKind.Package;
+    case 'class':
+      return vscode.SymbolKind.Class;
+    case 'typedef':
+      return vscode.SymbolKind.TypeParameter;
+    case 'macro':
+      return vscode.SymbolKind.Constant;
+    default:
+      return vscode.SymbolKind.Variable;
+  }
+}

--- a/src/semantic/SemanticIndex.ts
+++ b/src/semantic/SemanticIndex.ts
@@ -31,6 +31,10 @@ export class SemanticIndex {
     return this.symbols.filter((symbol): symbol is ModuleRecord => symbol.kind === 'module');
   }
 
+  getAllSymbols(): SymbolRecord[] {
+    return this.symbols.slice();
+  }
+
   findModules(name: string): ModuleRecord[] {
     return (this.modulesByName.get(name) ?? []).slice();
   }

--- a/src/test/definitionProvider.test.ts
+++ b/src/test/definitionProvider.test.ts
@@ -2,8 +2,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { VerilogDefinitionProvider } from '../providers/DefinitionProvider';
-import { CtagsManager } from '../ctags';
 import { END_OF_LINE } from '../constants';
+import type { DefinitionService } from '../hdl/DefinitionService';
 
 suite('DefinitionProvider', () => {
   test('returns definition links for found symbol', async () => {
@@ -24,11 +24,11 @@ suite('DefinitionProvider', () => {
       },
     ];
 
-    const ctagsManager = {
-      findSymbol: async () => definitionLinks,
-    } as unknown as CtagsManager;
+    const definitionService = {
+      provideDefinition: async () => definitionLinks,
+    } as unknown as DefinitionService;
 
-    const provider = new VerilogDefinitionProvider(ctagsManager);
+    const provider = new VerilogDefinitionProvider(definitionService);
     const tokenSource = new vscode.CancellationTokenSource();
 
     // Position on 'sig' in the assign statement
@@ -49,11 +49,11 @@ suite('DefinitionProvider', () => {
       content: 'module top; endmodule',
     });
 
-    const ctagsManager = {
-      findSymbol: async () => [],
-    } as unknown as CtagsManager;
+    const definitionService = {
+      provideDefinition: async () => [],
+    } as unknown as DefinitionService;
 
-    const provider = new VerilogDefinitionProvider(ctagsManager);
+    const provider = new VerilogDefinitionProvider(definitionService);
     const tokenSource = new vscode.CancellationTokenSource();
 
     const result = await provider.provideDefinition(
@@ -88,11 +88,11 @@ suite('DefinitionProvider', () => {
       },
     ];
 
-    const ctagsManager = {
-      findSymbol: async () => definitionLinks,
-    } as unknown as CtagsManager;
+    const definitionService = {
+      provideDefinition: async () => definitionLinks,
+    } as unknown as DefinitionService;
 
-    const provider = new VerilogDefinitionProvider(ctagsManager);
+    const provider = new VerilogDefinitionProvider(definitionService);
     const tokenSource = new vscode.CancellationTokenSource();
 
     const result = await provider.provideDefinition(

--- a/src/test/definitionService.test.ts
+++ b/src/test/definitionService.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CtagsManager } from '../ctags';
+import { DefinitionService } from '../hdl/DefinitionService';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+
+suite('DefinitionService', () => {
+  test('resolves module definitions across workspace by module name', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'other_module u_other();',
+    });
+    const moduleUri = vscode.Uri.file('/workspace/rtl/not_the_module_name.sv');
+    const moduleRecord = createModuleRecord('other_module', moduleUri);
+    const service = createDefinitionService(new SemanticIndex(1, [moduleRecord]));
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 2));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, moduleUri.fsPath);
+    assert.strictEqual(result[0]?.targetSelectionRange?.start.character, 7);
+  });
+
+  test('resolves include definitions from current file directory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-def-'));
+    const topPath = path.join(root, 'top.sv');
+    const includePath = path.join(root, 'defs.svh');
+    fs.writeFileSync(topPath, '`include "defs.svh"\n');
+    fs.writeFileSync(includePath, '`define SIM\n');
+    const document = await vscode.workspace.openTextDocument(topPath);
+    const service = createDefinitionService(new SemanticIndex(1, []));
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 11));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, includePath);
+    assert.strictEqual(result[0]?.targetSelectionRange?.start.line, 0);
+  });
+
+  test('resolves include definitions from preferred file context include dirs', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-def-'));
+    const src = path.join(root, 'src');
+    const inc = path.join(root, 'inc');
+    fs.mkdirSync(src);
+    fs.mkdirSync(inc);
+    const topPath = path.join(src, 'top.sv');
+    const includePath = path.join(inc, 'defs.svh');
+    fs.writeFileSync(topPath, '`include "defs.svh"\n');
+    fs.writeFileSync(includePath, '`define SIM\n');
+    const document = await vscode.workspace.openTextDocument(topPath);
+    const context: FileContext = {
+      file: vscode.Uri.file(topPath),
+      compileUnitId: 'unit',
+      includeDirs: [vscode.Uri.file(inc)],
+      defines: {},
+    };
+    const service = createDefinitionService(new SemanticIndex(1, []), context);
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 11));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, includePath);
+  });
+
+  test('falls back to ctags when project index has no definition', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'assign sig = 1;',
+    });
+    const targetRange = new vscode.Range(0, 7, 0, 10);
+    const fallbackLinks: vscode.DefinitionLink[] = [
+      {
+        targetUri: document.uri,
+        targetRange,
+        targetSelectionRange: targetRange,
+      },
+    ];
+    let fallbackCalled = false;
+    const service = createDefinitionService(
+      new SemanticIndex(1, []),
+      undefined,
+      {
+        findSymbol: async () => {
+          fallbackCalled = true;
+          return fallbackLinks;
+        },
+      } as unknown as CtagsManager
+    );
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 8));
+
+    assert.strictEqual(fallbackCalled, true);
+    assert.deepStrictEqual(result, fallbackLinks);
+  });
+});
+
+function createDefinitionService(
+  index: SemanticIndex,
+  context?: FileContext,
+  ctagsManager: CtagsManager = { findSymbol: async () => [] } as unknown as CtagsManager
+): DefinitionService {
+  const projectService = {
+    getPreferredFileContext: () => context,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => index,
+  } as unknown as IndexService;
+  return new DefinitionService(projectService, indexService, ctagsManager);
+}
+
+function createModuleRecord(name: string, uri: vscode.Uri): ModuleRecord {
+  const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
+  return {
+    id: `unit:${name}`,
+    name,
+    kind: 'module',
+    uri,
+    range: new vscode.Range(0, 0, 1, 0),
+    selectionRange,
+    compileUnitId: 'unit',
+    ports: [],
+    parameters: [],
+  };
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -162,5 +162,6 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.project.includeDirs']);
     assert.ok(properties['verilog.project.defines']);
     assert.ok(properties['verilog.project.exclude']);
+    assert.ok(properties['verilog.instantiate.useProjectIndex']);
   });
 });

--- a/src/test/moduleInstantiation.test.ts
+++ b/src/test/moduleInstantiation.test.ts
@@ -7,8 +7,93 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import which from 'which';
 import { instantiateModule, shouldShowParentDirectory } from '../commands/ModuleInstantiation';
+import {
+  buildModuleInstantiationSnippet,
+  InstantiationService,
+} from '../hdl/InstantiationService';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, ParameterRecord, PortRecord } from '../semantic/SymbolRecords';
 
 suite('Module Instantiation', () => {
+  test('builds project-index snippet with parameters and ports', () => {
+    const snippet = buildModuleInstantiationSnippet(
+      createModuleRecord('my_mod', ['WIDTH'], ['clk', 'rst_n'])
+    );
+    const value = snippet.value;
+
+    assert.ok(value.includes('my_mod'));
+    assert.ok(value.includes('#('));
+    assert.ok(value.includes('.WIDTH'));
+    assert.ok(value.includes('.clk  '), 'Snippet should align shorter port names');
+    assert.ok(value.includes('.rst_n'));
+    assert.ok(value.includes(');'));
+  });
+
+  test('uses project index module selection when available', async function () {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: '',
+    });
+    const editor = await vscode.window.showTextDocument(document);
+    const moduleRecord = createModuleRecord('idx_mod', ['WIDTH'], ['clk']);
+    const service = new InstantiationService({
+      getIndex: () => new SemanticIndex(1, [moduleRecord]),
+    } as unknown as IndexService);
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    let fallbackCalled = false;
+
+    try {
+      (vscode.window as any).showQuickPick = async (items: unknown) => {
+        assert.ok(Array.isArray(items));
+        return (items as Array<{ module: ModuleRecord }>)[0];
+      };
+      await service.instantiateModuleInteract(() => {
+        fallbackCalled = true;
+      });
+
+      assert.strictEqual(fallbackCalled, false);
+      assert.ok(editor.document.getText().includes('idx_mod'));
+      assert.ok(editor.document.getText().includes('.WIDTH'));
+      assert.ok(editor.document.getText().includes('.clk'));
+    } finally {
+      (vscode.window as any).showQuickPick = originalShowQuickPick;
+    }
+  });
+
+  test('falls back when project index instantiation is disabled', async () => {
+    const config = vscode.workspace.getConfiguration('verilog.instantiate');
+    const previous = config.get('useProjectIndex');
+    const service = new InstantiationService({
+      getIndex: () => new SemanticIndex(1, [createModuleRecord('idx_mod', [], [])]),
+    } as unknown as IndexService);
+    let fallbackCalled = false;
+
+    try {
+      await config.update('useProjectIndex', false, vscode.ConfigurationTarget.Global);
+      await service.instantiateModuleInteract(() => {
+        fallbackCalled = true;
+      });
+
+      assert.strictEqual(fallbackCalled, true);
+    } finally {
+      await config.update('useProjectIndex', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test('falls back when project index has no modules', async () => {
+    const service = new InstantiationService({
+      getIndex: () => new SemanticIndex(1, []),
+    } as unknown as IndexService);
+    let fallbackCalled = false;
+
+    await service.instantiateModuleInteract(() => {
+      fallbackCalled = true;
+    });
+
+    assert.strictEqual(fallbackCalled, true);
+  });
+
   test('uses the supplied workspace root for parent navigation decisions', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ctags-inst-root-'));
     const firstRoot = path.join(tempRoot, 'first');
@@ -100,3 +185,35 @@ suite('Module Instantiation', () => {
     }
   });
 });
+
+function createModuleRecord(name: string, parameterNames: string[], portNames: string[]): ModuleRecord {
+  const uri = vscode.Uri.file(`/workspace/${name}.sv`);
+  const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
+  const base = {
+    id: `unit:${name}`,
+    name,
+    uri,
+    range: selectionRange,
+    selectionRange,
+    containerName: name,
+    compileUnitId: 'unit',
+  };
+  return {
+    ...base,
+    kind: 'module',
+    parameters: parameterNames.map((parameterName): ParameterRecord => ({
+      ...base,
+      id: `unit:${name}:parameter:${parameterName}`,
+      name: parameterName,
+      kind: 'parameter',
+      containerName: name,
+    })),
+    ports: portNames.map((portName): PortRecord => ({
+      ...base,
+      id: `unit:${name}:port:${portName}`,
+      name: portName,
+      kind: 'port',
+      containerName: name,
+    })),
+  };
+}

--- a/src/test/workspaceSymbolProvider.test.ts
+++ b/src/test/workspaceSymbolProvider.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { VerilogWorkspaceSymbolProvider } from '../providers/WorkspaceSymbolProvider';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { SymbolRecord, SymbolRecordKind } from '../semantic/SymbolRecords';
+
+suite('WorkspaceSymbolProvider', () => {
+  test('maps project index records to workspace symbols', async () => {
+    const provider = createProvider([
+      createSymbol('top', 'module'),
+      createSymbol('pkg', 'package'),
+      createSymbol('SIM', 'macro'),
+      createSymbol('ifc', 'interface'),
+      createSymbol('klass', 'class'),
+      createSymbol('word_t', 'typedef'),
+      createSymbol('clk', 'port'),
+    ]);
+
+    const result = await provider.provideWorkspaceSymbols('', new vscode.CancellationTokenSource().token);
+
+    assert.ok(result);
+    assert.deepStrictEqual(result.map((symbol) => symbol.name), [
+      'top',
+      'pkg',
+      'SIM',
+      'ifc',
+      'klass',
+      'word_t',
+    ]);
+    assert.strictEqual(result[0]?.kind, vscode.SymbolKind.Module);
+    assert.strictEqual(result[1]?.kind, vscode.SymbolKind.Package);
+    assert.strictEqual(result[2]?.kind, vscode.SymbolKind.Constant);
+  });
+
+  test('filters workspace symbols by query', async () => {
+    const provider = createProvider([
+      createSymbol('uart_rx', 'module'),
+      createSymbol('spi_rx', 'module'),
+      createSymbol('uart_pkg', 'package'),
+    ]);
+
+    const result = await provider.provideWorkspaceSymbols('uart', new vscode.CancellationTokenSource().token);
+
+    assert.ok(result);
+    assert.deepStrictEqual(result.map((symbol) => symbol.name), ['uart_rx', 'uart_pkg']);
+  });
+
+  test('returns empty results for empty index', async () => {
+    const provider = createProvider([]);
+
+    const result = await provider.provideWorkspaceSymbols('', new vscode.CancellationTokenSource().token);
+
+    assert.deepStrictEqual(result, []);
+  });
+});
+
+function createProvider(symbols: SymbolRecord[]): VerilogWorkspaceSymbolProvider {
+  return new VerilogWorkspaceSymbolProvider({
+    getIndex: () => new SemanticIndex(1, symbols),
+  } as unknown as IndexService);
+}
+
+function createSymbol(name: string, kind: SymbolRecordKind): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 0, 0, name.length);
+  return {
+    id: `${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId: 'unit',
+  };
+}


### PR DESCRIPTION
## Summary
- Add DefinitionService to resolve project-index module definitions and include files before falling back to ctags.
- Add InstantiationService so module instantiation can use project-index modules while preserving the old ctags file-picker fallback.
- Add a lightweight workspace symbol provider for project-index modules, packages, interfaces, classes, typedefs, and macros.

## User impact
- Cross-workspace module definition lookup can work even when the file name differs from the module name.
- `include` paths can go to resolved include files using the active file context and include directories.
- Users can instantiate modules from the project index when available, controlled by `verilog.instantiate.useProjectIndex`.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` (`199 passing`, `3 pending`)