### PR TITLE
Stabilize minimal IDE model

### DIFF
--- a/src/project/ProjectLoader.ts
+++ b/src/project/ProjectLoader.ts
@@ -64,6 +64,14 @@ export class ProjectLoader {
         ? this.loadFilelistCompileUnits(workspaceRoot, settings, diagnostics)
         : await this.loadFallbackCompileUnit(workspaceRoot, settings, diagnostics);
 
+    logger.info('Loaded Verilog project model', {
+      workspaceRoot: workspaceRoot.fsPath,
+      compileUnits: compileUnits.length,
+      files: countFiles(compileUnits),
+      includeDirs: countIncludeDirs(compileUnits),
+      defines: countDefines(compileUnits),
+      diagnostics: diagnostics.length,
+    });
     return createSnapshot(version, workspaceRoot, settings.activeTarget, compileUnits, diagnostics);
   }
 
@@ -209,4 +217,16 @@ function globToRegExp(pattern: string): RegExp {
 
 function escapeRegExp(input: string): string {
   return input.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function countFiles(compileUnits: CompileUnit[]): number {
+  return compileUnits.reduce((sum, compileUnit) => sum + compileUnit.files.length, 0);
+}
+
+function countIncludeDirs(compileUnits: CompileUnit[]): number {
+  return compileUnits.reduce((sum, compileUnit) => sum + compileUnit.includeDirs.length, 0);
+}
+
+function countDefines(compileUnits: CompileUnit[]): number {
+  return compileUnits.reduce((sum, compileUnit) => sum + Object.keys(compileUnit.defines).length, 0);
 }

--- a/src/project/ProjectService.ts
+++ b/src/project/ProjectService.ts
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import { getExtensionLogger } from '../logging';
 import { FileContextResolver } from './FileContextResolver';
 import { ProjectLoader } from './ProjectLoader';
-import { cloneSnapshot, type FileContext, type ProjectSnapshot } from './ProjectTypes';
+import {
+  cloneSnapshot,
+  PROJECT_DIAGNOSTIC_SOURCE,
+  type FileContext,
+  type ProjectSnapshot,
+} from './ProjectTypes';
+
+const logger = getExtensionLogger('Project', 'Service');
 
 export class ProjectService implements vscode.Disposable {
   private readonly emitter = new vscode.EventEmitter<ProjectSnapshot>();
@@ -26,9 +34,36 @@ export class ProjectService implements vscode.Disposable {
     return cloneSnapshot(this.snapshot);
   }
 
-  async reload(_reason?: string): Promise<ProjectSnapshot> {
+  async reload(reason = 'unspecified'): Promise<ProjectSnapshot> {
     this.version += 1;
-    this.snapshot = await this.loader.load(this.version);
+    logger.info('Reloading Verilog project', { reason, version: this.version });
+    try {
+      this.snapshot = await this.loader.load(this.version);
+      logger.info('Reloaded Verilog project', {
+        reason,
+        version: this.snapshot.version,
+        compileUnits: this.snapshot.compileUnits.length,
+        files: this.snapshot.compileUnits.reduce((sum, compileUnit) => sum + compileUnit.files.length, 0),
+        diagnostics: this.snapshot.diagnostics.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to reload Verilog project', { reason, error: message });
+      this.snapshot = {
+        version: this.version,
+        workspaceRoot: this.snapshot.workspaceRoot,
+        activeTargetId: '',
+        compileUnits: [],
+        diagnostics: [
+          {
+            severity: 'error',
+            message: `Project loading failed: ${message}`,
+            source: PROJECT_DIAGNOSTIC_SOURCE,
+            code: 'project-load-failed',
+          },
+        ],
+      };
+    }
     const cloned = this.getSnapshot();
     this.emitter.fire(cloned);
     return cloned;

--- a/src/project/ProjectWatcher.ts
+++ b/src/project/ProjectWatcher.ts
@@ -2,12 +2,25 @@
 import * as vscode from 'vscode';
 import type { ProjectService } from './ProjectService';
 
+export interface ProjectWatcherOptions {
+  debounceMs?: number;
+  watch?: boolean;
+}
+
 export class ProjectWatcher implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
   private reloadTimer: NodeJS.Timeout | undefined;
   private filelistWatcher: vscode.FileSystemWatcher | undefined;
+  private readonly debounceMs: number;
 
-  constructor(private readonly projectService: ProjectService) {
+  constructor(
+    private readonly projectService: ProjectService,
+    options: ProjectWatcherOptions = {}
+  ) {
+    this.debounceMs = options.debounceMs ?? 300;
+    if (options.watch === false) {
+      return;
+    }
     this.disposables.push(
       vscode.workspace.onDidChangeConfiguration((event) => {
         if (!event.affectsConfiguration('verilog.project')) {
@@ -27,7 +40,7 @@ export class ProjectWatcher implements vscode.Disposable {
     this.reloadTimer = setTimeout(() => {
       this.reloadTimer = undefined;
       void this.projectService.reload(reason);
-    }, 300);
+    }, this.debounceMs);
   }
 
   dispose(): void {

--- a/src/semantic/IndexService.ts
+++ b/src/semantic/IndexService.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import { getExtensionLogger } from '../logging';
 import type { ProjectService } from '../project/ProjectService';
 import type { ProjectSnapshot } from '../project/ProjectTypes';
 import { FastIndexerBackend } from './backends/FastIndexerBackend';
 import { SemanticIndex } from './SemanticIndex';
+
+const logger = getExtensionLogger('Semantic', 'IndexService');
 
 export class IndexService implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
@@ -28,9 +31,29 @@ export class IndexService implements vscode.Disposable {
   async rebuild(snapshot: ProjectSnapshot): Promise<SemanticIndex> {
     const serial = this.rebuildSerial + 1;
     this.rebuildSerial = serial;
-    const symbols = await this.backend.build(snapshot);
-    if (serial === this.rebuildSerial) {
-      this.index = new SemanticIndex(snapshot.version, symbols);
+    logger.info('Rebuilding Verilog semantic index', {
+      version: snapshot.version,
+      compileUnits: snapshot.compileUnits.length,
+      files: snapshot.compileUnits.reduce((sum, compileUnit) => sum + compileUnit.files.length, 0),
+    });
+    try {
+      const symbols = await this.backend.build(snapshot);
+      if (serial === this.rebuildSerial) {
+        this.index = new SemanticIndex(snapshot.version, symbols);
+        logger.info('Rebuilt Verilog semantic index', {
+          version: snapshot.version,
+          symbols: symbols.length,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to rebuild Verilog semantic index', {
+        version: snapshot.version,
+        error: message,
+      });
+      if (serial === this.rebuildSerial) {
+        this.index = new SemanticIndex(snapshot.version, []);
+      }
     }
     return this.index;
   }

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CtagsManager } from '../ctags';
+import { CompletionService } from '../hdl/CompletionService';
+import { DefinitionService } from '../hdl/DefinitionService';
+import { FileContextResolver } from '../project/FileContextResolver';
+import { ProjectLoader } from '../project/ProjectLoader';
+import { ProjectService } from '../project/ProjectService';
+import { ProjectWatcher } from '../project/ProjectWatcher';
+import { buildCompileUnit } from '../project/ProjectModelMerger';
+import { renderProjectStatus } from '../project/ProjectCommands';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+import type { ProjectSettings } from '../project/providers/SettingsProjectSourceProvider';
+import { FastIndexerBackend } from '../semantic/backends/FastIndexerBackend';
+import { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { SymbolRecord } from '../semantic/SymbolRecords';
+
+suite('Minimal IDE Model Stabilization', () => {
+  suite('ProjectService and ProjectLoader fixtures', () => {
+    test('loads one configured filelist with files, include dirs, and defines', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+
+      assert.strictEqual(snapshot.compileUnits.length, 1);
+      assert.strictEqual(snapshot.compileUnits[0]?.files.length, 4);
+      assert.ok(snapshot.compileUnits[0]?.includeDirs.some((uri) => uri.fsPath.endsWith('rtl/include')));
+      assert.strictEqual(snapshot.compileUnits[0]?.defines.SIMPLE_PROJECT?.value, true);
+      assert.strictEqual(snapshot.diagnostics.length, 0);
+    });
+
+    test('loads nested filelists relative to the nested filelist location', async () => {
+      const root = fixtureRoot('nested-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+
+      const unit = snapshot.compileUnits[0];
+      assert.ok(unit?.files.some((file) => file.uri.fsPath.endsWith('rtl/foo.sv')));
+      assert.ok(unit?.files.some((file) => file.uri.fsPath.endsWith('include/defs.svh')));
+      assert.ok(unit?.includeDirs.some((uri) => uri.fsPath.endsWith('include')));
+      assert.strictEqual(unit?.defines.NESTED_PROJECT?.value, true);
+    });
+
+    test('reports nested cycles and missing project paths as readable diagnostics', async () => {
+      const root = fixtureRoot('malformed-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+      const codes = snapshot.diagnostics.map((diagnostic) => diagnostic.code);
+
+      assert.ok(codes.includes('nested-filelist-cycle'));
+      assert.ok(codes.includes('missing-filelist'));
+      assert.ok(codes.includes('missing-include-dir'));
+      assert.ok(codes.includes('missing-source-file'));
+      assert.ok(snapshot.diagnostics.every((diagnostic) => diagnostic.message.length > 0));
+    });
+
+    test('creates fallback auto-discovery compile unit and respects exclude patterns', async function () {
+      this.timeout(10000);
+      const root = fixtureRoot('no-filelist-autodiscovery');
+      const snapshot = await loadFixture(root, settings({ exclude: ['**/foo.sv'] }));
+
+      assert.strictEqual(snapshot.compileUnits[0]?.id, 'auto:workspace');
+      assert.ok(snapshot.compileUnits[0]?.files.some((file) => file.uri.fsPath.endsWith('top.sv')));
+      assert.ok(!snapshot.compileUnits[0]?.files.some((file) => file.uri.fsPath.endsWith('foo.sv')));
+      assert.ok(snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'fallback-discovery'));
+    });
+
+    test('respects verilog.project.enabled=false', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ enabled: false, filelists: ['files.f'] }));
+
+      assert.strictEqual(snapshot.compileUnits.length, 0);
+      assert.ok(snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'project-disabled'));
+    });
+
+    test('returns preferred file context by active target and no context for unrelated files', async () => {
+      const root = fixtureRoot('multi-target');
+      const snapshot = await loadFixture(
+        root,
+        settings({
+          filelists: ['rtl.f', 'sim.f'],
+          activeTarget: 'filelist:1:sim.f',
+        })
+      );
+      const resolver = new FileContextResolver(snapshot);
+      const rtlFile = vscode.Uri.file(path.join(root, 'rtl', 'top.sv'));
+
+      assert.deepStrictEqual(resolver.getFileContexts(rtlFile).map((context) => context.compileUnitId), [
+        'filelist:0:rtl.f',
+        'filelist:1:sim.f',
+      ]);
+      assert.strictEqual(resolver.getPreferredFileContext(rtlFile)?.compileUnitId, 'filelist:1:sim.f');
+      assert.strictEqual(resolver.getPreferredFileContext(vscode.Uri.file(path.join(root, 'outside.sv'))), undefined);
+    });
+
+    test('degrades to an empty diagnostic snapshot when loading throws', async () => {
+      const service = new ProjectService({
+        load: async () => {
+          throw new Error('boom');
+        },
+      } as unknown as ProjectLoader);
+
+      const snapshot = await service.reload('test failure');
+
+      assert.strictEqual(snapshot.compileUnits.length, 0);
+      assert.strictEqual(snapshot.diagnostics[0]?.code, 'project-load-failed');
+      assert.ok(snapshot.diagnostics[0]?.message.includes('boom'));
+      service.dispose();
+    });
+  });
+
+  suite('IndexService and FastIndexer fixtures', () => {
+    test('indexes modules, packages, macros, and includes across fixture files', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+      const index = await buildIndex(snapshot);
+
+      assert.strictEqual(index.findModules('top').length, 1);
+      assert.strictEqual(index.findModules('foo_core').length, 1);
+      assert.strictEqual(index.findPackages('simple_pkg').length, 1);
+      assert.strictEqual(index.findMacros('SIMPLE_DEF').length, 1);
+      assert.ok(index.getAllSymbols().some((symbol) => symbol.kind === 'include' && symbol.name === 'defs.svh'));
+    });
+
+    test('handles duplicate module names and returns all matches', async function () {
+      this.timeout(10000);
+      const root = fixtureRoot('duplicate-symbols');
+      const snapshot = await loadFixture(root, settings());
+      const index = await buildIndex(snapshot);
+
+      assert.strictEqual(index.findModules('duplicate_foo').length, 2);
+    });
+
+    test('resolves includes using current file directory and include dirs', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+      const index = await buildIndex(snapshot);
+      const resolver = new FileContextResolver(snapshot);
+      const topUri = vscode.Uri.file(path.join(root, 'rtl', 'top.sv'));
+      const context = resolver.getPreferredFileContext(topUri);
+
+      assert.ok(context);
+      assert.strictEqual(index.resolveInclude('"defs.svh"', context)?.fsPath, path.join(root, 'rtl', 'include', 'defs.svh'));
+    });
+
+    test('supports full rebuild after ProjectSnapshot changes', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const service = createStaticProjectService();
+      const indexService = new IndexService(service, new FastIndexerBackend());
+      const first = await loadFixture(root, settings({ filelists: ['files.f'] }));
+      const second = await loadFixture(fixtureRoot('nested-filelist'), settings({ filelists: ['files.f'] }));
+
+      await indexService.rebuild(first);
+      assert.strictEqual(indexService.getIndex().findModules('foo_core').length, 1);
+
+      await indexService.rebuild(second);
+      assert.strictEqual(indexService.getIndex().findModules('foo_core').length, 0);
+      assert.strictEqual(indexService.getIndex().findModules('nested_foo').length, 1);
+      indexService.dispose();
+    });
+
+    test('degrades to an empty index when backend throws', async () => {
+      const service = createStaticProjectService();
+      const indexService = new IndexService(service, {
+        build: async () => {
+          throw new Error('index failed');
+        },
+      } as unknown as FastIndexerBackend);
+
+      const index = await indexService.rebuild(createSnapshot('/workspace', []));
+
+      assert.strictEqual(index.getAllSymbols().length, 0);
+      assert.strictEqual(index.version, 1);
+      indexService.dispose();
+    });
+  });
+
+  suite('Provider fallback and project-disabled behavior', () => {
+    test('DefinitionService falls back to ctags when project index has no result', async () => {
+      const document = await vscode.workspace.openTextDocument({
+        language: 'systemverilog',
+        content: 'assign sig = 1;',
+      });
+      const range = new vscode.Range(0, 7, 0, 10);
+      const fallback: vscode.DefinitionLink[] = [
+        { targetUri: document.uri, targetRange: range, targetSelectionRange: range },
+      ];
+      const service = new DefinitionService(
+        createProjectServiceWithContext(undefined),
+        createIndexService(new SemanticIndex(1, [])),
+        { findSymbol: async () => fallback } as unknown as CtagsManager
+      );
+
+      assert.deepStrictEqual(await service.provideDefinition(document, new vscode.Position(0, 8)), fallback);
+    });
+
+    test('CompletionService falls back to ctags when project index is empty', async () => {
+      const document = await vscode.workspace.openTextDocument({
+        language: 'systemverilog',
+        content: 'logic fallback_sig;',
+      });
+      const service = new CompletionService(
+        createProjectServiceWithContext(undefined),
+        createIndexService(new SemanticIndex(1, [])),
+        {
+          getSymbols: async () => [
+            {
+              name: 'fallback_sig',
+              type: 'net',
+              startPosition: new vscode.Position(0, 0),
+              endPosition: new vscode.Position(0, 18),
+              parentScope: '',
+              parentType: '',
+              isValid: true,
+            },
+          ],
+        } as unknown as CtagsManager
+      );
+
+      const items = await service.provideCompletionItems(
+        document,
+        new vscode.Position(0, 0),
+        { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+      );
+
+      assert.ok(items.some((item) => item.label === 'fallback_sig'));
+    });
+  });
+
+  suite('Diagnostics, UX, and performance guardrails', () => {
+    test('renderProjectStatus includes project summary, diagnostics, and active editor context', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
+      const document = await vscode.workspace.openTextDocument(path.join(root, 'rtl', 'top.sv'));
+      await vscode.window.showTextDocument(document);
+      const service = createSnapshotProjectService(snapshot);
+
+      const report = renderProjectStatus(service);
+
+      assert.ok(report.includes('Project enabled: yes'));
+      assert.ok(report.includes(`Workspace root: ${root}`));
+      assert.ok(report.includes('Compile units: 1'));
+      assert.ok(report.includes('Files: 4'));
+      assert.ok(report.includes('Include dirs:'));
+      assert.ok(report.includes('Defines: SIMPLE_PROJECT'));
+      assert.ok(report.includes('## Active Editor Context'));
+      assert.ok(report.includes('Preferred: filelist:0:files.f'));
+      assert.ok(report.includes('## Diagnostics'));
+    });
+
+    test('ProjectWatcher debounces rapid reload requests', async () => {
+      const reasons: string[] = [];
+      const watcher = new ProjectWatcher({
+        reload: async (reason?: string) => {
+          reasons.push(reason ?? '');
+          return createSnapshot('/workspace', []);
+        },
+      } as unknown as ProjectService, { debounceMs: 5, watch: false });
+
+      watcher.scheduleReload('first');
+      watcher.scheduleReload('second');
+      watcher.scheduleReload('third');
+      await delay(30);
+
+      assert.deepStrictEqual(reasons, ['third']);
+      watcher.dispose();
+    });
+
+    test('auto-discovery excludes large ignored directories before indexing', async function () {
+      this.timeout(10000);
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-large-workspace-'));
+      fs.mkdirSync(path.join(root, 'rtl'), { recursive: true });
+      fs.mkdirSync(path.join(root, 'build'), { recursive: true });
+      for (let i = 0; i < 30; i += 1) {
+        fs.writeFileSync(path.join(root, 'build', `skip_${i}.sv`), `module skip_${i}; endmodule\n`);
+      }
+      fs.writeFileSync(path.join(root, 'rtl', 'keep.sv'), 'module keep; endmodule\n');
+      const snapshot = await loadFixture(root, settings({ exclude: ['**/build/**'] }));
+      const index = await buildIndex(snapshot);
+
+      assert.strictEqual(snapshot.compileUnits[0]?.files.length, 1);
+      assert.strictEqual(index.findModules('keep').length, 1);
+      assert.strictEqual(index.getAllModules().some((moduleRecord) => moduleRecord.name.startsWith('skip_')), false);
+    });
+  });
+});
+
+function fixtureRoot(name: string): string {
+  return path.join(process.cwd(), 'test', 'fixtures', 'hdl-projects', name);
+}
+
+function settings(overrides: Partial<ProjectSettings> = {}): ProjectSettings {
+  return {
+    enabled: true,
+    filelists: [],
+    activeTarget: '',
+    includeDirs: [],
+    defines: {},
+    exclude: ['**/.git/**', '**/node_modules/**', '**/build/**', '**/sim/**'],
+    ...overrides,
+  };
+}
+
+async function loadFixture(root: string, projectSettings: ProjectSettings): Promise<ProjectSnapshot> {
+  const loader = new ProjectLoader(
+    { getSettings: () => projectSettings },
+    undefined,
+    () => [{ uri: vscode.Uri.file(root), name: path.basename(root), index: 0 }]
+  );
+  return loader.load(1);
+}
+
+async function buildIndex(snapshot: ProjectSnapshot): Promise<SemanticIndex> {
+  return new SemanticIndex(snapshot.version, await new FastIndexerBackend().build(snapshot));
+}
+
+function createStaticProjectService(): ProjectService {
+  return {
+    onDidChangeSnapshot: () => ({ dispose: () => undefined }),
+  } as unknown as ProjectService;
+}
+
+function createIndexService(index: SemanticIndex): IndexService {
+  return {
+    getIndex: () => index,
+  } as unknown as IndexService;
+}
+
+function createProjectServiceWithContext(context: ReturnType<FileContextResolver['getPreferredFileContext']>): ProjectService {
+  return {
+    getPreferredFileContext: () => context,
+  } as unknown as ProjectService;
+}
+
+function createSnapshotProjectService(snapshot: ProjectSnapshot): ProjectService {
+  const resolver = new FileContextResolver(snapshot);
+  return {
+    getSnapshot: () => snapshot,
+    getFileContexts: (uri: vscode.Uri) => resolver.getFileContexts(uri),
+    getPreferredFileContext: (uri: vscode.Uri) => resolver.getPreferredFileContext(uri),
+  } as unknown as ProjectService;
+}
+
+function createSnapshot(workspaceRoot: string, symbols: SymbolRecord[]): ProjectSnapshot {
+  const root = vscode.Uri.file(workspaceRoot);
+  const files = symbols.length === 0
+    ? []
+    : [{ resolvedPath: symbols[0]?.uri.fsPath ?? path.join(workspaceRoot, 'empty.sv'), kind: 'source' as const }];
+  return {
+    version: 1,
+    workspaceRoot: root,
+    activeTargetId: '',
+    compileUnits: [
+      buildCompileUnit({
+        id: 'unit',
+        name: 'unit',
+        root,
+        files,
+        includeDirs: [],
+        defines: [],
+        settingsIncludeDirs: [],
+        settingsDefines: {},
+        source: { type: 'settings' },
+      }),
+    ],
+    diagnostics: [],
+  };
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/fixtures/hdl-projects/duplicate-symbols/rtl/foo_a.sv
+++ b/test/fixtures/hdl-projects/duplicate-symbols/rtl/foo_a.sv
@@ -1,0 +1,2 @@
+module duplicate_foo;
+endmodule

--- a/test/fixtures/hdl-projects/duplicate-symbols/rtl/foo_b.sv
+++ b/test/fixtures/hdl-projects/duplicate-symbols/rtl/foo_b.sv
@@ -1,0 +1,2 @@
+module duplicate_foo;
+endmodule

--- a/test/fixtures/hdl-projects/malformed-filelist/cycle.f
+++ b/test/fixtures/hdl-projects/malformed-filelist/cycle.f
@@ -1,0 +1,1 @@
+-f cycle.f

--- a/test/fixtures/hdl-projects/malformed-filelist/files.f
+++ b/test/fixtures/hdl-projects/malformed-filelist/files.f
@@ -1,0 +1,4 @@
+-f missing_nested.f
+-f cycle.f
++incdir+missing_include_dir
+missing_source.sv

--- a/test/fixtures/hdl-projects/multi-target/include/rtl_defs.svh
+++ b/test/fixtures/hdl-projects/multi-target/include/rtl_defs.svh
@@ -1,0 +1,1 @@
+`define RTL_ONLY 1

--- a/test/fixtures/hdl-projects/multi-target/include/sim_defs.svh
+++ b/test/fixtures/hdl-projects/multi-target/include/sim_defs.svh
@@ -1,0 +1,1 @@
+`define SIM_ONLY 1

--- a/test/fixtures/hdl-projects/multi-target/rtl.f
+++ b/test/fixtures/hdl-projects/multi-target/rtl.f
@@ -1,0 +1,4 @@
++incdir+include
++define+RTL_TARGET
+include/rtl_defs.svh
+rtl/top.sv

--- a/test/fixtures/hdl-projects/multi-target/rtl/top.sv
+++ b/test/fixtures/hdl-projects/multi-target/rtl/top.sv
@@ -1,0 +1,4 @@
+`include "rtl_defs.svh"
+
+module multi_top(input logic clk);
+endmodule

--- a/test/fixtures/hdl-projects/multi-target/sim.f
+++ b/test/fixtures/hdl-projects/multi-target/sim.f
@@ -1,0 +1,5 @@
++incdir+include
++define+SIM_TARGET
+include/sim_defs.svh
+rtl/top.sv
+tb/tb_top.sv

--- a/test/fixtures/hdl-projects/multi-target/tb/tb_top.sv
+++ b/test/fixtures/hdl-projects/multi-target/tb/tb_top.sv
@@ -1,0 +1,5 @@
+`include "sim_defs.svh"
+
+module tb_top;
+  multi_top dut(.clk());
+endmodule

--- a/test/fixtures/hdl-projects/nested-filelist/files.f
+++ b/test/fixtures/hdl-projects/nested-filelist/files.f
@@ -1,0 +1,2 @@
+rtl/top.sv
+-f rtl/common.f

--- a/test/fixtures/hdl-projects/nested-filelist/include/defs.svh
+++ b/test/fixtures/hdl-projects/nested-filelist/include/defs.svh
@@ -1,0 +1,1 @@
+`define NESTED_DEF 1

--- a/test/fixtures/hdl-projects/nested-filelist/rtl/common.f
+++ b/test/fixtures/hdl-projects/nested-filelist/rtl/common.f
@@ -1,0 +1,4 @@
++incdir+../include
++define+NESTED_PROJECT
+../include/defs.svh
+foo.sv

--- a/test/fixtures/hdl-projects/nested-filelist/rtl/foo.sv
+++ b/test/fixtures/hdl-projects/nested-filelist/rtl/foo.sv
@@ -1,0 +1,2 @@
+module nested_foo(input logic clk);
+endmodule

--- a/test/fixtures/hdl-projects/nested-filelist/rtl/top.sv
+++ b/test/fixtures/hdl-projects/nested-filelist/rtl/top.sv
@@ -1,0 +1,5 @@
+`include "defs.svh"
+
+module nested_top(input logic clk);
+  nested_foo u_foo(.clk(clk));
+endmodule

--- a/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/foo.sv
+++ b/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/foo.sv
@@ -1,0 +1,2 @@
+module auto_foo;
+endmodule

--- a/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/pkg.sv
+++ b/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/pkg.sv
@@ -1,0 +1,2 @@
+package auto_pkg;
+endpackage

--- a/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/top.sv
+++ b/test/fixtures/hdl-projects/no-filelist-autodiscovery/rtl/top.sv
@@ -1,0 +1,3 @@
+module auto_top;
+  auto_foo u_foo();
+endmodule

--- a/test/fixtures/hdl-projects/simple-filelist/files.f
+++ b/test/fixtures/hdl-projects/simple-filelist/files.f
@@ -1,0 +1,6 @@
++incdir+rtl/include
++define+SIMPLE_PROJECT
+rtl/pkg.sv
+rtl/include/defs.svh
+rtl/foo.sv
+rtl/top.sv

--- a/test/fixtures/hdl-projects/simple-filelist/rtl/foo.sv
+++ b/test/fixtures/hdl-projects/simple-filelist/rtl/foo.sv
@@ -1,0 +1,3 @@
+module foo_core(input logic clk, output logic done);
+  assign done = clk;
+endmodule

--- a/test/fixtures/hdl-projects/simple-filelist/rtl/include/defs.svh
+++ b/test/fixtures/hdl-projects/simple-filelist/rtl/include/defs.svh
@@ -1,0 +1,1 @@
+`define SIMPLE_DEF 1

--- a/test/fixtures/hdl-projects/simple-filelist/rtl/pkg.sv
+++ b/test/fixtures/hdl-projects/simple-filelist/rtl/pkg.sv
@@ -1,0 +1,3 @@
+package simple_pkg;
+  typedef logic [3:0] nibble_t;
+endpackage

--- a/test/fixtures/hdl-projects/simple-filelist/rtl/top.sv
+++ b/test/fixtures/hdl-projects/simple-filelist/rtl/top.sv
@@ -1,0 +1,5 @@
+`include "defs.svh"
+
+module top(input logic clk, output logic done);
+  foo_core u_foo(.clk(clk), .done(done));
+endmodule


### PR DESCRIPTION
## Summary
- add deterministic HDL project fixtures for Minimal IDE Model integration coverage
- add stabilization tests for project loading, indexing, provider fallback, diagnostics/status output, debounce, and excluded auto-discovery paths
- harden project reload and semantic index rebuild failures so the extension degrades gracefully
- add summary logging for project loading and index rebuilds without per-symbol noise

## Validation
- `npm run check-types` passed
- `npm run lint` passed
- `npm run compile-tests` passed
- `npm test` passed: 224 passing, 3 pending