### PR TITLE
Use project context in HDL UX features

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,12 @@
             "default": "none",
             "markdownDescription": "Select the verilog linter."
           },
+          "verilog.linting.useProjectContext": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "When enabled, pass active project include directories and preprocessor defines to supported lint tools. Existing custom linter arguments are still appended after project context arguments."
+          },
           "verilog.linting.iverilog.arguments": {
             "scope": "window",
             "type": "string",
@@ -781,6 +787,12 @@
             },
             "default": [],
             "markdownDescription": "Macro names to treat as predefined for Verilog/SystemVerilog preprocessor inactive-code highlighting."
+          },
+          "verilog.preprocessor.useProjectDefines": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Use active project preprocessor defines when highlighting inactive Verilog/SystemVerilog preprocessor regions."
           },
           "verilog.preprocessor.inactiveCode.enabled": {
             "scope": "window",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { openWaveform } from './waveform/OpenWaveform';
 import { InactivePreprocessorDecorationProvider } from './providers/InactivePreprocessorDecorationProvider';
 import { DefinitionService } from './hdl/DefinitionService';
 import { InstantiationService } from './hdl/InstantiationService';
+import { CompletionService } from './hdl/CompletionService';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
@@ -49,6 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const indexService = new IndexService(projectService);
   const definitionService = new DefinitionService(projectService, indexService, ctagsManager);
   const instantiationService = new InstantiationService(indexService);
+  const completionService = new CompletionService(projectService, indexService, ctagsManager);
   context.subscriptions.push(projectService, indexService, new ProjectWatcher(projectService));
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
   void projectService.reload('activation');
@@ -73,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Configure Completion Item Provider
   // Trigger on ".", "(", "="
   const verilogCompletionItemProvider = new CompletionItemProvider.VerilogCompletionItemProvider(
-    ctagsManager,
+    completionService,
   );
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
@@ -81,7 +83,9 @@ export async function activate(context: vscode.ExtensionContext) {
       verilogCompletionItemProvider,
       '.',
       '(',
-      '='
+      '=',
+      '`',
+      '"'
     )
   );
   context.subscriptions.push(
@@ -90,7 +94,9 @@ export async function activate(context: vscode.ExtensionContext) {
       verilogCompletionItemProvider,
       '.',
       '(',
-      '='
+      '=',
+      '`',
+      '"'
     )
   );
 
