### PR TITLE
Add project-aware HDL hover

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { DefinitionService } from './hdl/DefinitionService';
 import { InstantiationService } from './hdl/InstantiationService';
 import { CompletionService } from './hdl/CompletionService';
 import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
+import { HoverService } from './hdl/HoverService';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
@@ -54,6 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const instantiationService = new InstantiationService(indexService);
   const completionService = new CompletionService(projectService, indexService, ctagsManager);
   const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
+  const hoverService = new HoverService(projectService, indexService, ctagsManager);
   context.subscriptions.push(projectService, indexService, new ProjectWatcher(projectService));
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
   void projectService.reload('activation');
@@ -105,7 +107,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Configure Hover Providers
   const verilogHoverProvider = new HoverProvider.VerilogHoverProvider(
-    ctagsManager,
+    hoverService,
   );
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(

--- a/src/hdl/HoverService.ts
+++ b/src/hdl/HoverService.ts
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: MIT
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { CtagsManager } from '../ctags';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { scanInstanceContext, type InstanceConnection } from '../semantic/InstanceContextScanner';
+import type {
+  ModuleRecord,
+  ParameterRecord,
+  PortRecord,
+  SymbolRecord,
+} from '../semantic/SymbolRecords';
+
+const HDL_LANGUAGES = new Set(['verilog', 'systemverilog']);
+const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/;
+const HOVER_SYMBOL_KINDS = new Set<SymbolRecord['kind']>([
+  'package',
+  'interface',
+  'class',
+  'typedef',
+]);
+const MAX_HOVER_PORTS = 20;
+
+export class HoverService {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly ctagsManager: CtagsManager
+  ) {}
+
+  async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    if (HDL_LANGUAGES.has(document.languageId)) {
+      const projectHover = await this.provideProjectHover(document, position);
+      if (projectHover) {
+        return projectHover;
+      }
+    }
+    return this.provideCtagsFallbackHover(document, position);
+  }
+
+  private async provideProjectHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    try {
+      return await this.provideIncludeHover(document, position)
+        ?? await this.provideMacroHover(document, position)
+        ?? await this.provideInstanceHover(document, position)
+        ?? await this.provideModuleHover(document, position)
+        ?? await this.provideIndexedSymbolHover(document, position);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async provideModuleHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const word = getWordAtPosition(document, position);
+    if (!word) {
+      return undefined;
+    }
+    const moduleRecord = this.findBestModuleRecord(
+      this.indexService.getIndex().findModules(word.text),
+      document.uri
+    );
+    if (!moduleRecord) {
+      return undefined;
+    }
+    return new vscode.Hover(await moduleRecordToMarkdown(moduleRecord), word.range);
+  }
+
+  private async provideInstanceHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const offset = document.offsetAt(position);
+    const context = scanInstanceContext(document.getText(), offset);
+    if (!context) {
+      return undefined;
+    }
+    const connection = context.connections.find((candidate) => isOffsetOnConnectionName(candidate, offset));
+    if (!connection) {
+      return undefined;
+    }
+
+    const moduleRecord = this.findBestModuleRecord(
+      this.indexService.getIndex().findModules(context.moduleName),
+      document.uri
+    );
+    if (!moduleRecord) {
+      return undefined;
+    }
+
+    if (context.kind === 'parameters') {
+      const parameter = moduleRecord.parameters.find((candidate) => candidate.name === connection.name);
+      return parameter
+        ? new vscode.Hover(await parameterRecordToMarkdown(parameter, moduleRecord), connectionNameRange(document, connection))
+        : undefined;
+    }
+
+    const port = moduleRecord.ports.find((candidate) => candidate.name === connection.name);
+    return port
+      ? new vscode.Hover(await portRecordToMarkdown(port, moduleRecord), connectionNameRange(document, connection))
+      : undefined;
+  }
+
+  private async provideMacroHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const macro = getMacroAtPosition(document, position);
+    if (!macro) {
+      return undefined;
+    }
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    const contextDefine = fileContext?.defines[macro.name];
+    if (contextDefine) {
+      const markdown = new vscode.MarkdownString();
+      markdown.appendCodeblock(`macro ${contextDefine.name}`, 'systemverilog');
+      markdown.appendMarkdown(`\n\nvalue: ${escapeMarkdown(String(contextDefine.value))}`);
+      markdown.appendMarkdown(`\n\nsource: ${escapeMarkdown(contextDefine.source)}`);
+      if (contextDefine.location) {
+        markdown.appendMarkdown(`\n\ndefined at: ${escapeMarkdown(formatLocation(contextDefine.location))}`);
+      }
+      return new vscode.Hover(markdown, macro.range);
+    }
+
+    const sourceMacro = this.indexService.getIndex().findMacros(macro.name, fileContext).at(0);
+    if (sourceMacro) {
+      return new vscode.Hover(await macroRecordToMarkdown(sourceMacro), macro.range);
+    }
+    return undefined;
+  }
+
+  private async provideIncludeHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const include = getIncludeAtPosition(document, position);
+    if (!include) {
+      return undefined;
+    }
+    const context = this.projectService.getPreferredFileContext(document.uri) ?? createLocalFileContext(document.uri);
+    const resolved = this.indexService.getIndex().resolveInclude(include.includeText, context);
+    const markdown = new vscode.MarkdownString();
+    markdown.appendCodeblock(`include ${include.pathText}`, 'systemverilog');
+    if (resolved) {
+      markdown.appendMarkdown(`\n\nresolved to: ${escapeMarkdown(resolved.fsPath)}`);
+    } else {
+      markdown.appendMarkdown('\n\nunresolved');
+      markdown.appendMarkdown('\n\nsearched include dirs:');
+      for (const dir of getIncludeSearchDirs(document.uri, context)) {
+        markdown.appendMarkdown(`\n- ${escapeMarkdown(dir)}`);
+      }
+    }
+    return new vscode.Hover(markdown, include.range);
+  }
+
+  private async provideIndexedSymbolHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const word = getWordAtPosition(document, position);
+    if (!word) {
+      return undefined;
+    }
+    const preferredCompileUnitId = this.projectService.getPreferredFileContext(document.uri)?.compileUnitId;
+    const symbol = this.indexService
+      .getIndex()
+      .getAllSymbols()
+      .find((candidate) =>
+        HOVER_SYMBOL_KINDS.has(candidate.kind)
+        && candidate.name === word.text
+        && (!preferredCompileUnitId || candidate.compileUnitId === preferredCompileUnitId)
+      )
+      ?? this.indexService
+        .getIndex()
+        .getAllSymbols()
+        .find((candidate) => HOVER_SYMBOL_KINDS.has(candidate.kind) && candidate.name === word.text);
+    if (!symbol) {
+      return undefined;
+    }
+    return new vscode.Hover(await symbolRecordToMarkdown(symbol), word.range);
+  }
+
+  private async provideCtagsFallbackHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Hover | undefined> {
+    const matches: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, position);
+    for (const match of matches) {
+      let targetDocument = document;
+      if (match.targetUri.toString() !== document.uri.toString()) {
+        targetDocument = await vscode.workspace.openTextDocument(match.targetUri);
+      }
+      const code = targetDocument.getText(match.targetRange).trim();
+      const hoverText = new vscode.MarkdownString();
+      hoverText.appendCodeblock(code, document.languageId);
+      return new vscode.Hover(hoverText);
+    }
+    return undefined;
+  }
+
+  private findBestModuleRecord(modules: ModuleRecord[], documentUri: vscode.Uri): ModuleRecord | undefined {
+    const preferredCompileUnitId = this.projectService.getPreferredFileContext(documentUri)?.compileUnitId;
+    return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
+  }
+}
+
+async function moduleRecordToMarkdown(moduleRecord: ModuleRecord): Promise<vscode.MarkdownString> {
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(`module ${moduleRecord.name}`, 'systemverilog');
+  markdown.appendMarkdown(`\n\nDefined in: ${escapeMarkdown(formatSymbolLocation(moduleRecord))}`);
+  appendDeclaration(markdown, await readDeclarationLine(moduleRecord));
+  if (moduleRecord.parameters.length > 0) {
+    markdown.appendMarkdown('\n\nParameters:');
+    for (const parameter of moduleRecord.parameters) {
+      markdown.appendMarkdown(`\n- ${escapeMarkdown(formatParameterSummary(parameter))}`);
+    }
+  }
+  if (moduleRecord.ports.length > 0) {
+    markdown.appendMarkdown('\n\nPorts:');
+    const visiblePorts = moduleRecord.ports.slice(0, MAX_HOVER_PORTS);
+    markdown.appendCodeblock(visiblePorts.map(formatPortSummary).join('\n'), 'systemverilog');
+    const hiddenPorts = moduleRecord.ports.length - visiblePorts.length;
+    if (hiddenPorts > 0) {
+      markdown.appendMarkdown(`\n... and ${hiddenPorts} more ports`);
+    }
+  }
+  return markdown;
+}
+
+async function portRecordToMarkdown(
+  port: PortRecord,
+  moduleRecord: ModuleRecord
+): Promise<vscode.MarkdownString> {
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(`port ${port.name}`, 'systemverilog');
+  markdown.appendMarkdown(`\n\nDirection: ${escapeMarkdown(port.direction ?? 'unknown')}`);
+  markdown.appendMarkdown(`\n\nType: ${escapeMarkdown(formatType(port))}`);
+  markdown.appendMarkdown(`\n\nModule: ${escapeMarkdown(moduleRecord.name)}`);
+  markdown.appendMarkdown(`\n\nDefined in: ${escapeMarkdown(formatSymbolLocation(port))}`);
+  appendDeclaration(markdown, await readDeclarationLine(port));
+  return markdown;
+}
+
+async function parameterRecordToMarkdown(
+  parameter: ParameterRecord,
+  moduleRecord: ModuleRecord
+): Promise<vscode.MarkdownString> {
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(`parameter ${parameter.name}`, 'systemverilog');
+  if (parameter.defaultValue) {
+    markdown.appendMarkdown(`\n\nDefault: ${escapeMarkdown(parameter.defaultValue)}`);
+  }
+  if (parameter.dataType || parameter.width) {
+    markdown.appendMarkdown(`\n\nType: ${escapeMarkdown(formatType(parameter))}`);
+  }
+  markdown.appendMarkdown(`\n\nModule: ${escapeMarkdown(moduleRecord.name)}`);
+  markdown.appendMarkdown(`\n\nDefined in: ${escapeMarkdown(formatSymbolLocation(parameter))}`);
+  appendDeclaration(markdown, await readDeclarationLine(parameter));
+  return markdown;
+}
+
+async function macroRecordToMarkdown(symbol: SymbolRecord): Promise<vscode.MarkdownString> {
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(`macro ${symbol.name}`, 'systemverilog');
+  markdown.appendMarkdown(`\n\ndefined at: ${escapeMarkdown(formatSymbolLocation(symbol))}`);
+  appendDeclaration(markdown, await readDeclarationLine(symbol));
+  return markdown;
+}
+
+async function symbolRecordToMarkdown(symbol: SymbolRecord): Promise<vscode.MarkdownString> {
+  const markdown = new vscode.MarkdownString();
+  markdown.appendCodeblock(`${symbol.kind} ${symbol.name}`, 'systemverilog');
+  markdown.appendMarkdown(`\n\nDefined in: ${escapeMarkdown(formatSymbolLocation(symbol))}`);
+  appendDeclaration(markdown, await readDeclarationLine(symbol));
+  return markdown;
+}
+
+function formatParameterSummary(parameter: ParameterRecord): string {
+  const type = formatType(parameter);
+  const defaultValue = parameter.defaultValue ? ` = ${parameter.defaultValue}` : '';
+  return `${type === 'unknown' ? '' : `${type} `}${parameter.name}${defaultValue}`.trim();
+}
+
+function formatPortSummary(port: PortRecord): string {
+  return [port.direction, port.dataType, port.width, port.name].filter(Boolean).join(' ');
+}
+
+function formatType(record: PortRecord | ParameterRecord): string {
+  return [record.dataType, record.width].filter(Boolean).join(' ') || 'unknown';
+}
+
+function appendDeclaration(markdown: vscode.MarkdownString, declaration: string | undefined): void {
+  if (declaration) {
+    markdown.appendMarkdown('\n\nDeclaration:');
+    markdown.appendCodeblock(declaration, 'systemverilog');
+  }
+}
+
+async function readDeclarationLine(symbol: SymbolRecord): Promise<string | undefined> {
+  try {
+    const document = await vscode.workspace.openTextDocument(symbol.uri);
+    return document.lineAt(symbol.selectionRange.start.line).text.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function getWordAtPosition(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): { text: string; range: vscode.Range } | undefined {
+  const range = document.getWordRangeAtPosition(position, WORD_PATTERN);
+  if (!range || range.isEmpty) {
+    return undefined;
+  }
+  return { text: document.getText(range), range };
+}
+
+function getMacroAtPosition(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): { name: string; range: vscode.Range } | undefined {
+  const line = document.lineAt(position.line).text;
+  for (const match of line.matchAll(/`([A-Za-z_][A-Za-z0-9_$]*)/g)) {
+    const name = match[1] ?? '';
+    const start = (match.index ?? 0) + 1;
+    const end = start + name.length;
+    if (position.character >= start && position.character <= end) {
+      return {
+        name,
+        range: new vscode.Range(position.line, start, position.line, end),
+      };
+    }
+  }
+  return undefined;
+}
+
+interface IncludeAtPosition {
+  includeText: string;
+  pathText: string;
+  range: vscode.Range;
+}
+
+function getIncludeAtPosition(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): IncludeAtPosition | undefined {
+  const line = document.lineAt(position.line).text;
+  const includePattern = /`include\s*(["<])([^">]+)[">]/g;
+  for (const match of line.matchAll(includePattern)) {
+    const fullMatch = match[0];
+    const quote = match[1] ?? '"';
+    const pathText = match[2] ?? '';
+    const start = match.index ?? 0;
+    const pathStart = start + fullMatch.indexOf(quote) + 1;
+    const pathEnd = pathStart + pathText.length;
+    if (position.character >= pathStart && position.character <= pathEnd) {
+      return {
+        includeText: `${quote}${pathText}${quote === '<' ? '>' : quote}`,
+        pathText,
+        range: new vscode.Range(position.line, pathStart, position.line, pathEnd),
+      };
+    }
+  }
+  return undefined;
+}
+
+function isOffsetOnConnectionName(connection: InstanceConnection, offset: number): boolean {
+  return offset >= connection.startOffset + 1 && offset <= connection.startOffset + 1 + connection.name.length;
+}
+
+function connectionNameRange(document: vscode.TextDocument, connection: InstanceConnection): vscode.Range {
+  return new vscode.Range(
+    document.positionAt(connection.startOffset + 1),
+    document.positionAt(connection.startOffset + 1 + connection.name.length)
+  );
+}
+
+function createLocalFileContext(uri: vscode.Uri): FileContext {
+  return {
+    file: uri,
+    compileUnitId: '',
+    includeDirs: [],
+    defines: {},
+  };
+}
+
+function getIncludeSearchDirs(uri: vscode.Uri, context: FileContext): string[] {
+  return [path.dirname(uri.fsPath), ...context.includeDirs.map((dir) => dir.fsPath)];
+}
+
+function formatSymbolLocation(symbol: SymbolRecord): string {
+  return `${symbol.uri.fsPath}:${symbol.selectionRange.start.line + 1}`;
+}
+
+function formatLocation(location: vscode.Location): string {
+  return `${location.uri.fsPath}:${location.range.start.line + 1}`;
+}
+
+function escapeMarkdown(input: string): string {
+  return input.replace(/[\\`*_{}[\]()#+\-.!|>]/g, '\\$&');
+}

--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { CtagsManager } from '../ctags';
+import type { HoverService } from '../hdl/HoverService';
 import { getExtensionLogger } from '../logging';
 
 export class VerilogHoverProvider implements vscode.HoverProvider {
   // lang: verilog / systemverilog
   private readonly logger = getExtensionLogger('Provider', 'Hover');
-  private ctagsManager: CtagsManager;
-  constructor(ctagsManager: CtagsManager) {
-    this.ctagsManager = ctagsManager;
-  }
+  constructor(private readonly hoverService: HoverService) {}
 
   public async provideHover(
     document: vscode.TextDocument,
@@ -17,21 +14,10 @@ export class VerilogHoverProvider implements vscode.HoverProvider {
     _token: vscode.CancellationToken
   ): Promise<vscode.Hover | undefined> {
     this.logger.info(`Hover requested for ${document.uri.toString()}`);
-    const matches: vscode.DefinitionLink[] = await this.ctagsManager.findSymbol(document, position);
-    // find symbol
-    for (const i of matches) {
-      // returns the first found tag. Disregards others
-      // TODO: very basic hover implementation. Can be extended
-      let doc = document;
-      if (i.targetUri !== document.uri) {
-        doc = await vscode.workspace.openTextDocument(i.targetUri);
-      }
-      // make a range 5 more lines
-      const code = doc.getText(i.targetRange).trim();
-      const hoverText: vscode.MarkdownString = new vscode.MarkdownString();
-      hoverText.appendCodeblock(code, document.languageId);
+    const hover = await this.hoverService.provideHover(document, position);
+    if (hover) {
       this.logger.info("Hover returned");
-      return new vscode.Hover(hoverText);
+      return hover;
     }
     this.logger.warn("Hover not found");
     return undefined;

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -2,7 +2,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { VerilogHoverProvider } from '../providers/HoverProvider';
-import { CtagsManager } from '../ctags';
+import type { HoverService } from '../hdl/HoverService';
 import { END_OF_LINE } from '../constants';
 
 suite('Hover Provider', () => {
@@ -16,17 +16,15 @@ suite('Hover Provider', () => {
       new vscode.Position(0, 0),
       new vscode.Position(0, END_OF_LINE)
     );
-    const ctagsManager = {
-      findSymbol: async () => [
-        {
-          targetUri: document.uri,
-          targetRange,
-          targetSelectionRange: targetRange,
-        },
-      ],
-    } as unknown as CtagsManager;
+    const hoverService = {
+      provideHover: async () => {
+        const hoverText = new vscode.MarkdownString();
+        hoverText.appendCodeblock(document.getText(targetRange).trim(), document.languageId);
+        return new vscode.Hover(hoverText);
+      },
+    } as unknown as HoverService;
 
-    const provider = new VerilogHoverProvider(ctagsManager);
+    const provider = new VerilogHoverProvider(hoverService);
     const hover = await provider.provideHover(
       document,
       new vscode.Position(0, 8),

--- a/src/test/hoverService.test.ts
+++ b/src/test/hoverService.test.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CtagsManager } from '../ctags';
+import { HoverService } from '../hdl/HoverService';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord, SymbolRecordKind } from '../semantic/SymbolRecords';
+
+suite('HoverService', () => {
+  test('shows module hover with location, parameters, and ports', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'foo u_foo();',
+    });
+    const service = createHoverService([
+      createModuleRecord('foo', [
+        createPortRecord('clk', 'input', 'logic'),
+        createPortRecord('data_i', 'input', 'logic', '[WIDTH-1:0]'),
+      ], [
+        createParameterRecord('WIDTH', 'int', undefined, '32'),
+      ]),
+    ]);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 1));
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('module foo'));
+    assert.ok(markdown.includes('Defined in:'));
+    assert.ok(markdown.includes('WIDTH'));
+    assert.ok(markdown.includes('32'));
+    assert.ok(markdown.includes('input logic clk'));
+    assert.ok(markdown.includes('data_i'));
+  });
+
+  test('truncates large module port lists', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'wide u_wide();',
+    });
+    const ports = Array.from({ length: 25 }, (_, index) => createPortRecord(`p${index}`, 'input'));
+    const service = createHoverService([createModuleRecord('wide', ports)]);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 1));
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('p19'));
+    assert.ok(!markdown.includes('p20'));
+    assert.ok(markdown.includes('... and 5 more ports'));
+  });
+
+  test('shows port hover inside named instance connection', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo u_foo (',
+      '  .da|ta_i(signal)',
+      ');',
+    ].join('\n'));
+    const service = createHoverService([
+      createModuleRecord('foo', [
+        createPortRecord('data_i', 'input', 'logic', '[WIDTH-1:0]'),
+      ]),
+    ]);
+
+    const hover = await service.provideHover(document, position);
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('port data_i'));
+    assert.ok(markdown.includes('Direction: input'));
+    assert.ok(markdown.includes('logic'));
+    assert.ok(markdown.includes('WIDTH'));
+    assert.ok(markdown.includes('Module: foo'));
+  });
+
+  test('shows parameter hover inside named parameter override', async () => {
+    const { document, position } = await openDocumentAtCursor([
+      'foo #(',
+      '  .WI|DTH(64)',
+      ') u_foo ();',
+    ].join('\n'));
+    const service = createHoverService([
+      createModuleRecord('foo', [], [
+        createParameterRecord('WIDTH', 'int', undefined, '32'),
+      ]),
+    ]);
+
+    const hover = await service.provideHover(document, position);
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('parameter WIDTH'));
+    assert.ok(markdown.includes('Default: 32'));
+    assert.ok(markdown.includes('Type: int'));
+    assert.ok(markdown.includes('Module: foo'));
+  });
+
+  test('shows macro hover from active project define', async () => {
+    const { document, position } = await openDocumentAtCursor('`SI|M');
+    const context: FileContext = {
+      file: document.uri,
+      compileUnitId: 'unit',
+      includeDirs: [],
+      defines: {
+        SIM: {
+          name: 'SIM',
+          value: true,
+          source: 'filelist',
+        },
+      },
+    };
+    const service = createHoverService([], context);
+
+    const hover = await service.provideHover(document, position);
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('macro SIM'));
+    assert.ok(markdown.includes('value: true'));
+    assert.ok(markdown.includes('source: filelist'));
+  });
+
+  test('shows macro hover from indexed source define', async () => {
+    const { document, position } = await openDocumentAtCursor('`SRC_|MACRO');
+    const service = createHoverService([
+      createSymbolRecord('SRC_MACRO', 'macro'),
+    ]);
+
+    const hover = await service.provideHover(document, position);
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('macro SRC_MACRO'));
+    assert.ok(markdown.includes('defined at:'));
+  });
+
+  test('shows resolved include hover', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-hover-'));
+    const topPath = path.join(root, 'top.sv');
+    const includePath = path.join(root, 'defs.svh');
+    fs.writeFileSync(topPath, '`include "defs.svh"\n');
+    fs.writeFileSync(includePath, '`define SIM\n');
+    const document = await vscode.workspace.openTextDocument(topPath);
+    const service = createHoverService([]);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 11));
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('include defs.svh'));
+    assert.ok(markdown.includes('resolved to:'));
+    assert.ok(markdown.includes('defs\\.svh'));
+  });
+
+  test('shows unresolved include hover with searched include dirs', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-hover-'));
+    const src = path.join(root, 'src');
+    const inc = path.join(root, 'inc');
+    fs.mkdirSync(src);
+    fs.mkdirSync(inc);
+    const topPath = path.join(src, 'top.sv');
+    fs.writeFileSync(topPath, '`include "missing.svh"\n');
+    const document = await vscode.workspace.openTextDocument(topPath);
+    const context: FileContext = {
+      file: vscode.Uri.file(topPath),
+      compileUnitId: 'unit',
+      includeDirs: [vscode.Uri.file(inc)],
+      defines: {},
+    };
+    const service = createHoverService([], context);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 12));
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('include missing.svh'));
+    assert.ok(markdown.includes('unresolved'));
+    assert.ok(markdown.includes('searched include dirs:'));
+    assert.ok(markdown.includes('inc'));
+  });
+
+  test('shows package hover from semantic index', async () => {
+    const { document, position } = await openDocumentAtCursor('pkg|::value');
+    const service = createHoverService([
+      createSymbolRecord('pkg', 'package'),
+    ]);
+
+    const hover = await service.provideHover(document, position);
+    const markdown = getMarkdownValue(hover);
+
+    assert.ok(markdown.includes('package pkg'));
+    assert.ok(markdown.includes('Defined in:'));
+  });
+
+  test('falls back to ctags hover when no project result exists', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'assign sig = 1;',
+    });
+    const targetRange = new vscode.Range(0, 0, 0, 15);
+    let fallbackCalled = false;
+    const service = createHoverService([], undefined, {
+      findSymbol: async () => {
+        fallbackCalled = true;
+        return [{
+          targetUri: document.uri,
+          targetRange,
+          targetSelectionRange: targetRange,
+        }];
+      },
+    } as unknown as CtagsManager);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 8));
+    const markdown = getMarkdownValue(hover);
+
+    assert.strictEqual(fallbackCalled, true);
+    assert.ok(markdown.includes('assign sig = 1;'));
+  });
+
+  test('uses fallback when project context is unavailable and index is empty', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'logic fallback_sig;',
+    });
+    const targetRange = new vscode.Range(0, 0, 0, 19);
+    let fallbackCalled = false;
+    const service = createHoverService([], undefined, {
+      findSymbol: async () => {
+        fallbackCalled = true;
+        return [{
+          targetUri: document.uri,
+          targetRange,
+          targetSelectionRange: targetRange,
+        }];
+      },
+    } as unknown as CtagsManager);
+
+    const hover = await service.provideHover(document, new vscode.Position(0, 8));
+    const markdown = getMarkdownValue(hover);
+
+    assert.strictEqual(fallbackCalled, true);
+    assert.ok(markdown.includes('logic fallback_sig;'));
+  });
+});
+
+async function openDocumentAtCursor(
+  textWithCursor: string
+): Promise<{ document: vscode.TextDocument; position: vscode.Position }> {
+  const offset = textWithCursor.indexOf('|');
+  const text = textWithCursor.split('|').join('');
+  const document = await vscode.workspace.openTextDocument({
+    language: 'systemverilog',
+    content: text,
+  });
+  return { document, position: document.positionAt(offset) };
+}
+
+function getMarkdownValue(hover: vscode.Hover | undefined): string {
+  assert.ok(hover, 'Expected hover to be returned');
+  const contents = Array.isArray(hover.contents) ? hover.contents : [hover.contents];
+  const markdown = contents.find(
+    (item): item is vscode.MarkdownString => item instanceof vscode.MarkdownString
+  );
+  assert.ok(markdown, 'Expected MarkdownString hover content');
+  return markdown.value;
+}
+
+function createHoverService(
+  symbols: SymbolRecord[],
+  context?: FileContext,
+  ctagsManager: CtagsManager = { findSymbol: async () => [] } as unknown as CtagsManager
+): HoverService {
+  const projectService = {
+    getPreferredFileContext: () => context,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => new SemanticIndex(1, symbols),
+  } as unknown as IndexService;
+  return new HoverService(projectService, indexService, ctagsManager);
+}
+
+function createModuleRecord(
+  name: string,
+  ports: PortRecord[] = [],
+  parameters: ParameterRecord[] = []
+): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module'),
+    kind: 'module',
+    ports,
+    parameters,
+  };
+}
+
+function createPortRecord(
+  name: string,
+  direction?: PortRecord['direction'],
+  dataType?: string,
+  width?: string
+): PortRecord {
+  return {
+    ...createSymbolRecord(name, 'port'),
+    kind: 'port',
+    direction,
+    dataType,
+    width,
+  };
+}
+
+function createParameterRecord(
+  name: string,
+  dataType?: string,
+  width?: string,
+  defaultValue?: string
+): ParameterRecord {
+  return {
+    ...createSymbolRecord(name, 'parameter'),
+    kind: 'parameter',
+    dataType,
+    width,
+    defaultValue,
+  };
+}
+
+function createSymbolRecord(name: string, kind: SymbolRecordKind): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 0, 0, name.length);
+  return {
+    id: `${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId: 'unit',
+  };
+}


### PR DESCRIPTION
## Summary
- Add a project-aware HoverService backed by ProjectService, IndexService, SemanticIndex, and InstanceContextScanner.
- Show concise hover details for modules, instance ports and parameters, macros, includes, and indexed package-like symbols.
- Keep the existing ctags hover behavior as the fallback path.

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 261 passing, 3 pending