### PR TITLE
Add module instance code actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -795,6 +795,29 @@
         }
       },
       {
+        "title": "Verilog: Code Actions",
+        "properties": {
+          "verilog.codeActions.fillMissingPorts.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable code actions that fill missing named module port connections from the project index."
+          },
+          "verilog.codeActions.fillMissingParameters.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable code actions that fill missing named module parameter overrides from the project index."
+          },
+          "verilog.codeActions.alignment.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Align generated named module port and parameter connections in code actions."
+          }
+        }
+      },
+      {
         "title": "Verilog: Module Instantiation",
         "properties": {
           "verilog.instantiate.useProjectIndex": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as DocumentSymbolProvider from './providers/DocumentSymbolProvider';
 import * as HoverProvider from './providers/HoverProvider';
 import * as DefinitionProvider from './providers/DefinitionProvider';
 import * as CompletionItemProvider from './providers/CompletionItemProvider';
+import * as CodeActionProvider from './providers/CodeActionProvider';
 import * as ModuleInstantiation from './commands/ModuleInstantiation';
 import { registerDoctorCommand } from './commands/Doctor';
 import * as FormatProvider from './providers/FormatProvider';
@@ -20,6 +21,7 @@ import { InactivePreprocessorDecorationProvider } from './providers/InactivePrep
 import { DefinitionService } from './hdl/DefinitionService';
 import { InstantiationService } from './hdl/InstantiationService';
 import { CompletionService } from './hdl/CompletionService';
+import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
@@ -51,6 +53,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const definitionService = new DefinitionService(projectService, indexService, ctagsManager);
   const instantiationService = new InstantiationService(indexService);
   const completionService = new CompletionService(projectService, indexService, ctagsManager);
+  const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
   context.subscriptions.push(projectService, indexService, new ProjectWatcher(projectService));
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
   void projectService.reload('activation');
@@ -136,6 +139,24 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerWorkspaceSymbolProvider(
       new VerilogWorkspaceSymbolProvider(indexService)
+    )
+  );
+
+  const verilogCodeActionProvider = new CodeActionProvider.VerilogCodeActionProvider(
+    codeActionService
+  );
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      { scheme: 'file', language: 'verilog' },
+      verilogCodeActionProvider,
+      { providedCodeActionKinds: CodeActionProvider.VerilogCodeActionProvider.providedCodeActionKinds }
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      { scheme: 'file', language: 'systemverilog' },
+      verilogCodeActionProvider,
+      { providedCodeActionKinds: CodeActionProvider.VerilogCodeActionProvider.providedCodeActionKinds }
     )
   );
 