@@ -149,7 +155,7 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  context.subscriptions.push(new InactivePreprocessorDecorationProvider());
+  context.subscriptions.push(new InactivePreprocessorDecorationProvider(projectService));
 
   // Configure command to instantiate a module
   context.subscriptions.push(
@@ -160,7 +166,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // Register command for manual linting
-  lintManager = new LintManager();
+  lintManager = new LintManager(projectService);
   context.subscriptions.push(lintManager);
   context.subscriptions.push(
     vscode.commands.registerCommand('verilog.lint', lintManager.runLintTool, lintManager)

--- a/src/hdl/CompletionService.ts
+++ b/src/hdl/CompletionService.ts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { CtagsManager, Symbol } from '../ctags';
+import { END_OF_LINE } from '../constants';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import type { SymbolRecord } from '../semantic/SymbolRecords';
+
+export class CompletionService {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly ctagsManager: CtagsManager
+  ) {}
+
+  async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.CompletionContext
+  ): Promise<vscode.CompletionItem[]> {
+    const projectItems = this.getProjectCompletionItems(document, position, context);
+    const ctagsItems = await this.getCtagsCompletionItems(document);
+    return mergeCompletionItems(projectItems, ctagsItems);
+  }
+
+  private getProjectCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.CompletionContext
+  ): vscode.CompletionItem[] {
+    const includeContext = getIncludeCompletionContext(document, position);
+    if (includeContext) {
+      return getIncludeCompletionItems(includeContext, this.projectService.getPreferredFileContext(document.uri));
+    }
+
+    if (isMacroCompletionContext(document, position, context)) {
+      return this.indexService
+        .getIndex()
+        .getAllSymbols()
+        .filter((symbol) => symbol.kind === 'macro')
+        .map(macroRecordToCompletionItem);
+    }
+
+    if (isNormalCodeCompletionContext(document, position)) {
+      return this.indexService
+        .getIndex()
+        .getAllModules()
+        .map((moduleRecord) => {
+          const item = new vscode.CompletionItem(moduleRecord.name, vscode.CompletionItemKind.Module);
+          item.detail = 'module';
+          item.documentation = new vscode.MarkdownString(moduleRecord.uri.fsPath);
+          return item;
+        });
+    }
+
+    return [];
+  }
+
+  private async getCtagsCompletionItems(document: vscode.TextDocument): Promise<vscode.CompletionItem[]> {
+    const symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
+    return symbols.map((symbol) => symbolToCompletionItem(document, symbol));
+  }
+}
+
+export function symbolToCompletionItem(
+  document: vscode.TextDocument,
+  symbol: Symbol
+): vscode.CompletionItem {
+  const newItem = new vscode.CompletionItem(symbol.name, getCompletionItemKind(symbol.type));
+  const codeRange = new vscode.Range(
+    symbol.startPosition,
+    new vscode.Position(symbol.startPosition.line, END_OF_LINE)
+  );
+  const code = document.getText(codeRange).trim();
+  newItem.detail = symbol.type;
+  let doc = `\`\`\`systemverilog\n${code}\n\`\`\``;
+  if (symbol.parentScope !== undefined && symbol.parentScope !== '') {
+    doc += `\nHierarchical Scope: ${symbol.parentScope}`;
+  }
+  newItem.documentation = new vscode.MarkdownString(doc);
+  return newItem;
+}
+
+export function mergeCompletionItems(
+  primaryItems: vscode.CompletionItem[],
+  fallbackItems: vscode.CompletionItem[]
+): vscode.CompletionItem[] {
+  const primaryKeys = new Set<string>();
+  const merged: vscode.CompletionItem[] = [];
+  for (const item of primaryItems) {
+    const key = `${completionLabelText(item.label)}:${item.kind ?? ''}`;
+    if (primaryKeys.has(key)) {
+      continue;
+    }
+    primaryKeys.add(key);
+    merged.push(item);
+  }
+  for (const item of fallbackItems) {
+    const key = `${completionLabelText(item.label)}:${item.kind ?? ''}`;
+    if (!primaryKeys.has(key)) {
+      merged.push(item);
+    }
+  }
+  return merged;
+}
+
+interface IncludeCompletionContext {
+  directoryPrefix: string;
+  replacementRange: vscode.Range;
+  documentDirectory: string;
+}
+
+export function getIncludeCompletionItems(
+  context: IncludeCompletionContext,
+  fileContext: FileContext | undefined
+): vscode.CompletionItem[] {
+  const searchRoots = [context.documentDirectory].concat(
+    fileContext?.includeDirs.map((dir) => dir.fsPath) ?? []
+  );
+  const items: vscode.CompletionItem[] = [];
+  const seen = new Set<string>();
+  for (const root of searchRoots) {
+    const directory = path.resolve(root, context.directoryPrefix);
+    if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const suffix = entry.isDirectory() ? '/' : '';
+      const label = `${entry.name}${suffix}`;
+      if (seen.has(label)) {
+        continue;
+      }
+      seen.add(label);
+      const item = new vscode.CompletionItem(
+        label,
+        entry.isDirectory() ? vscode.CompletionItemKind.Folder : vscode.CompletionItemKind.File
+      );
+      item.range = context.replacementRange;
+      items.push(item);
+    }
+  }
+  return items;
+}
+
+function macroRecordToCompletionItem(symbol: SymbolRecord): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(symbol.name, vscode.CompletionItemKind.Constant);
+  item.detail = 'macro';
+  item.documentation = new vscode.MarkdownString(symbol.uri.fsPath);
+  return item;
+}
+
+function getIncludeCompletionContext(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): IncludeCompletionContext | undefined {
+  const line = document.lineAt(position.line).text;
+  const prefix = line.slice(0, position.character);
+  const match = /`include\s+["<]([^">]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+  const typedPath = match[1] ?? '';
+  return {
+    directoryPrefix: path.dirname(typedPath) === '.' ? '' : path.dirname(typedPath),
+    replacementRange: new vscode.Range(
+      position.line,
+      position.character - path.basename(typedPath).length,
+      position.line,
+      position.character
+    ),
+    documentDirectory: path.dirname(document.uri.fsPath),
+  };
+}
+
+function isMacroCompletionContext(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  context: vscode.CompletionContext
+): boolean {
+  if (context.triggerCharacter === '`') {
+    return true;
+  }
+  const before = document.lineAt(position.line).text.slice(0, position.character);
+  return /`[A-Za-z0-9_$]*$/.test(before);
+}
+
+function isNormalCodeCompletionContext(document: vscode.TextDocument, position: vscode.Position): boolean {
+  const line = document.lineAt(position.line).text;
+  if (isInsideLineString(line, position.character)) {
+    return false;
+  }
+  const before = line.slice(0, position.character);
+  return !/`[A-Za-z0-9_$]*$/.test(before) && !/`include\s+["<][^">]*$/.test(before);
+}
+
+function isInsideLineString(line: string, character: number): boolean {
+  let inString = false;
+  for (let i = 0; i < character; i += 1) {
+    const current = line[i];
+    if (current === '\\') {
+      i += 1;
+      continue;
+    }
+    if (current === '"') {
+      inString = !inString;
+    }
+  }
+  return inString;
+}
+
+function completionLabelText(label: string | vscode.CompletionItemLabel): string {
+  return typeof label === 'string' ? label : label.label;
+}
+
+function getCompletionItemKind(type: string): vscode.CompletionItemKind {
+  switch (type) {
+    case 'constant':
+      return vscode.CompletionItemKind.Constant;
+    case 'event':
+      return vscode.CompletionItemKind.Event;
+    case 'function':
+      return vscode.CompletionItemKind.Function;
+    case 'module':
+      return vscode.CompletionItemKind.Module;
+    case 'net':
+    case 'port':
+    case 'register':
+      return vscode.CompletionItemKind.Variable;
+    case 'task':
+      return vscode.CompletionItemKind.Function;
+    case 'block':
+      return vscode.CompletionItemKind.Module;
+    case 'class':
+    case 'covergroup':
+      return vscode.CompletionItemKind.Class;
+    case 'enum':
+      return vscode.CompletionItemKind.Enum;
+    case 'interface':
+      return vscode.CompletionItemKind.Interface;
+    case 'package':
+    case 'program':
+      return vscode.CompletionItemKind.Module;
+    case 'prototype':
+      return vscode.CompletionItemKind.Function;
+    case 'property':
+      return vscode.CompletionItemKind.Property;
+    case 'struct':
+      return vscode.CompletionItemKind.Struct;
+    case 'typedef':
+      return vscode.CompletionItemKind.TypeParameter;
+    default:
+      return vscode.CompletionItemKind.Variable;
+  }
+}

--- a/src/linter/BaseLinter.ts
+++ b/src/linter/BaseLinter.ts
@@ -2,9 +2,11 @@
 import * as vscode from 'vscode';
 import { type Logger } from '@logtape/logtape';
 import { getExtensionLogger } from '../logging';
+import type { ProjectService } from '../project/ProjectService';
 import { getWorkingDirectoryForDocument, resolvePathsForDocument } from '../utils/workspace';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import { getLintProjectContext, type LintProjectContext } from './ProjectLintContext';
 
 /** Common configuration interface for linters */
 export interface LinterConfig {
@@ -50,7 +52,8 @@ export default abstract class BaseLinter implements vscode.Disposable {
   constructor(
     name: string,
     diagnosticManager: LinterDiagnosticManager,
-    runManager: LintRunManager
+    runManager: LintRunManager,
+    private readonly projectService?: ProjectService
   ) {
     this.diagnosticManager = diagnosticManager;
     this.runManager = runManager;
@@ -105,6 +108,15 @@ export default abstract class BaseLinter implements vscode.Disposable {
    */
   protected resolveIncludePaths(paths: string[], doc: vscode.TextDocument): string[] {
     return resolvePathsForDocument(paths, doc);
+  }
+
+  protected getProjectContext(doc: vscode.TextDocument): LintProjectContext {
+    return getLintProjectContext(this.projectService, doc);
+  }
+
+  protected getConfiguredAndProjectIncludePaths(doc: vscode.TextDocument): string[] {
+    const projectContext = this.getProjectContext(doc);
+    return this.resolveIncludePaths(this.config.includePath, doc).concat(projectContext.includePaths);
   }
 
   /**

--- a/src/linter/IcarusLinter.ts
+++ b/src/linter/IcarusLinter.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import BaseLinter from './BaseLinter';
+import type { ProjectService } from '../project/ProjectService';
 import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
@@ -22,6 +23,7 @@ export interface BuildIcarusArgsOptions {
   languageId: string;
   standards: Map<string, string>;
   includePaths: string[];
+  defineArgs?: string[];
   customArguments: string;
   documentPath: string;
 }
@@ -35,6 +37,9 @@ export function buildIcarusArgs(options: BuildIcarusArgsOptions): string[] {
   }
   for (const includePath of options.includePaths) {
     args.push('-I', includePath);
+  }
+  for (const defineArg of options.defineArgs ?? []) {
+    args.push('-D', defineArg);
   }
   args.push(...splitCommandLineArgs(options.customArguments));
   args.push(options.documentPath);
@@ -142,8 +147,12 @@ export default class IcarusLinter extends BaseLinter {
   private configuration!: vscode.WorkspaceConfiguration;
   private standards!: Map<string, string>;
 
-  constructor(diagnosticManager: LinterDiagnosticManager, runManager: LintRunManager) {
-    super('iverilog', diagnosticManager, runManager);
+  constructor(
+    diagnosticManager: LinterDiagnosticManager,
+    runManager: LintRunManager,
+    projectService?: ProjectService
+  ) {
+    super('iverilog', diagnosticManager, runManager, projectService);
     this.updateConfig();
   }
 
@@ -171,7 +180,11 @@ export default class IcarusLinter extends BaseLinter {
     const args = buildIcarusArgs({
       languageId: doc.languageId,
       standards: this.standards,
-      includePaths: this.resolveIncludePaths(this.config.includePath, doc),
+      includePaths: this.getConfiguredAndProjectIncludePaths(doc),
+      // Argument order is: tool defaults, configured include paths, project include
+      // paths/defines, user custom args, document. Custom args stay later so users
+      // can override or supplement project context.
+      defineArgs: this.getProjectContext(doc).defineArgs,
       customArguments: this.config.arguments,
       documentPath: doc.uri.fsPath,
     });

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -10,6 +10,7 @@ import XvlogLinter from './XvlogLinter';
 import VeribleVerilogLintLinter from './VeribleVerilogLintLinter';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager from './LintRunManager';
+import type { ProjectService } from '../project/ProjectService';
 
 export default class LintManager {
   private subscriptions: vscode.Disposable[];
@@ -20,7 +21,7 @@ export default class LintManager {
   private runManager: LintRunManager;
   private readonly logger = getExtensionLogger('Linter', 'Manager');
 
-  constructor() {
+  constructor(private readonly projectService?: ProjectService) {
     this.subscriptions = [];
     this.linter = null;
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection('verilog-lint');
@@ -41,15 +42,15 @@ export default class LintManager {
   getLinterFromString(name: string): BaseLinter | null {
     switch (name) {
       case 'iverilog':
-        return new IcarusLinter(this.diagnosticManager, this.runManager);
+        return new IcarusLinter(this.diagnosticManager, this.runManager, this.projectService);
       case 'xvlog':
-        return new XvlogLinter(this.diagnosticManager, this.runManager);
+        return new XvlogLinter(this.diagnosticManager, this.runManager, this.projectService);
       case 'modelsim':
         return new ModelsimLinter(this.diagnosticManager, this.runManager);
       case 'verilator':
-        return new VerilatorLinter(this.diagnosticManager, this.runManager);
+        return new VerilatorLinter(this.diagnosticManager, this.runManager, this.projectService);
       case 'slang':
-        return new SlangLinter(this.diagnosticManager, this.runManager);
+        return new SlangLinter(this.diagnosticManager, this.runManager, this.projectService);
       case 'verible-verilog-lint':
         return new VeribleVerilogLintLinter(this.diagnosticManager, this.runManager);
       default:

--- a/src/linter/ProjectLintContext.ts
+++ b/src/linter/ProjectLintContext.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ProjectService } from '../project/ProjectService';
+import type { MacroDefine } from '../project/ProjectTypes';
+
+export interface LintProjectContext {
+  includePaths: string[];
+  defineArgs: string[];
+}
+
+export function getLintProjectContext(
+  projectService: ProjectService | undefined,
+  doc: vscode.TextDocument
+): LintProjectContext {
+  if (!vscode.workspace.getConfiguration('verilog.linting').get<boolean>('useProjectContext', false)) {
+    return { includePaths: [], defineArgs: [] };
+  }
+  const context = projectService?.getPreferredFileContext(doc.uri);
+  if (!context) {
+    return { includePaths: [], defineArgs: [] };
+  }
+  return {
+    includePaths: context.includeDirs.map((dir) => dir.fsPath),
+    defineArgs: Object.values(context.defines).map(formatMacroDefine),
+  };
+}
+
+export function formatMacroDefine(define: MacroDefine): string {
+  return define.value === true ? define.name : `${define.name}=${define.value}`;
+}

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -7,6 +7,7 @@ import { END_OF_LINE } from '../constants';
 import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { convertToWslPath, type WslPathConversionOptions } from '../tools/WslPathConverter';
 import { getWorkspaceRootForDocument } from '../utils/workspace';
+import type { ProjectService } from '../project/ProjectService';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
@@ -42,6 +43,7 @@ export interface SlangPaths {
 export interface BuildSlangArgsOptions {
   docFolder: string;
   includePaths: string[];
+  defineArgs?: string[];
   customArguments: string;
   documentPath: string;
 }
@@ -97,6 +99,9 @@ export function buildSlangArgs(options: BuildSlangArgsOptions): string[] {
   const args: string[] = ['-I', options.docFolder];
   for (const includePath of options.includePaths) {
     args.push('-I', includePath);
+  }
+  for (const defineArg of options.defineArgs ?? []) {
+    args.push('-D', defineArg);
   }
   args.push(...splitCommandLineArgs(options.customArguments));
   args.push(options.documentPath);
@@ -155,8 +160,12 @@ export default class SlangLinter extends BaseLinter {
   private configuration!: vscode.WorkspaceConfiguration;
   private useWSL!: boolean;
 
-  constructor(diagnosticManager: LinterDiagnosticManager, runManager: LintRunManager) {
-    super('slang', diagnosticManager, runManager);
+  constructor(
+    diagnosticManager: LinterDiagnosticManager,
+    runManager: LintRunManager,
+    projectService?: ProjectService
+  ) {
+    super('slang', diagnosticManager, runManager, projectService);
     this.updateConfig();
   }
 
@@ -187,7 +196,11 @@ export default class SlangLinter extends BaseLinter {
     const args = commandInfo.leadingArgs.concat(
       buildSlangArgs({
         docFolder: paths.docFolder,
-        includePaths: this.resolveIncludePaths(this.config.includePath, doc),
+        includePaths: this.getConfiguredAndProjectIncludePaths(doc),
+        // Argument order is: tool defaults, configured include paths, project include
+        // paths/defines, user custom args, document. Custom args stay later so users
+        // can override or supplement project context.
+        defineArgs: this.getProjectContext(doc).defineArgs,
         customArguments: this.config.arguments,
         documentPath: paths.docUri,
       })

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -11,6 +11,7 @@ import {
   type WslPathConversionOptions,
 } from '../tools/WslPathConverter';
 import { getWorkspaceRootForDocument } from '../utils/workspace';
+import type { ProjectService } from '../project/ProjectService';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
@@ -47,6 +48,7 @@ export interface BuildVerilatorArgsOptions {
   languageId: string;
   docFolder: string;
   includePaths: string[];
+  defineArgs?: string[];
   customArguments: string;
   documentPath: string;
 }
@@ -60,6 +62,7 @@ export interface BuildVerilatorRunInputsOptions {
   workspaceFolder?: string;
   linterInstalledPath: string;
   includePaths: string[];
+  defineArgs?: string[];
   customArguments: string;
   cancellationToken?: vscode.CancellationToken;
   convertToWslPathFn?: typeof convertToWslPath;
@@ -134,6 +137,7 @@ export function buildVerilatorArgs(options: BuildVerilatorArgsOptions): string[]
   args.push('--lint-only');
   args.push(`-I${options.docFolder}`);
   args.push(...options.includePaths.map((includePath) => `-I${includePath}`));
+  args.push(...(options.defineArgs ?? []).map((defineArg) => `-D${defineArg}`));
   args.push(...splitCommandLineArgs(options.customArguments));
   args.push(options.documentPath);
   return args;
@@ -180,12 +184,13 @@ export async function buildVerilatorRunInputs(
     : options.workspaceFolder ?? docFolder;
 
   const args = commandInfo.leadingArgs.concat(
-    buildVerilatorArgs({
-      languageId: options.languageId,
-      docFolder,
-      includePaths,
-      customArguments: options.customArguments,
-      documentPath: docUri,
+      buildVerilatorArgs({
+        languageId: options.languageId,
+        docFolder,
+        includePaths,
+        defineArgs: options.defineArgs,
+        customArguments: options.customArguments,
+        documentPath: docUri,
     })
   );
 
@@ -331,8 +336,12 @@ export default class VerilatorLinter extends BaseLinter {
   private configuration!: vscode.WorkspaceConfiguration;
   private useWSL!: boolean;
 
-  constructor(diagnosticManager: LinterDiagnosticManager, runManager: LintRunManager) {
-    super('verilator', diagnosticManager, runManager);
+  constructor(
+    diagnosticManager: LinterDiagnosticManager,
+    runManager: LintRunManager,
+    projectService?: ProjectService
+  ) {
+    super('verilator', diagnosticManager, runManager, projectService);
     this.updateConfig();
   }
 
@@ -373,7 +382,8 @@ export default class VerilatorLinter extends BaseLinter {
         runAtFileLocation: this.config.runAtFileLocation,
         workspaceFolder: getWorkspaceRootForDocument(doc),
         linterInstalledPath: this.config.linterInstalledPath,
-        includePaths: this.resolveIncludePaths(this.config.includePath, doc),
+        includePaths: this.getConfiguredAndProjectIncludePaths(doc),
+        defineArgs: this.getProjectContext(doc).defineArgs,
         customArguments: this.config.arguments,
         cancellationToken: run.cancellationToken,
       });

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import BaseLinter from './BaseLinter';
+import type { ProjectService } from '../project/ProjectService';
 import { END_OF_LINE } from '../constants';
 import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
@@ -11,6 +12,7 @@ import LintRunManager, { type LintRunHandle } from './LintRunManager';
 export interface BuildXvlogArgsOptions {
   languageId: string;
   includePaths: string[];
+  defineArgs?: string[];
   customArguments: string;
   documentPath: string;
 }
@@ -22,6 +24,9 @@ export function buildXvlogArgs(options: BuildXvlogArgsOptions): string[] {
   }
   for (const includePath of options.includePaths) {
     args.push('-i', includePath);
+  }
+  for (const defineArg of options.defineArgs ?? []) {
+    args.push('--define', defineArg);
   }
   args.push(...splitCommandLineArgs(options.customArguments));
   args.push(options.documentPath);
@@ -61,8 +66,12 @@ export function parseXvlogDiagnostics(stdout: string): vscode.Diagnostic[] {
 }
 
 export default class XvlogLinter extends BaseLinter {
-  constructor(diagnosticManager: LinterDiagnosticManager, runManager: LintRunManager) {
-    super('xvlog', diagnosticManager, runManager);
+  constructor(
+    diagnosticManager: LinterDiagnosticManager,
+    runManager: LintRunManager,
+    projectService?: ProjectService
+  ) {
+    super('xvlog', diagnosticManager, runManager, projectService);
     this.updateConfig();
   }
 
@@ -81,7 +90,8 @@ export default class XvlogLinter extends BaseLinter {
 
     const args = buildXvlogArgs({
       languageId: doc.languageId,
-      includePaths: this.resolveIncludePaths(this.config.includePath, doc),
+      includePaths: this.getConfiguredAndProjectIncludePaths(doc),
+      defineArgs: this.getProjectContext(doc).defineArgs,
       customArguments: this.config.arguments,
       documentPath: doc.fileName,
     });

--- a/src/providers/CompletionItemProvider.ts
+++ b/src/providers/CompletionItemProvider.ts
@@ -1,95 +1,21 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { CtagsManager, Symbol } from '../ctags';
+import type { CompletionService } from '../hdl/CompletionService';
 import { getExtensionLogger } from '../logging';
-import { END_OF_LINE } from '../constants';
 
 export class VerilogCompletionItemProvider implements vscode.CompletionItemProvider {
   private readonly logger = getExtensionLogger('Provider', 'CompletionItem');
-  private ctagsManager: CtagsManager;
-  constructor(ctagsManager: CtagsManager) {
-    this.ctagsManager = ctagsManager;
-  }
+  constructor(private readonly completionService: CompletionService) {}
 
-  //TODO: Better context based completion items
   async provideCompletionItems(
     document: vscode.TextDocument,
-    _position: vscode.Position,
+    position: vscode.Position,
     _token: vscode.CancellationToken,
-    _context: vscode.CompletionContext
+    context: vscode.CompletionContext
   ): Promise<vscode.CompletionItem[]> {
     this.logger.info("Completion items requested", { uri: document.uri.toString() });
-    const items: vscode.CompletionItem[] = [];
-
-    const symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
-    symbols.forEach((symbol) => {
-      const newItem: vscode.CompletionItem = new vscode.CompletionItem(
-        symbol.name,
-        this.getCompletionItemKind(symbol.type)
-      );
-      const codeRange = new vscode.Range(
-        symbol.startPosition,
-        new vscode.Position(symbol.startPosition.line, END_OF_LINE)
-      );
-      const code = document.getText(codeRange).trim();
-      newItem.detail = symbol.type;
-      let doc: string = `\`\`\`systemverilog\n${  code  }\n\`\`\``;
-      if (symbol.parentScope !== undefined && symbol.parentScope !== '') {
-        doc += `\nHierarchical Scope: ${  symbol.parentScope}`;
-      }
-      newItem.documentation = new vscode.MarkdownString(doc);
-      items.push(newItem);
-    });
+    const items = await this.completionService.provideCompletionItems(document, position, context);
     this.logger.info("Completion items returned", { count: items.length });
     return items;
