### PR TITLE
Add instance port and parameter completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -766,6 +766,35 @@
         }
       },
       {
+        "title": "Verilog: Completion",
+        "properties": {
+          "verilog.completion.ports.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable project-index completion for named module port connections."
+          },
+          "verilog.completion.parameters.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable project-index completion for named module parameter overrides."
+          },
+          "verilog.completion.autoConnectPorts": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Insert `.port(port)` snippets for named port completion."
+          },
+          "verilog.completion.autoConnectParameters": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Insert `.PARAM(PARAM)` snippets for named parameter completion."
+          }
+        }
+      },
+      {
         "title": "Verilog: Module Instantiation",
         "properties": {
           "verilog.instantiate.useProjectIndex": {

--- a/src/hdl/CompletionService.ts
+++ b/src/hdl/CompletionService.ts
@@ -7,7 +7,13 @@ import { END_OF_LINE } from '../constants';
 import type { ProjectService } from '../project/ProjectService';
 import type { FileContext } from '../project/ProjectTypes';
 import type { IndexService } from '../semantic/IndexService';
-import type { SymbolRecord } from '../semantic/SymbolRecords';
+import { scanInstanceContext, type InstanceContext } from '../semantic/InstanceContextScanner';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+interface ProjectCompletionResult {
+  items: vscode.CompletionItem[];
+  suppressFallback?: boolean;
+}
 
 export class CompletionService {
   constructor(
@@ -21,48 +27,162 @@ export class CompletionService {
     position: vscode.Position,
     context: vscode.CompletionContext
   ): Promise<vscode.CompletionItem[]> {
-    const projectItems = this.getProjectCompletionItems(document, position, context);
+    const projectResult = this.getProjectCompletionItems(document, position, context);
+    if (projectResult.suppressFallback) {
+      return projectResult.items;
+    }
     const ctagsItems = await this.getCtagsCompletionItems(document);
-    return mergeCompletionItems(projectItems, ctagsItems);
+    return mergeCompletionItems(projectResult.items, ctagsItems);
   }
 
   private getProjectCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,
     context: vscode.CompletionContext
-  ): vscode.CompletionItem[] {
+  ): ProjectCompletionResult {
     const includeContext = getIncludeCompletionContext(document, position);
     if (includeContext) {
-      return getIncludeCompletionItems(includeContext, this.projectService.getPreferredFileContext(document.uri));
+      return {
+        items: getIncludeCompletionItems(includeContext, this.projectService.getPreferredFileContext(document.uri)),
+      };
     }
 
     if (isMacroCompletionContext(document, position, context)) {
-      return this.indexService
-        .getIndex()
-        .getAllSymbols()
-        .filter((symbol) => symbol.kind === 'macro')
-        .map(macroRecordToCompletionItem);
+      return {
+        items: this.indexService
+          .getIndex()
+          .getAllSymbols()
+          .filter((symbol) => symbol.kind === 'macro')
+          .map(macroRecordToCompletionItem),
+      };
+    }
+
+    const instanceContext = scanInstanceContext(document.getText(), document.offsetAt(position));
+    if (instanceContext) {
+      if (!isInstanceCompletionEnabled(instanceContext.kind)) {
+        return { items: [] };
+      }
+      const moduleRecord = findBestModuleRecord(
+        this.indexService.getIndex().findModules(instanceContext.moduleName),
+        this.projectService.getPreferredFileContext(document.uri)?.compileUnitId
+      );
+      if (moduleRecord) {
+        return {
+          items: getInstanceCompletionItems(moduleRecord, instanceContext, document, position),
+          suppressFallback: true,
+        };
+      }
     }
 
     if (isNormalCodeCompletionContext(document, position)) {
-      return this.indexService
-        .getIndex()
-        .getAllModules()
-        .map((moduleRecord) => {
-          const item = new vscode.CompletionItem(moduleRecord.name, vscode.CompletionItemKind.Module);
-          item.detail = 'module';
-          item.documentation = new vscode.MarkdownString(moduleRecord.uri.fsPath);
-          return item;
-        });
+      return {
+        items: this.indexService
+          .getIndex()
+          .getAllModules()
+          .map((moduleRecord) => {
+            const item = new vscode.CompletionItem(moduleRecord.name, vscode.CompletionItemKind.Module);
+            item.detail = 'module';
+            item.documentation = new vscode.MarkdownString(moduleRecord.uri.fsPath);
+            return item;
+          }),
+      };
     }
 
-    return [];
+    return { items: [] };
   }
 
   private async getCtagsCompletionItems(document: vscode.TextDocument): Promise<vscode.CompletionItem[]> {
     const symbols: Symbol[] = await this.ctagsManager.getSymbols(document);
     return symbols.map((symbol) => symbolToCompletionItem(document, symbol));
   }
+}
+
+function getInstanceCompletionItems(
+  moduleRecord: ModuleRecord,
+  context: InstanceContext,
+  document: vscode.TextDocument,
+  position: vscode.Position
+): vscode.CompletionItem[] {
+  if (context.kind === 'parameters') {
+    return moduleRecord.parameters
+      .filter((parameter) => !context.connectedNames.has(parameter.name))
+      .map((parameter) => parameterRecordToCompletionItem(parameter, document, position));
+  }
+
+  return moduleRecord.ports
+    .filter((port) => !context.connectedNames.has(port.name))
+    .map((port) => portRecordToCompletionItem(port, document, position));
+}
+
+function portRecordToCompletionItem(
+  port: PortRecord,
+  document: vscode.TextDocument,
+  position: vscode.Position
+): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(port.name, vscode.CompletionItemKind.Field);
+  item.detail = ['port', port.direction, port.dataType, port.width].filter(Boolean).join(' ');
+  item.insertText = buildNamedConnectionSnippet(
+    port.name,
+    shouldAutoConnect('verilog.completion.autoConnectPorts', true),
+    hasDotBeforePosition(document, position)
+  );
+  item.documentation = new vscode.MarkdownString(port.uri.fsPath);
+  return item;
+}
+
+function parameterRecordToCompletionItem(
+  parameter: ParameterRecord,
+  document: vscode.TextDocument,
+  position: vscode.Position
+): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(parameter.name, vscode.CompletionItemKind.TypeParameter);
+  const detailParts = ['parameter', parameter.dataType, parameter.width];
+  if (parameter.defaultValue) {
+    detailParts.push(`= ${parameter.defaultValue}`);
+  }
+  item.detail = detailParts.filter(Boolean).join(' ');
+  item.insertText = buildNamedConnectionSnippet(
+    parameter.name,
+    shouldAutoConnect('verilog.completion.autoConnectParameters', true),
+    hasDotBeforePosition(document, position)
+  );
+  item.documentation = new vscode.MarkdownString(parameter.uri.fsPath);
+  return item;
+}
+
+function buildNamedConnectionSnippet(
+  name: string,
+  autoConnect: boolean,
+  dotAlreadyTyped: boolean
+): vscode.SnippetString | string {
+  if (!autoConnect) {
+    return dotAlreadyTyped ? name : `.${name}`;
+  }
+  const prefix = dotAlreadyTyped ? '' : '.';
+  return new vscode.SnippetString(`${prefix}${name}(\${1:${name}})`);
+}
+
+function hasDotBeforePosition(document: vscode.TextDocument, position: vscode.Position): boolean {
+  const before = document.lineAt(position.line).text.slice(0, position.character);
+  return /\.[A-Za-z0-9_$]*$/.test(before);
+}
+
+function shouldAutoConnect(setting: string, defaultValue: boolean): boolean {
+  return vscode.workspace.getConfiguration().get<boolean>(setting, defaultValue);
+}
+
+function isInstanceCompletionEnabled(kind: InstanceContext['kind']): boolean {
+  const setting = kind === 'parameters'
+    ? 'verilog.completion.parameters.enabled'
+    : 'verilog.completion.ports.enabled';
+  return vscode.workspace.getConfiguration().get<boolean>(setting, true);
+}
+
+function findBestModuleRecord(
+  modules: ModuleRecord[],
+  preferredCompileUnitId: string | undefined
+): ModuleRecord | undefined {
+  return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
 }
 
 export function symbolToCompletionItem(

--- a/src/semantic/InstanceContextScanner.ts
+++ b/src/semantic/InstanceContextScanner.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+
+export interface InstanceContext {
+  moduleName: string;
+  instanceName?: string;
+  kind: 'ports' | 'parameters';
+  connectedNames: Set<string>;
+}
+
+interface CandidateContext {
+  openParen: number;
+  kind: 'ports' | 'parameters';
+  moduleName: string;
+  instanceName?: string;
+}
+
+const IDENTIFIER = '[A-Za-z_][A-Za-z0-9_$]*';
+
+export function scanInstanceContext(text: string, offset: number): InstanceContext | undefined {
+  try {
+    const safeText = maskCommentsAndStrings(text);
+    const boundedOffset = Math.max(0, Math.min(offset, safeText.length));
+    const stack = getOpenParenStack(safeText, boundedOffset);
+    for (let i = stack.length - 1; i >= 0; i -= 1) {
+      const candidate = parseCandidate(safeText, stack[i] ?? 0);
+      if (!candidate) {
+        continue;
+      }
+      return {
+        moduleName: candidate.moduleName,
+        instanceName: candidate.instanceName,
+        kind: candidate.kind,
+        connectedNames: collectNamedConnections(safeText, candidate.openParen, boundedOffset),
+      };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function parseCandidate(text: string, openParen: number): CandidateContext | undefined {
+  const before = text.slice(0, openParen);
+  const previous = before.trimEnd();
+  if (previous.endsWith('#')) {
+    const moduleMatch = new RegExp(`(${IDENTIFIER})\\s*#$`).exec(previous);
+    const moduleName = moduleMatch?.[1];
+    return moduleName ? { openParen, kind: 'parameters', moduleName } : undefined;
+  }
+
+  const instanceMatch = new RegExp(`(${IDENTIFIER})\\s*$`).exec(previous);
+  const instanceName = instanceMatch?.[1];
+  if (!instanceName) {
+    return undefined;
+  }
+
+  const beforeInstance = previous.slice(0, instanceMatch.index).trimEnd();
+  const parameterOverride = findTrailingParameterOverride(beforeInstance);
+  if (parameterOverride) {
+    return {
+      openParen,
+      kind: 'ports',
+      moduleName: parameterOverride.moduleName,
+      instanceName,
+    };
+  }
+
+  const moduleMatch = new RegExp(`(${IDENTIFIER})\\s*$`).exec(beforeInstance);
+  const moduleName = moduleMatch?.[1];
+  if (!moduleName) {
+    return undefined;
+  }
+
+  return { openParen, kind: 'ports', moduleName, instanceName };
+}
+
+function findTrailingParameterOverride(text: string): { moduleName: string } | undefined {
+  const trimmed = text.trimEnd();
+  if (!trimmed.endsWith(')')) {
+    return undefined;
+  }
+
+  let depth = 0;
+  for (let i = trimmed.length - 1; i >= 0; i -= 1) {
+    const ch = trimmed[i];
+    if (ch === ')') {
+      depth += 1;
+    } else if (ch === '(') {
+      depth -= 1;
+      if (depth === 0) {
+        const beforeOpen = trimmed.slice(0, i).trimEnd();
+        if (!beforeOpen.endsWith('#')) {
+          return undefined;
+        }
+        const moduleMatch = new RegExp(`(${IDENTIFIER})\\s*#$`).exec(beforeOpen);
+        const moduleName = moduleMatch?.[1];
+        return moduleName ? { moduleName } : undefined;
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectNamedConnections(text: string, openParen: number, offset: number): Set<string> {
+  const names = new Set<string>();
+  const segment = text.slice(openParen + 1, offset);
+  for (const match of segment.matchAll(/\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/g)) {
+    const name = match[1];
+    if (name) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+function getOpenParenStack(text: string, offset: number): number[] {
+  const stack: number[] = [];
+  for (let i = 0; i < offset; i += 1) {
+    const ch = text[i];
+    if (ch === '(') {
+      stack.push(i);
+    } else if (ch === ')') {
+      stack.pop();
+    }
+  }
+  return stack;
+}
+
+function maskCommentsAndStrings(text: string): string {
+  let result = '';
+  let index = 0;
+  while (index < text.length) {
+    const ch = text[index] ?? '';
+    const next = text[index + 1] ?? '';
+    if (ch === '/' && next === '/') {
+      result += '  ';
+      index += 2;
+      while (index < text.length && text[index] !== '\n') {
+        result += ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      result += '  ';
+      index += 2;
+      while (index < text.length) {
+        const blockCh = text[index] ?? '';
+        const blockNext = text[index + 1] ?? '';
+        if (blockCh === '*' && blockNext === '/') {
+          result += '  ';
+          index += 2;
+          break;
+        }
+        result += blockCh === '\n' ? '\n' : ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      result += ' ';
+      index += 1;
+      while (index < text.length) {
+        const stringCh = text[index] ?? '';
+        result += stringCh === '\n' ? '\n' : ' ';
+        if (stringCh === '\\' && index + 1 < text.length) {
+          result += text[index + 1] === '\n' ? '\n' : ' ';
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (stringCh === '"') {
+          break;
+        }
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}

--- a/src/semantic/SymbolRecords.ts
+++ b/src/semantic/SymbolRecords.ts
@@ -26,10 +26,16 @@ export interface SymbolRecord {
 
 export interface ParameterRecord extends SymbolRecord {
   kind: 'parameter' | 'localparam';
+  dataType?: string;
+  width?: string;
+  defaultValue?: string;
 }
 
 export interface PortRecord extends SymbolRecord {
   kind: 'port';
+  direction?: 'input' | 'output' | 'inout' | 'ref' | 'interface' | 'unknown';
+  dataType?: string;
+  width?: string;
 }
 
 export interface ModuleRecord extends SymbolRecord {

--- a/src/semantic/backends/FastScanner.ts
+++ b/src/semantic/backends/FastScanner.ts
@@ -139,6 +139,10 @@ export class FastScanner {
         moduleRecord.ports.push(port);
         symbols.push(port);
       }
+      for (const port of findNonAnsiPorts(stripped, original, uri, compileUnitId, lineStarts, moduleName, moduleRecord)) {
+        moduleRecord.ports.push(port);
+        symbols.push(port);
+      }
     }
   }
 }
@@ -153,16 +157,27 @@ function findHeaderParameters(
   moduleName: string
 ): ParameterRecord[] {
   const parameters: ParameterRecord[] = [];
-  const pattern = /\b(parameter|localparam)\b([^,)]*)/g;
-  for (const match of header.matchAll(pattern)) {
-    const name = findDeclaredName(match[2] ?? '');
-    if (!name) {
+  const parameterList = findParameterList(header);
+  if (!parameterList) {
+    return parameters;
+  }
+  for (const declaration of splitTopLevelCommas(parameterList.text)) {
+    const match = /\b(parameter|localparam)\b([\s\S]*)/.exec(declaration);
+    if (!match) {
       continue;
     }
-    const start = headerStart + (match.index ?? 0) + match[0].lastIndexOf(name);
+    const parsed = parseParameterDeclaration(match[1] as 'parameter' | 'localparam', match[2] ?? '');
+    if (!parsed) {
+      continue;
+    }
+    const relativeStart = parameterList.start + declaration.indexOf(parsed.name);
+    const start = headerStart + relativeStart;
     parameters.push({
-      ...createSymbol(match[1] as 'parameter' | 'localparam', name, original, uri, compileUnitId, lineStarts, start, moduleName),
-      kind: match[1] as 'parameter' | 'localparam',
+      ...createSymbol(parsed.kind, parsed.name, original, uri, compileUnitId, lineStarts, start, moduleName),
+      kind: parsed.kind,
+      dataType: parsed.dataType,
+      width: parsed.width,
+      defaultValue: parsed.defaultValue,
     });
   }
   return parameters;
@@ -184,16 +199,195 @@ function findHeaderPorts(
   moduleName: string
 ): PortRecord[] {
   const ports: PortRecord[] = [];
-  const pattern = /\b(?:input|output|inout|ref)\b[^,)]*?\b([A-Za-z_][A-Za-z0-9_$]*)\b\s*(?=[,)])/g;
-  for (const match of header.matchAll(pattern)) {
-    const name = match[1] ?? '';
-    const start = headerStart + (match.index ?? 0) + match[0].lastIndexOf(name);
+  const portList = findPortList(header);
+  if (!portList) {
+    return ports;
+  }
+  for (const declaration of splitTopLevelCommas(portList.text)) {
+    const parsed = parsePortDeclaration(declaration);
+    if (!parsed || parsed.direction === 'unknown') {
+      continue;
+    }
+    const start = headerStart + portList.start + declaration.lastIndexOf(parsed.name);
     ports.push({
-      ...createSymbol('port', name, original, uri, compileUnitId, lineStarts, start, moduleName),
+      ...createSymbol('port', parsed.name, original, uri, compileUnitId, lineStarts, start, moduleName),
       kind: 'port',
+      direction: parsed.direction,
+      dataType: parsed.dataType,
+      width: parsed.width,
     });
   }
   return ports;
+}
+
+function findNonAnsiPorts(
+  stripped: string,
+  original: string,
+  uri: vscode.Uri,
+  compileUnitId: string,
+  lineStarts: number[],
+  moduleName: string,
+  moduleRecord: ModuleRecord
+): PortRecord[] {
+  const modulePattern = new RegExp(`\\bmodule\\s+${escapeRegExp(moduleName)}[\\s\\S]*?;([\\s\\S]*?)\\bendmodule\\b`, 'g');
+  const match = modulePattern.exec(stripped);
+  if (!match) {
+    return [];
+  }
+  const body = match[1] ?? '';
+  const bodyStart = (match.index ?? 0) + match[0].indexOf(body);
+  const existing = new Set(moduleRecord.ports.map((port) => port.name));
+  const ports: PortRecord[] = [];
+  // TODO: This intentionally handles only simple one-line non-ANSI port declarations.
+  const declarationPattern = /\b(input|output|inout|ref)\b([^;]*);/g;
+  for (const declarationMatch of body.matchAll(declarationPattern)) {
+    const direction = declarationMatch[1] as PortRecord['direction'];
+    const tail = declarationMatch[2] ?? '';
+    for (const declaration of splitTopLevelCommas(tail)) {
+      const parsed = parsePortDeclaration(`${direction} ${declaration}`);
+      if (!parsed || existing.has(parsed.name)) {
+        continue;
+      }
+      existing.add(parsed.name);
+      const start = bodyStart + (declarationMatch.index ?? 0) + declarationMatch[0].lastIndexOf(parsed.name);
+      ports.push({
+        ...createSymbol('port', parsed.name, original, uri, compileUnitId, lineStarts, start, moduleName),
+        kind: 'port',
+        direction: parsed.direction,
+        dataType: parsed.dataType,
+        width: parsed.width,
+      });
+    }
+  }
+  return ports;
+}
+
+interface ParenthesizedSegment {
+  text: string;
+  start: number;
+}
+
+function findParameterList(header: string): ParenthesizedSegment | undefined {
+  const hashIndex = header.indexOf('#');
+  if (hashIndex < 0) {
+    return undefined;
+  }
+  const openIndex = header.indexOf('(', hashIndex);
+  return openIndex >= 0 ? readParenthesized(header, openIndex) : undefined;
+}
+
+function findPortList(header: string): ParenthesizedSegment | undefined {
+  const segments = findParenthesizedSegments(header);
+  if (segments.length === 0) {
+    return undefined;
+  }
+  return header.trimStart().startsWith('#') ? segments[1] : segments[0];
+}
+
+function findParenthesizedSegments(text: string): ParenthesizedSegment[] {
+  const segments: ParenthesizedSegment[] = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] !== '(') {
+      continue;
+    }
+    const segment = readParenthesized(text, i);
+    if (segment) {
+      segments.push(segment);
+      i = segment.start + segment.text.length;
+    }
+  }
+  return segments;
+}
+
+function readParenthesized(text: string, openIndex: number): ParenthesizedSegment | undefined {
+  let depth = 0;
+  for (let i = openIndex; i < text.length; i += 1) {
+    if (text[i] === '(') {
+      depth += 1;
+    } else if (text[i] === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return { text: text.slice(openIndex + 1, i), start: openIndex + 1 };
+      }
+    }
+  }
+  return undefined;
+}
+
+function splitTopLevelCommas(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth += 1;
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === ',' && depth === 0) {
+      parts.push(text.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  const finalPart = text.slice(start).trim();
+  if (finalPart.length > 0) {
+    parts.push(finalPart);
+  }
+  return parts;
+}
+
+function parseParameterDeclaration(
+  kind: 'parameter' | 'localparam',
+  tail: string
+): Pick<ParameterRecord, 'kind' | 'name' | 'dataType' | 'width' | 'defaultValue'> | undefined {
+  const [left = '', ...defaultParts] = tail.split('=');
+  const name = findDeclaredName(left);
+  if (!name) {
+    return undefined;
+  }
+  const prefix = left.slice(0, left.lastIndexOf(name)).trim();
+  return {
+    kind,
+    name,
+    dataType: cleanDataType(prefix),
+    width: findWidth(prefix),
+    defaultValue: defaultParts.join('=').trim() || undefined,
+  };
+}
+
+function parsePortDeclaration(
+  declaration: string
+): Pick<PortRecord, 'name' | 'direction' | 'dataType' | 'width'> | undefined {
+  const match = /\b(input|output|inout|ref)\b([\s\S]*)/.exec(declaration);
+  if (!match) {
+    return undefined;
+  }
+  const direction = match[1] as PortRecord['direction'];
+  const tail = match[2] ?? '';
+  const name = findDeclaredName(tail);
+  if (!name) {
+    return undefined;
+  }
+  const prefix = tail.slice(0, tail.lastIndexOf(name)).trim();
+  return {
+    name,
+    direction,
+    dataType: cleanDataType(prefix),
+    width: findWidth(prefix),
+  };
+}
+
+function cleanDataType(text: string): string | undefined {
+  const dataType = text.replace(/\[[^\]]+\]/g, '').trim().replace(/\s+/g, ' ');
+  return dataType.length > 0 ? dataType : undefined;
+}
+
+function findWidth(text: string): string | undefined {
+  return text.match(/\[[^\]]+\]/)?.[0];
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
 }
 
 function createSymbol(

--- a/src/test/completionService.test.ts
+++ b/src/test/completionService.test.ts
@@ -10,7 +10,7 @@ import type { ProjectService } from '../project/ProjectService';
 import type { FileContext } from '../project/ProjectTypes';
 import type { IndexService } from '../semantic/IndexService';
 import { SemanticIndex } from '../semantic/SemanticIndex';
-import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
 
 suite('CompletionService', () => {
   test('completes module names from project index', async () => {
@@ -90,6 +90,98 @@ suite('CompletionService', () => {
     assert.ok(items.some((item) => item.label === 'nested/'));
   });
 
+  test('completes only target module ports and excludes already connected ports', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'foo u_foo (',
+        '  .clk(clk),',
+        '  .da',
+        ');',
+      ].join('\n'),
+    });
+    const service = createCompletionService([
+      createModuleRecord('foo', [
+        createPortRecord('clk', 'input'),
+        createPortRecord('data_i', 'input', 'logic', '[7:0]'),
+      ]),
+      createModuleRecord('bar', [
+        createPortRecord('bar_port', 'output'),
+      ]),
+    ]);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(2, 5),
+      { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+    );
+
+    assert.ok(items.some((item) => item.label === 'data_i'));
+    assert.ok(!items.some((item) => item.label === 'clk'));
+    assert.ok(!items.some((item) => item.label === 'bar_port'));
+    const item = items.find((completionItem) => completionItem.label === 'data_i');
+    assert.strictEqual(item?.kind, vscode.CompletionItemKind.Field);
+    assert.ok(item?.detail?.includes('input'));
+    assert.ok(item?.detail?.includes('[7:0]'));
+    assert.strictEqual((item?.insertText as vscode.SnippetString).value, 'data_i(${1:data_i})');
+  });
+
+  test('completes only target module parameters and excludes already overridden parameters', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'foo #(',
+        '  .WIDTH(32),',
+        '  .DE',
+        ') u_foo ();',
+      ].join('\n'),
+    });
+    const service = createCompletionService([
+      createModuleRecord('foo', [], [
+        createParameterRecord('WIDTH', 'int', undefined, '32'),
+        createParameterRecord('DEPTH', undefined, undefined, '4'),
+      ]),
+    ]);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(2, 5),
+      { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+    );
+
+    assert.ok(items.some((item) => item.label === 'DEPTH'));
+    assert.ok(!items.some((item) => item.label === 'WIDTH'));
+    const item = items.find((completionItem) => completionItem.label === 'DEPTH');
+    assert.strictEqual(item?.kind, vscode.CompletionItemKind.TypeParameter);
+    assert.ok(item?.detail?.includes('= 4'));
+    assert.strictEqual((item?.insertText as vscode.SnippetString).value, 'DEPTH(${1:DEPTH})');
+  });
+
+  test('builds dotted snippets when dot has not already been typed', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'foo u_foo (',
+        '  ',
+        ');',
+      ].join('\n'),
+    });
+    const service = createCompletionService([
+      createModuleRecord('foo', [
+        createPortRecord('clk', 'input'),
+      ]),
+    ]);
+
+    const items = await service.provideCompletionItems(
+      document,
+      new vscode.Position(1, 2),
+      { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+    );
+
+    const item = items.find((completionItem) => completionItem.label === 'clk');
+    assert.strictEqual((item?.insertText as vscode.SnippetString).value, '.clk(${1:clk})');
+  });
+
   test('preserves ctags completion fallback', async () => {
     const document = await vscode.workspace.openTextDocument({
       language: 'systemverilog',
@@ -119,6 +211,50 @@ suite('CompletionService', () => {
     assert.ok(item, 'Expected ctags fallback completion');
     assert.strictEqual(item.kind, vscode.CompletionItemKind.Variable);
   });
+
+  test('falls back to ctags when port completion is disabled', async () => {
+    const config = vscode.workspace.getConfiguration();
+    const previous = config.get('verilog.completion.ports.enabled');
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'foo u_foo (',
+        '  .',
+        ');',
+      ].join('\n'),
+    });
+    const service = createCompletionService([
+      createModuleRecord('foo', [
+        createPortRecord('clk', 'input'),
+      ]),
+    ], undefined, {
+      getSymbols: async () => [
+        {
+          name: 'fallback_sig',
+          type: 'net',
+          startPosition: new vscode.Position(0, 0),
+          endPosition: new vscode.Position(0, 12),
+          parentScope: '',
+          parentType: '',
+          isValid: true,
+        },
+      ],
+    } as unknown as CtagsManager);
+
+    try {
+      await config.update('verilog.completion.ports.enabled', false, vscode.ConfigurationTarget.Global);
+      const items = await service.provideCompletionItems(
+        document,
+        new vscode.Position(1, 3),
+        { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: undefined }
+      );
+
+      assert.ok(!items.some((item) => item.label === 'clk'));
+      assert.ok(items.some((item) => item.label === 'fallback_sig'));
+    } finally {
+      await config.update('verilog.completion.ports.enabled', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
 });
 
 function createCompletionService(
@@ -135,12 +271,46 @@ function createCompletionService(
   return new CompletionService(projectService, indexService, ctagsManager);
 }
 
-function createModuleRecord(name: string): ModuleRecord {
+function createModuleRecord(
+  name: string,
+  ports: PortRecord[] = [],
+  parameters: ParameterRecord[] = []
+): ModuleRecord {
   return {
     ...createSymbolRecord(name, 'module'),
     kind: 'module',
-    ports: [],
-    parameters: [],
+    ports,
+    parameters,
+  };
+}
+
+function createPortRecord(
+  name: string,
+  direction: PortRecord['direction'],
+  dataType?: string,
+  width?: string
+): PortRecord {
+  return {
+    ...createSymbolRecord(name, 'port'),
+    kind: 'port',
+    direction,
+    dataType,
+    width,
+  };
+}
+
+function createParameterRecord(
+  name: string,
+  dataType?: string,
+  width?: string,
+  defaultValue?: string
+): ParameterRecord {
+  return {
+    ...createSymbolRecord(name, 'parameter'),
+    kind: 'parameter',
+    dataType,
+    width,
+    defaultValue,
   };
 }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -165,5 +165,9 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
     assert.ok(properties['verilog.preprocessor.useProjectDefines']);
     assert.ok(properties['verilog.linting.useProjectContext']);
+    assert.ok(properties['verilog.completion.ports.enabled']);
+    assert.ok(properties['verilog.completion.parameters.enabled']);
+    assert.ok(properties['verilog.completion.autoConnectPorts']);
+    assert.ok(properties['verilog.completion.autoConnectParameters']);
   });
 });

--- a/src/test/instanceContextScanner.test.ts
+++ b/src/test/instanceContextScanner.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import { scanInstanceContext } from '../semantic/InstanceContextScanner';
+
+suite('InstanceContextScanner', () => {
+  test('detects simple instance port list', () => {
+    const context = scanAtCursor([
+      'foo u_foo (',
+      '  .cl|',
+      ');',
+    ].join('\n'));
+
+    assert.strictEqual(context?.moduleName, 'foo');
+    assert.strictEqual(context?.instanceName, 'u_foo');
+    assert.strictEqual(context?.kind, 'ports');
+  });
+
+  test('detects parameterized instance port list', () => {
+    const context = scanAtCursor([
+      'foo #(',
+      '  .WIDTH(32)',
+      ') u_foo (',
+      '  .cl|',
+      ');',
+    ].join('\n'));
+
+    assert.strictEqual(context?.moduleName, 'foo');
+    assert.strictEqual(context?.instanceName, 'u_foo');
+    assert.strictEqual(context?.kind, 'ports');
+  });
+
+  test('detects inline parameter override', () => {
+    const context = scanAtCursor('foo #(.WI|) u_foo ();');
+
+    assert.strictEqual(context?.moduleName, 'foo');
+    assert.strictEqual(context?.kind, 'parameters');
+  });
+
+  test('detects multiline parameter override', () => {
+    const context = scanAtCursor([
+      'foo',
+      '#(',
+      '  .WI|',
+      ')',
+      'u_foo',
+      '(',
+      ');',
+    ].join('\n'));
+
+    assert.strictEqual(context?.moduleName, 'foo');
+    assert.strictEqual(context?.kind, 'parameters');
+  });
+
+  test('detects already connected ports', () => {
+    const context = scanAtCursor([
+      'foo u_foo (',
+      '  .clk(clk),',
+      '  .rst|',
+      ');',
+    ].join('\n'));
+
+    assert.ok(context?.connectedNames.has('clk'));
+  });
+
+  test('detects already overridden parameters', () => {
+    const context = scanAtCursor([
+      'foo #(',
+      '  .WIDTH(32),',
+      '  .DE|',
+      ') u_foo ();',
+    ].join('\n'));
+
+    assert.ok(context?.connectedNames.has('WIDTH'));
+  });
+
+  test('returns undefined outside instance context', () => {
+    const context = scanAtCursor('assign value = wi|re_sig;');
+
+    assert.strictEqual(context, undefined);
+  });
+
+  test('handles malformed code safely', () => {
+    assert.doesNotThrow(() => scanAtCursor('foo #(( .WIDTH(|'));
+  });
+});
+
+function scanAtCursor(textWithCursor: string): ReturnType<typeof scanInstanceContext> {
+  const offset = textWithCursor.indexOf('|');
+  const text = textWithCursor.replace('|', '');
+  return scanInstanceContext(text, offset);
+}

--- a/src/test/instanceContextScanner.test.ts
+++ b/src/test/instanceContextScanner.test.ts
@@ -86,6 +86,6 @@ suite('InstanceContextScanner', () => {
 
 function scanAtCursor(textWithCursor: string): ReturnType<typeof scanInstanceContext> {
   const offset = textWithCursor.indexOf('|');
-  const text = textWithCursor.replace('|', '');
+  const text = textWithCursor.replace(/\|/g, '');
   return scanInstanceContext(text, offset);
 }

--- a/src/test/semanticProject.test.ts
+++ b/src/test/semanticProject.test.ts
@@ -36,6 +36,65 @@ suite('FastScanner', () => {
     assert.ok(moduleRecord.parameters.some((parameter) => parameter.name === 'WIDTH'));
   });
 
+  test('captures ANSI ports and parameters with simple metadata', () => {
+    const result = new FastScanner().scan([
+      'module foo #(',
+      '  parameter int WIDTH = 32,',
+      '  parameter DEPTH = 4',
+      ') (',
+      '  input logic clk,',
+      '  input logic [WIDTH-1:0] data_i,',
+      '  output logic valid_o',
+      ');',
+      'endmodule',
+    ].join('\n'), vscode.Uri.file('/workspace/foo.sv'), 'unit');
+    const moduleRecord = result.symbols.find(
+      (symbol): symbol is ModuleRecord => symbol.kind === 'module' && symbol.name === 'foo'
+    );
+
+    assert.ok(moduleRecord);
+    assert.deepStrictEqual(
+      moduleRecord.parameters.map((parameter) => [parameter.name, parameter.dataType, parameter.defaultValue]),
+      [
+        ['WIDTH', 'int', '32'],
+        ['DEPTH', undefined, '4'],
+      ]
+    );
+    assert.deepStrictEqual(
+      moduleRecord.ports.map((port) => [port.name, port.direction, port.dataType, port.width]),
+      [
+        ['clk', 'input', 'logic', undefined],
+        ['data_i', 'input', 'logic', '[WIDTH-1:0]'],
+        ['valid_o', 'output', 'logic', undefined],
+      ]
+    );
+  });
+
+  test('captures simple non-ANSI port declarations', () => {
+    const result = new FastScanner().scan([
+      'module foo(clk, rst_n, data_i, valid_o);',
+      '  input clk;',
+      '  input rst_n;',
+      '  input [7:0] data_i;',
+      '  output valid_o;',
+      'endmodule',
+    ].join('\n'), vscode.Uri.file('/workspace/foo.sv'), 'unit');
+    const moduleRecord = result.symbols.find(
+      (symbol): symbol is ModuleRecord => symbol.kind === 'module' && symbol.name === 'foo'
+    );
+
+    assert.ok(moduleRecord);
+    assert.deepStrictEqual(
+      moduleRecord.ports.map((port) => [port.name, port.direction, port.width]),
+      [
+        ['clk', 'input', undefined],
+        ['rst_n', 'input', undefined],
+        ['data_i', 'input', '[7:0]'],
+        ['valid_o', 'output', undefined],
+      ]
+    );
+  });
+
   test('does not throw on malformed SystemVerilog', () => {
     const result = new FastScanner().scan('module ; /* unterminated', vscode.Uri.file('/bad.sv'), 'unit');
     assert.deepStrictEqual(result.symbols, []);


### PR DESCRIPTION
## Summary
- add a lightweight instance context scanner for named module port and parameter override completion
- extend FastScanner module records with simple port/parameter metadata for direction, width, type, and default values
- add project-index completions for named ports and parameters with snippet insertion and duplicate connection filtering
- add completion settings to enable/disable port and parameter completions and auto-connect snippets

## Validation
- `npm run check-types` passed
- `npm run lint` passed
- `npm run compile-tests` passed
- `npm test` passed: 238 passing, 3 pending