--- a/src/hdl/ModuleInstanceCodeActionService.ts
+++ b/src/hdl/ModuleInstanceCodeActionService.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ProjectService } from '../project/ProjectService';
+import type { IndexService } from '../semantic/IndexService';
+import { scanInstanceContext, type InstanceConnection, type InstanceContext } from '../semantic/InstanceContextScanner';
+import type { ModuleRecord, ParameterRecord, PortRecord } from '../semantic/SymbolRecords';
+
+const FILL_MISSING_PORTS_TITLE = 'Verilog: Fill Missing Ports';
+const FILL_MISSING_PARAMETERS_TITLE = 'Verilog: Fill Missing Parameters';
+
+export interface ConnectionRenderOptions {
+  newline: string;
+  indent: string;
+  closingIndent: string;
+  align: boolean;
+  trailingComma: boolean;
+}
+
+interface RenderConnection {
+  name: string;
+  expressionText: string;
+}
+
+interface FillActionBuildResult {
+  title: string;
+  edit: vscode.WorkspaceEdit;
+}
+
+export class ModuleInstanceCodeActionService {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService
+  ) {}
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range
+  ): vscode.CodeAction[] {
+    const text = document.getText();
+    const context = scanInstanceContext(text, document.offsetAt(range.start));
+    if (!context || context.listCloseOffset === undefined) {
+      return [];
+    }
+
+    const moduleRecord = findBestModuleRecord(
+      this.indexService.getIndex().findModules(context.moduleName),
+      this.projectService.getPreferredFileContext(document.uri)?.compileUnitId
+    );
+    if (!moduleRecord) {
+      return [];
+    }
+
+    const actions: vscode.CodeAction[] = [];
+    const portAction = this.buildFillMissingPortsAction(document, text, context, moduleRecord);
+    if (portAction) {
+      actions.push(createCodeAction(portAction));
+    }
+    const parameterAction = this.buildFillMissingParametersAction(document, text, context, moduleRecord);
+    if (parameterAction) {
+      actions.push(createCodeAction(parameterAction));
+    }
+    return actions;
+  }
+
+  private buildFillMissingPortsAction(
+    document: vscode.TextDocument,
+    text: string,
+    context: InstanceContext,
+    moduleRecord: ModuleRecord
+  ): FillActionBuildResult | undefined {
+    if (context.kind !== 'ports' || !isSettingEnabled('verilog.codeActions.fillMissingPorts.enabled')) {
+      return undefined;
+    }
+    const missingPorts = moduleRecord.ports.filter((port) => !context.connectedNames.has(port.name));
+    if (missingPorts.length === 0) {
+      return undefined;
+    }
+    return {
+      title: FILL_MISSING_PORTS_TITLE,
+      edit: buildFillMissingEdit(
+        document,
+        text,
+        context,
+        moduleRecord.ports,
+        missingPorts.map((port) => port.name)
+      ),
+    };
+  }
+
+  private buildFillMissingParametersAction(
+    document: vscode.TextDocument,
+    text: string,
+    context: InstanceContext,
+    moduleRecord: ModuleRecord
+  ): FillActionBuildResult | undefined {
+    if (context.kind !== 'parameters' || !isSettingEnabled('verilog.codeActions.fillMissingParameters.enabled')) {
+      return undefined;
+    }
+    const missingParameters = moduleRecord.parameters.filter((parameter) => !context.connectedNames.has(parameter.name));
+    if (missingParameters.length === 0) {
+      return undefined;
+    }
+    return {
+      title: FILL_MISSING_PARAMETERS_TITLE,
+      edit: buildFillMissingEdit(
+        document,
+        text,
+        context,
+        moduleRecord.parameters,
+        missingParameters.map((parameter) => parameter.name)
+      ),
+    };
+  }
+}
+
+export function buildFillMissingEdit(
+  document: vscode.TextDocument,
+  text: string,
+  context: InstanceContext,
+  declarations: Array<PortRecord | ParameterRecord>,
+  missingNames: string[]
+): vscode.WorkspaceEdit {
+  const closeOffset = context.listCloseOffset ?? context.listOpenOffset + 1;
+  const renderOptions = getConnectionRenderOptions(document, context);
+  const rendered = renderConnectionBody(
+    buildRenderConnections(text, context.connections, declarations, missingNames),
+    renderOptions
+  );
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(
+    document.uri,
+    new vscode.Range(document.positionAt(context.listOpenOffset + 1), document.positionAt(closeOffset)),
+    rendered
+  );
+  return edit;
+}
+
+export function renderConnectionBody(
+  connections: RenderConnection[],
+  options: ConnectionRenderOptions
+): string {
+  if (connections.length === 0) {
+    return '';
+  }
+  const maxNameLength = options.align
+    ? Math.max(...connections.map((connection) => connection.name.length))
+    : 0;
+  const lines = connections.map((connection, index) => {
+    const padding = options.align ? ' '.repeat(maxNameLength - connection.name.length) : '';
+    const comma = index < connections.length - 1 || options.trailingComma ? ',' : '';
+    return `${options.indent}.${connection.name}${padding}(${connection.expressionText})${comma}`;
+  });
+  return `${options.newline}${lines.join(options.newline)}${options.newline}${options.closingIndent}`;
+}
+
+function buildRenderConnections(
+  text: string,
+  existingConnections: InstanceConnection[],
+  declarations: Array<PortRecord | ParameterRecord>,
+  missingNames: string[]
+): RenderConnection[] {
+  const existingNames = new Set(existingConnections.map((connection) => connection.name));
+  const missingNameSet = new Set(missingNames);
+  return existingConnections
+    .map((connection) => ({
+      name: connection.name,
+      expressionText: text.slice(connection.expressionStartOffset, connection.expressionEndOffset).trim(),
+    }))
+    .concat(
+      declarations
+        .filter((declaration) => missingNameSet.has(declaration.name) && !existingNames.has(declaration.name))
+        .map((declaration) => ({
+          name: declaration.name,
+          expressionText: declaration.name,
+        }))
+    );
+}
+
+function getConnectionRenderOptions(
+  document: vscode.TextDocument,
+  context: InstanceContext
+): ConnectionRenderOptions {
+  return {
+    newline: document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n',
+    indent: getConnectionIndent(document, context),
+    closingIndent: getLineIndent(document, document.positionAt(context.listOpenOffset).line),
+    align: isSettingEnabled('verilog.codeActions.alignment.enabled'),
+    trailingComma: context.connections.length > 0
+      ? context.connections[context.connections.length - 1]?.hasTrailingComma === true
+      : false,
+  };
+}
+
+function getConnectionIndent(
+  document: vscode.TextDocument,
+  context: InstanceContext
+): string {
+  const firstConnection = context.connections[0];
+  if (firstConnection) {
+    return getLineIndent(document, document.positionAt(firstConnection.startOffset).line);
+  }
+  return getLineIndent(document, document.positionAt(context.listOpenOffset).line) + getIndentUnit(document);
+}
+
+function getIndentUnit(document: vscode.TextDocument): string {
+  const visibleEditor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.toString() === document.uri.toString());
+  const insertSpaces = visibleEditor?.options.insertSpaces ?? vscode.workspace.getConfiguration('editor', document.uri).get<boolean>('insertSpaces', true);
+  if (!insertSpaces) {
+    return '\t';
+  }
+  const tabSize = visibleEditor?.options.tabSize ?? vscode.workspace.getConfiguration('editor', document.uri).get<number>('tabSize', 2);
+  return ' '.repeat(typeof tabSize === 'number' ? tabSize : Number(tabSize) || 2);
+}
+
+function getLineIndent(document: vscode.TextDocument, line: number): string {
+  return document.lineAt(line).text.match(/^\s*/)?.[0] ?? '';
+}
+
+function createCodeAction(result: FillActionBuildResult): vscode.CodeAction {
+  const action = new vscode.CodeAction(result.title, vscode.CodeActionKind.QuickFix);
+  action.edit = result.edit;
+  return action;
+}
+
+function findBestModuleRecord(
+  modules: ModuleRecord[],
+  preferredCompileUnitId: string | undefined
+): ModuleRecord | undefined {
+  return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
+}
+
+function isSettingEnabled(setting: string): boolean {
+  return vscode.workspace.getConfiguration().get<boolean>(setting, true);
+}