-  }
-
-  private getCompletionItemKind(type: string): vscode.CompletionItemKind {
-    switch (type) {
-      case 'constant':
-        return vscode.CompletionItemKind.Constant;
-      case 'event':
-        return vscode.CompletionItemKind.Event;
-      case 'function':
-        return vscode.CompletionItemKind.Function;
-      case 'module':
-        return vscode.CompletionItemKind.Module;
-      case 'net':
-        return vscode.CompletionItemKind.Variable;
-      case 'port':
-        return vscode.CompletionItemKind.Variable;
-      case 'register':
-        return vscode.CompletionItemKind.Variable;
-      case 'task':
-        return vscode.CompletionItemKind.Function;
-      case 'block':
-        return vscode.CompletionItemKind.Module;
-      case 'assert':
-        return vscode.CompletionItemKind.Variable; // No idea what to use
-      case 'class':
-        return vscode.CompletionItemKind.Class;
-      case 'covergroup':
-        return vscode.CompletionItemKind.Class; // No idea what to use
-      case 'enum':
-        return vscode.CompletionItemKind.Enum;
-      case 'interface':
-        return vscode.CompletionItemKind.Interface;
-      case 'modport':
-        return vscode.CompletionItemKind.Variable; // same as ports
-      case 'package':
-        return vscode.CompletionItemKind.Module;
-      case 'program':
-        return vscode.CompletionItemKind.Module;
-      case 'prototype':
-        return vscode.CompletionItemKind.Function;
-      case 'property':
-        return vscode.CompletionItemKind.Property;
-      case 'struct':
-        return vscode.CompletionItemKind.Struct;
-      case 'typedef':
-        return vscode.CompletionItemKind.TypeParameter;
-      default:
-        return vscode.CompletionItemKind.Variable;
-    }
   }
 }

--- a/src/providers/InactivePreprocessorDecorationProvider.ts
+++ b/src/providers/InactivePreprocessorDecorationProvider.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import type { ProjectService } from '../project/ProjectService';
+import type { MacroDefine } from '../project/ProjectTypes';
 
 interface InactivePreprocessorRange {
   startLine: number;
@@ -195,11 +197,25 @@ export function computeInactivePreprocessorRanges(
   return ranges;
 }
 
+export function mergePreprocessorDefines(
+  configuredDefines: readonly string[],
+  projectDefines: Record<string, MacroDefine> | undefined,
+  useProjectDefines: boolean
+): string[] {
+  const merged = new Set(configuredDefines);
+  if (useProjectDefines && projectDefines) {
+    for (const defineName of Object.keys(projectDefines)) {
+      merged.add(defineName);
+    }
+  }
+  return [...merged];
+}
+
 export class InactivePreprocessorDecorationProvider implements vscode.Disposable {
   private readonly subscriptions: vscode.Disposable[] = [];
   private decorationType: vscode.TextEditorDecorationType | undefined;
 
-  constructor() {
+  constructor(private readonly projectService?: ProjectService) {
     this.recreateDecorationType();
     this.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(() => {
@@ -220,6 +236,13 @@ export class InactivePreprocessorDecorationProvider implements vscode.Disposable
         this.updateVisibleEditors();
       })
     );
+    if (this.projectService) {
+      this.subscriptions.push(
+        this.projectService.onDidChangeSnapshot(() => {
+          this.updateVisibleEditors();
+        })
+      );
+    }
     this.updateVisibleEditors();
   }
 
@@ -263,9 +286,15 @@ export class InactivePreprocessorDecorationProvider implements vscode.Disposable
       return;
     }
 
+    const config = vscode.workspace.getConfiguration('verilog.preprocessor');
+    const projectContext = this.projectService?.getPreferredFileContext(editor.document.uri);
     const ranges = computeInactivePreprocessorRanges(
       editor.document.getText(),
-      vscode.workspace.getConfiguration('verilog.preprocessor').get('defines', [])
+      mergePreprocessorDefines(
+        config.get<string[]>('defines', []),
+        projectContext?.defines,
+        config.get<boolean>('useProjectDefines', true)
+      )
     ).map((range) => this.toVscodeRange(editor.document, range));
     editor.setDecorations(this.decorationType, ranges);
   }