--- a/src/providers/CodeActionProvider.ts
+++ b/src/providers/CodeActionProvider.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ModuleInstanceCodeActionService } from '../hdl/ModuleInstanceCodeActionService';
+import { getExtensionLogger } from '../logging';
+
+export class VerilogCodeActionProvider implements vscode.CodeActionProvider {
+  private readonly logger = getExtensionLogger('Provider', 'CodeAction');
+
+  static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+
+  constructor(private readonly codeActionService: ModuleInstanceCodeActionService) {}
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range
+  ): vscode.CodeAction[] {
+    this.logger.info('Code actions requested', { uri: document.uri.toString() });
+    const actions = this.codeActionService.provideCodeActions(document, range);
+    this.logger.info('Code actions returned', { count: actions.length });
+    return actions;
+  }
+}

--- a/src/semantic/InstanceContextScanner.ts
+++ b/src/semantic/InstanceContextScanner.ts
@@ -5,6 +5,19 @@ export interface InstanceContext {
   instanceName?: string;
   kind: 'ports' | 'parameters';
   connectedNames: Set<string>;
+  listOpenOffset: number;
+  listCloseOffset?: number;
+  connections: InstanceConnection[];
+}
+
+export interface InstanceConnection {
+  name: string;
+  expressionText: string;
+  hasTrailingComma: boolean;
+  startOffset: number;
+  endOffset: number;
+  expressionStartOffset: number;
+  expressionEndOffset: number;
 }
 
 interface CandidateContext {
@@ -30,7 +43,9 @@ export function scanInstanceContext(text: string, offset: number): InstanceConte
         moduleName: candidate.moduleName,
         instanceName: candidate.instanceName,
         kind: candidate.kind,
-        connectedNames: collectNamedConnections(safeText, candidate.openParen, boundedOffset),
+        listOpenOffset: candidate.openParen,
+        listCloseOffset: findMatchingCloseParen(safeText, candidate.openParen),
+        ...collectConnections(safeText, candidate.openParen, boundedOffset),
       };
     }
   } catch {
@@ -101,16 +116,95 @@ function findTrailingParameterOverride(text: string): { moduleName: string } | u
   return undefined;
 }
 