--- a/src/test/completionService.test.ts
+++ b/src/test/completionService.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CtagsManager } from '../ctags';
+import { CompletionService } from '../hdl/CompletionService';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+suite('CompletionService', () => {
+  test('completes module names from project index', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'my_',
+    });
+    const service = createCompletionService([
+      createModuleRecord('my_module'),
+    ]);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(0, 3),
+      { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+    );
+
+    const item = items.find((completionItem) => completionItem.label === 'my_module');
+    assert.ok(item, 'Expected project module completion');
+    assert.strictEqual(item.kind, vscode.CompletionItemKind.Module);
+  });
+
+  test('completes macros after backtick', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: '`',
+    });
+    const service = createCompletionService([
+      createSymbolRecord('PROJECT_MACRO', 'macro'),
+    ]);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(0, 1),
+      {
+        triggerKind: vscode.CompletionTriggerKind.TriggerCharacter,
+        triggerCharacter: '`',
+      }
+    );
+
+    const item = items.find((completionItem) => completionItem.label === 'PROJECT_MACRO');
+    assert.ok(item, 'Expected project macro completion');
+    assert.strictEqual(item.kind, vscode.CompletionItemKind.Constant);
+  });
+
+  test('completes include paths from current directory and include dirs', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'completion-include-'));
+    const src = path.join(root, 'src');
+    const inc = path.join(root, 'inc');
+    fs.mkdirSync(src);
+    fs.mkdirSync(inc);
+    fs.writeFileSync(path.join(src, 'local.svh'), '');
+    fs.writeFileSync(path.join(inc, 'shared.svh'), '');
+    fs.mkdirSync(path.join(inc, 'nested'));
+    const documentPath = path.join(src, 'top.sv');
+    fs.writeFileSync(documentPath, '`include "');
+    const document = await vscode.workspace.openTextDocument(documentPath);
+    const context: FileContext = {
+      file: vscode.Uri.file(documentPath),
+      compileUnitId: 'unit',
+      includeDirs: [vscode.Uri.file(inc)],
+      defines: {},
+    };
+    const service = createCompletionService([], context);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(0, 10),
+      {
+        triggerKind: vscode.CompletionTriggerKind.TriggerCharacter,
+        triggerCharacter: '"',
+      }
+    );
+
+    assert.ok(items.some((item) => item.label === 'local.svh'));
+    assert.ok(items.some((item) => item.label === 'shared.svh'));
+    assert.ok(items.some((item) => item.label === 'nested/'));
+  });
+
+  test('preserves ctags completion fallback', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'logic fallback_sig;',
+    });
+    const service = createCompletionService([], undefined, {
+      getSymbols: async () => [
+        {
+          name: 'fallback_sig',
+          type: 'net',
+          startPosition: new vscode.Position(0, 0),
+          endPosition: new vscode.Position(0, 19),
+          parentScope: '',
+          parentType: '',
+          isValid: true,
+        },
+      ],
+    } as unknown as CtagsManager);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(0, 0),
+      { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+    );
+
+    const item = items.find((completionItem) => completionItem.label === 'fallback_sig');
+    assert.ok(item, 'Expected ctags fallback completion');
+    assert.strictEqual(item.kind, vscode.CompletionItemKind.Variable);
+  });
+});
+
+function createCompletionService(
+  symbols: SymbolRecord[],
+  context?: FileContext,
+  ctagsManager: CtagsManager = { getSymbols: async () => [] } as unknown as CtagsManager
+): CompletionService {
+  const projectService = {
+    getPreferredFileContext: () => context,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => new SemanticIndex(1, symbols),
+  } as unknown as IndexService;
+  return new CompletionService(projectService, indexService, ctagsManager);
+}
+
+function createModuleRecord(name: string): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module'),
+    kind: 'module',
+    ports: [],
+    parameters: [],
+  };
+}
+
+function createSymbolRecord(name: string, kind: SymbolRecord['kind']): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 0, 0, name.length);
+  return {
+    id: `${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId: 'unit',
+  };
+}

--- a/src/test/ctags.test.ts
+++ b/src/test/ctags.test.ts
@@ -4,6 +4,10 @@ import * as vscode from 'vscode';
 import { VerilogCompletionItemProvider } from '../providers/CompletionItemProvider';
 import { Ctags, CtagsManager, Symbol } from '../ctags';
 import { getExtensionLogger } from '../logging';
+import { CompletionService } from '../hdl/CompletionService';
+import type { ProjectService } from '../project/ProjectService';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
 
 suite('Ctags Parsing', () => {
   test('builds symbols from ctags output without invoking ctags binary', async () => {
@@ -99,7 +103,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -139,7 +143,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -176,7 +180,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -214,7 +218,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -247,7 +251,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -286,7 +290,7 @@ suite('Ctags Completion', () => {
       getSymbols: async () => symbols,
     } as unknown as CtagsManager;
 
-    const provider = new VerilogCompletionItemProvider(ctagsManager);
+    const provider = createCompletionProvider(ctagsManager);
     const tokenSource = new vscode.CancellationTokenSource();
     const items = await provider.provideCompletionItems(
       document,
@@ -307,3 +311,13 @@ suite('Ctags Completion', () => {
     assert.strictEqual(classItem?.kind, vscode.CompletionItemKind.Class);
   });
 });
+
+function createCompletionProvider(ctagsManager: CtagsManager): VerilogCompletionItemProvider {
+  const projectService = {} as ProjectService;
+  const indexService = {
+    getIndex: () => new SemanticIndex(1, []),
+  } as unknown as IndexService;
+  return new VerilogCompletionItemProvider(
+    new CompletionService(projectService, indexService, ctagsManager)
+  );
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -163,5 +163,7 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.project.defines']);
     assert.ok(properties['verilog.project.exclude']);
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
+    assert.ok(properties['verilog.preprocessor.useProjectDefines']);
+    assert.ok(properties['verilog.linting.useProjectContext']);
   });
 });

--- a/src/test/inactivePreprocessor.test.ts
+++ b/src/test/inactivePreprocessor.test.ts
@@ -2,6 +2,7 @@
 import * as assert from 'assert';
 import {
   computeInactivePreprocessorRanges,
+  mergePreprocessorDefines,
 } from '../providers/InactivePreprocessorDecorationProvider';
 
 suite('Inactive Preprocessor Ranges', () => {
@@ -21,6 +22,44 @@ suite('Inactive Preprocessor Ranges', () => {
     );
 
     assert.deepStrictEqual(ranges, [{ startLine: 3, endLine: 3 }]);
+  });
+
+  test('project defines merge with configured defines', () => {
+    const defines = mergePreprocessorDefines(
+      ['CONFIG_DEFINED'],
+      {
+        PROJECT_DEFINED: { name: 'PROJECT_DEFINED', value: true, source: 'filelist' },
+      },
+      true
+    );
+    const ranges = computeInactivePreprocessorRanges(
+      [
+        '`ifdef PROJECT_DEFINED',
+        'assign a = 1;',
+        '`else',
+        'assign a = 0;',
+        '`endif',
+      ].join('\n'),
+      defines
+    );
+
+    assert.deepStrictEqual(ranges, [{ startLine: 3, endLine: 3 }]);
+  });
+
+  test('project defines can be disabled for inactive preprocessing', () => {
+    const defines = mergePreprocessorDefines(
+      [],
+      {
+        PROJECT_DEFINED: { name: 'PROJECT_DEFINED', value: true, source: 'filelist' },
+      },
+      false
+    );
+    const ranges = computeInactivePreprocessorRanges(
+      ['`ifdef PROJECT_DEFINED', 'assign a = 1;', '`endif'].join('\n'),
+      defines
+    );
+
+    assert.deepStrictEqual(ranges, [{ startLine: 1, endLine: 1 }]);
   });
 
   test('ifndef treats a defined macro as inactive', () => {

--- a/src/test/iverilog.test.ts
+++ b/src/test/iverilog.test.ts
@@ -48,6 +48,7 @@ suite('Icarus Linter', () => {
 
   test('builds argv without shell quoting', () => {
     const includePath = path.join(os.tmpdir(), 'iverilog include path');
+    const projectIncludePath = path.join(os.tmpdir(), 'iverilog project include');
     const documentPath = path.join(os.tmpdir(), 'iverilog source path', 'bad file.v');
     const args = buildIcarusArgs({
       languageId: 'systemverilog',
@@ -55,7 +56,8 @@ suite('Icarus Linter', () => {
         ['verilog', 'Verilog-2005'],
         ['systemverilog', 'SystemVerilog2012'],
       ]),
-      includePaths: [includePath],
+      includePaths: [includePath, projectIncludePath],
+      defineArgs: ['SIM', 'WIDTH=32'],
       customArguments: '-Wall -DMSG="hello world"',
       documentPath,
     });
@@ -66,6 +68,12 @@ suite('Icarus Linter', () => {
       '-g2012',
       '-I',
       includePath,
+      '-I',
+      projectIncludePath,
+      '-D',
+      'SIM',
+      '-D',
+      'WIDTH=32',
       '-Wall',
       '-DMSG=hello world',
       documentPath,

--- a/src/test/projectLintContext.test.ts
+++ b/src/test/projectLintContext.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { getLintProjectContext } from '../linter/ProjectLintContext';
+import type { ProjectService } from '../project/ProjectService';
+
+suite('Project lint context', () => {
+  test('returns include dirs and defines when enabled', async () => {
+    const config = vscode.workspace.getConfiguration('verilog.linting');
+    const previous = config.get('useProjectContext');
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+    const projectService = {
+      getPreferredFileContext: () => ({
+        file: document.uri,
+        compileUnitId: 'unit',
+        includeDirs: [vscode.Uri.file('/workspace/inc')],
+        defines: {
+          SIM: { name: 'SIM', value: true, source: 'filelist' },
+          WIDTH: { name: 'WIDTH', value: '32', source: 'filelist' },
+        },
+      }),
+    } as unknown as ProjectService;
+
+    try {
+      await config.update('useProjectContext', true, vscode.ConfigurationTarget.Global);
+      const context = getLintProjectContext(projectService, document);
+
+      assert.deepStrictEqual(context.includePaths, ['/workspace/inc']);
+      assert.deepStrictEqual(context.defineArgs, ['SIM', 'WIDTH=32']);
+    } finally {
+      await config.update('useProjectContext', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test('returns empty context when disabled', async () => {
+    const config = vscode.workspace.getConfiguration('verilog.linting');
+    const previous = config.get('useProjectContext');
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+
+    try {
+      await config.update('useProjectContext', false, vscode.ConfigurationTarget.Global);
+      const context = getLintProjectContext({} as ProjectService, document);
+
+      assert.deepStrictEqual(context, { includePaths: [], defineArgs: [] });
+    } finally {
+      await config.update('useProjectContext', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+});

--- a/src/test/slang.test.ts
+++ b/src/test/slang.test.ts
@@ -15,6 +15,7 @@ suite('Slang Linter', () => {
     const documentPath = '/tmp/slang source/top file.sv';
     const docFolder = '/tmp/slang source';
     const includePath = '/tmp/slang include';
+    const projectIncludePath = '/tmp/slang project include';
     const commandInfo = buildSlangCommand({
       isWindows: false,
       useWSL: false,
@@ -23,7 +24,8 @@ suite('Slang Linter', () => {
     const args = commandInfo.leadingArgs.concat(
       buildSlangArgs({
         docFolder,
-        includePaths: [includePath],
+        includePaths: [includePath, projectIncludePath],
+        defineArgs: ['SIM', 'WIDTH=32'],
         customArguments: '--single-unit --top "top mod"',
         documentPath,
       })
@@ -35,6 +37,12 @@ suite('Slang Linter', () => {
       docFolder,
       '-I',
       includePath,
+      '-I',
+      projectIncludePath,
+      '-D',
+      'SIM',
+      '-D',
+      'WIDTH=32',
       '--single-unit',
       '--top',
       'top mod',

--- a/src/test/verilator.test.ts
+++ b/src/test/verilator.test.ts
@@ -137,6 +137,7 @@ suite('Verilator Linter', () => {
     const documentPath = '/tmp/verilator source/top file.sv';
     const docFolder = '/tmp/verilator source';
     const includePath = '/tmp/verilator include';
+    const projectIncludePath = '/tmp/verilator project include';
     const commandInfo = buildVerilatorCommand({
       isWindows: false,
       useWSL: false,
@@ -146,7 +147,8 @@ suite('Verilator Linter', () => {
       buildVerilatorArgs({
         languageId: 'systemverilog',
         docFolder,
-        includePaths: [includePath],
+        includePaths: [includePath, projectIncludePath],
+        defineArgs: ['SIM', 'WIDTH=32'],
         customArguments: '--timing --top-module "top mod"',
         documentPath,
       })
@@ -158,6 +160,9 @@ suite('Verilator Linter', () => {
       '--lint-only',
       `-I${docFolder}`,
       `-I${includePath}`,
+      `-I${projectIncludePath}`,
+      '-DSIM',
+      '-DWIDTH=32',
       '--timing',
       '--top-module',
       'top mod',

--- a/src/test/xvlog.test.ts
+++ b/src/test/xvlog.test.ts
@@ -9,10 +9,12 @@ import { buildXvlogArgs, parseXvlogDiagnostics } from '../linter/XvlogLinter';
 suite('Xvlog Linter', () => {
   test('builds args with automatic flags and split custom args', () => {
     const includePath = path.join(os.tmpdir(), 'xvlog include');
+    const projectIncludePath = path.join(os.tmpdir(), 'xvlog project include');
     const documentPath = path.join(os.tmpdir(), 'xvlog source', 'top file.sv');
     const args = buildXvlogArgs({
       languageId: 'systemverilog',
-      includePaths: [includePath],
+      includePaths: [includePath, projectIncludePath],
+      defineArgs: ['SIM', 'WIDTH=32'],
       customArguments: '--define FOO="bar baz"',
       documentPath,
     });
@@ -22,6 +24,12 @@ suite('Xvlog Linter', () => {
       '-sv',
       '-i',
       includePath,
+      '-i',
+      projectIncludePath,
+      '--define',
+      'SIM',
+      '--define',
+      'WIDTH=32',
       '--define',
       'FOO=bar baz',
       documentPath,


### PR DESCRIPTION
## Summary
- merge project filelist/settings defines into inactive preprocessor highlighting when enabled
- add project-index completion for modules, macros, and include paths while preserving ctags fallback
- optionally pass project include directories and defines into Icarus, Verilator, Slang, and Xvlog lint arguments

## Validation
- `npm run check-types` passed
- `npm run lint` passed
- `npm run compile-tests` passed
- `npm test` passed: 207 passing, 3 pending