-function collectNamedConnections(text: string, openParen: number, offset: number): Set<string> {
-  const names = new Set<string>();
-  const segment = text.slice(openParen + 1, offset);
-  for (const match of segment.matchAll(/\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/g)) {
-    const name = match[1];
-    if (name) {
-      names.add(name);
+function collectConnections(
+  text: string,
+  openParen: number,
+  cursorOffset: number
+): Pick<InstanceContext, 'connectedNames' | 'connections'> {
+  const connectedNames = new Set<string>();
+  const connections: InstanceConnection[] = [];
+  const closeParen = findMatchingCloseParen(text, openParen) ?? text.length;
+  let index = openParen + 1;
+  while (index < closeParen) {
+    index = skipWhitespaceAndCommas(text, index, closeParen);
+    if (index >= closeParen) {
+      break;
+    }
+    if (text[index] !== '.') {
+      throw new Error('positional or mixed instance connections are not supported');
+    }
+    const connection = readNamedConnection(text, index, closeParen);
+    if (!connection) {
+      if (index <= cursorOffset) {
+        break;
+      }
+      throw new Error('malformed named instance connection');
+    }
+    connectedNames.add(connection.name);
+    connections.push(connection);
+    index = connection.hasTrailingComma ? connection.endOffset + 1 : connection.endOffset;
+  }
+  return { connectedNames, connections };
+}
+
+function readNamedConnection(
+  text: string,
+  dotOffset: number,
+  closeParen: number
+): InstanceConnection | undefined {
+  const match = /\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/.exec(text.slice(dotOffset, closeParen));
+  if (!match || match.index !== 0) {
+    return undefined;
+  }
+  const name = match[1] ?? '';
+  const expressionOpenOffset = dotOffset + match[0].length - 1;
+  const expressionCloseOffset = findMatchingCloseParen(text, expressionOpenOffset);
+  if (expressionCloseOffset === undefined || expressionCloseOffset > closeParen) {
+    return undefined;
+  }
+  const afterExpression = skipWhitespace(text, expressionCloseOffset + 1, closeParen);
+  const hasTrailingComma = text[afterExpression] === ',';
+  return {
+    name,
+    expressionText: text.slice(expressionOpenOffset + 1, expressionCloseOffset).trim(),
+    hasTrailingComma,
+    startOffset: dotOffset,
+    endOffset: expressionCloseOffset + 1,
+    expressionStartOffset: expressionOpenOffset + 1,
+    expressionEndOffset: expressionCloseOffset,
+  };
+}
+
+function findMatchingCloseParen(text: string, openParen: number): number | undefined {
+  let depth = 0;
+  for (let i = openParen; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch === '(') {
+      depth += 1;
+    } else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
     }
   }
-  return names;
+  return undefined;
+}
+
+function skipWhitespaceAndCommas(text: string, offset: number, endOffset: number): number {
+  let index = offset;
+  while (index < endOffset && (/[\s,]/.test(text[index] ?? ''))) {
+    index += 1;
+  }
+  return index;
+}
+
+function skipWhitespace(text: string, offset: number, endOffset: number): number {
+  let index = offset;
+  while (index < endOffset && (/\s/.test(text[index] ?? ''))) {
+    index += 1;
+  }
+  return index;
 }
 
 function getOpenParenStack(text: string, offset: number): number[] {

--- a/src/test/codeActionProvider.test.ts
+++ b/src/test/codeActionProvider.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import type { ModuleInstanceCodeActionService } from '../hdl/ModuleInstanceCodeActionService';
+import { VerilogCodeActionProvider } from '../providers/CodeActionProvider';
+
+suite('CodeActionProvider', () => {
+  test('returns fill-missing actions from the service', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'foo u_foo ();',
+    });
+    const action = new vscode.CodeAction('Verilog: Fill Missing Ports', vscode.CodeActionKind.QuickFix);
+    const provider = new VerilogCodeActionProvider({
+      provideCodeActions: () => [action],
+    } as unknown as ModuleInstanceCodeActionService);
+
+    const actions = provider.provideCodeActions(
+      document,
+      new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0))
+    );
+
+    assert.deepStrictEqual(actions, [action]);
+  });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -169,5 +169,8 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.completion.parameters.enabled']);
     assert.ok(properties['verilog.completion.autoConnectPorts']);
     assert.ok(properties['verilog.completion.autoConnectParameters']);
+    assert.ok(properties['verilog.codeActions.fillMissingPorts.enabled']);
+    assert.ok(properties['verilog.codeActions.fillMissingParameters.enabled']);
+    assert.ok(properties['verilog.codeActions.alignment.enabled']);
   });
 });

--- a/src/test/instanceContextScanner.test.ts
+++ b/src/test/instanceContextScanner.test.ts
@@ -60,6 +60,7 @@ suite('InstanceContextScanner', () => {
     ].join('\n'));
 
     assert.ok(context?.connectedNames.has('clk'));
+    assert.strictEqual(context?.connections[0]?.expressionText, 'clk');
   });
 
   test('detects already overridden parameters', () => {
@@ -75,6 +76,12 @@ suite('InstanceContextScanner', () => {
 
   test('returns undefined outside instance context', () => {
     const context = scanAtCursor('assign value = wi|re_sig;');
+
+    assert.strictEqual(context, undefined);
+  });
+
+  test('returns undefined for positional instance connections', () => {
+    const context = scanAtCursor('foo u_foo (cl|k);');
 
     assert.strictEqual(context, undefined);
   });

--- a/src/test/moduleInstanceCodeActionService.test.ts
+++ b/src/test/moduleInstanceCodeActionService.test.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ModuleInstanceCodeActionService } from '../hdl/ModuleInstanceCodeActionService';
+import type { ProjectService } from '../project/ProjectService';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+suite('ModuleInstanceCodeActionService', () => {
+  test('fills missing ports for a simple instance', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo u_foo (',
+      '  .clk(clk)|',
+      ');',
+    ].join('\n'));
+    const service = createService([
+      createModuleRecord('foo', [
+        createPortRecord('clk'),
+        createPortRecord('rst_n'),
+        createPortRecord('data_i'),
+        createPortRecord('valid_o'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      'foo u_foo (',
+      '  .clk    (clk),',
+      '  .rst_n  (rst_n),',
+      '  .data_i (data_i),',
+      '  .valid_o(valid_o)',
+      ');',
+    ].join('\n'));
+  });
+
+  test('fills missing ports with an existing subset', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo u_foo (',
+      '  .rst_n(reset_n)|',
+      ');',
+    ].join('\n'));
+    const service = createService([
+      createModuleRecord('foo', [
+        createPortRecord('clk'),
+        createPortRecord('rst_n'),
+        createPortRecord('valid_o'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      'foo u_foo (',
+      '  .rst_n  (reset_n),',
+      '  .clk    (clk),',
+      '  .valid_o(valid_o)',
+      ');',
+    ].join('\n'));
+  });
+
+  test('fills missing ports when no connections exist', async () => {
+    const { document, position } = await openDocumentAtCursor('foo u_foo (|);');
+    const service = createService([
+      createModuleRecord('foo', [
+        createPortRecord('clk'),
+        createPortRecord('rst_n'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      'foo u_foo (',
+      '    .clk  (clk),',
+      '    .rst_n(rst_n)',
+      ');',
+    ].join('\n'));
+  });
+
+  test('preserves indentation for filled ports', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      '  foo u_foo (',
+      '    .clk(clk)|',
+      '  );',
+    ].join('\n'));
+    const service = createService([
+      createModuleRecord('foo', [
+        createPortRecord('clk'),
+        createPortRecord('rst_n'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      '  foo u_foo (',
+      '    .clk  (clk),',
+      '    .rst_n(rst_n)',
+      '  );',
+    ].join('\n'));
+  });
+
+  test('preserves trailing comma style', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo u_foo (',
+      '  .clk(clk),|',
+      ');',
+    ].join('\n'));
+    const service = createService([
+      createModuleRecord('foo', [
+        createPortRecord('clk'),
+        createPortRecord('rst_n'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      'foo u_foo (',
+      '  .clk  (clk),',
+      '  .rst_n(rst_n),',
+      ');',
+    ].join('\n'));
+  });
+
+  test('fills missing parameters', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo #(',
+      '  .WIDTH(32)|',
+      ') u_foo ();',
+    ].join('\n'));
+    const service = createService([
+      createModuleRecord('foo', [], [
+        createParameterRecord('WIDTH'),
+        createParameterRecord('DEPTH'),
+      ]),
+    ]);
+
+    const action = getAction(service, document, position, 'Verilog: Fill Missing Parameters');
+
+    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+      'foo #(',
+      '  .WIDTH(32),',
+      '  .DEPTH(DEPTH)',
+      ') u_foo ();',
+    ].join('\n'));
+  });
+
+  test('does not return actions outside an instance', async () => {
+    const { document, position } = await openDocumentAtCursor('assign value = si|g;');
+    const service = createService([createModuleRecord('foo', [createPortRecord('clk')])]);
+
+    assert.deepStrictEqual(service.provideCodeActions(document, new vscode.Range(position, position)), []);
+  });
+
+  test('does not return actions when module is unresolved', async () => {
+    const { document, position } = await openDocumentAtCursor('foo u_foo (|);');
+    const service = createService([]);
+
+    assert.deepStrictEqual(service.provideCodeActions(document, new vscode.Range(position, position)), []);
+  });
+
+  test('does not duplicate existing ports', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo u_foo (',
+      '  .clk(clk)|',
+      ');',
+    ].join('\n'));
+    const service = createService([createModuleRecord('foo', [createPortRecord('clk')])]);
+
+    assert.deepStrictEqual(service.provideCodeActions(document, new vscode.Range(position, position)), []);
+  });
+
+  test('disabled settings suppress actions', async () => {
+    const config = vscode.workspace.getConfiguration();
+    const previous = config.get('verilog.codeActions.fillMissingPorts.enabled');
+    const { document, position } = await openDocumentAtCursor('foo u_foo (|);');
+    const service = createService([createModuleRecord('foo', [createPortRecord('clk')])]);
+
+    try {
+      await config.update('verilog.codeActions.fillMissingPorts.enabled', false, vscode.ConfigurationTarget.Global);
+      assert.deepStrictEqual(service.provideCodeActions(document, new vscode.Range(position, position)), []);
+    } finally {
+      await config.update('verilog.codeActions.fillMissingPorts.enabled', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+});
+
+async function openDocumentAtCursor(textWithCursor: string): Promise<{ document: vscode.TextDocument; position: vscode.Position }> {
+  const offset = textWithCursor.indexOf('|');
+  const text = textWithCursor.replace(/\|/g, '');
+  const document = await vscode.workspace.openTextDocument({
+    language: 'systemverilog',
+    content: text,
+  });
+  return { document, position: document.positionAt(offset) };
+}
+
+function getAction(
+  service: ModuleInstanceCodeActionService,
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  title: string
+): vscode.CodeAction {
+  const action = service
+    .provideCodeActions(document, new vscode.Range(position, position))
+    .find((codeAction) => codeAction.title === title);
+  assert.ok(action, `Expected code action: ${title}`);
+  assert.ok(action.edit, `Expected edit for code action: ${title}`);
+  return action;
+}
+
+function applyWorkspaceEdit(document: vscode.TextDocument, edit: vscode.WorkspaceEdit | undefined): string {
+  assert.ok(edit);
+  const textEdits = edit.entries().find(([uri]) => uri.toString() === document.uri.toString())?.[1] ?? [];
+  return textEdits
+    .slice()
+    .sort((a, b) => document.offsetAt(b.range.start) - document.offsetAt(a.range.start))
+    .reduce((text, textEdit) => {
+      const start = document.offsetAt(textEdit.range.start);
+      const end = document.offsetAt(textEdit.range.end);
+      return `${text.slice(0, start)}${textEdit.newText}${text.slice(end)}`;
+    }, document.getText());
+}
+
+function createService(symbols: SymbolRecord[]): ModuleInstanceCodeActionService {
+  const projectService = {
+    getPreferredFileContext: () => undefined,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => new SemanticIndex(1, symbols),
+  } as unknown as IndexService;
+  return new ModuleInstanceCodeActionService(projectService, indexService);
+}
+
+function createModuleRecord(
+  name: string,
+  ports: PortRecord[] = [],
+  parameters: ParameterRecord[] = []
+): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module'),
+    kind: 'module',
+    ports,
+    parameters,
+  };
+}
+
+function createPortRecord(name: string): PortRecord {
+  return {
+    ...createSymbolRecord(name, 'port'),
+    kind: 'port',
+  };
+}
+
+function createParameterRecord(name: string): ParameterRecord {
+  return {
+    ...createSymbolRecord(name, 'parameter'),
+    kind: 'parameter',
+  };
+}
+
+function createSymbolRecord(name: string, kind: SymbolRecord['kind']): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 0, 0, name.length);
+  return {
+    id: `${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId: 'unit',
+  };
+}


### PR DESCRIPTION
## Summary
- add project-index code actions to fill missing named module ports and parameters
- extend instance context scanning to expose connection list ranges and existing named connections
- register a Verilog/SystemVerilog code action provider and add code action settings
- add tests for scanner behavior, code action edits, provider delegation, and package settings

## Validation
- `npm run check-types` passed
- `npm run lint` passed
- `npm run compile-tests` passed
- `npm test` passed: 250 passing, 3 pending