### PR TITLE
Add HDL Explorer hierarchy

### DIFF
--- a/package.json
+++ b/package.json
@@ -734,6 +734,15 @@
             "default": "",
             "markdownDescription": "Active HDL project target / compile unit name."
           },
+          "verilog.project.topModules": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "Top modules to use for best-effort HDL hierarchy roots. When empty, roots are inferred from module instantiations."
+          },
           "verilog.project.includeDirs": {
             "scope": "window",
             "type": "array",
@@ -762,6 +771,36 @@
               "**/sim/**"
             ],
             "markdownDescription": "Glob patterns excluded from project indexing."
+          }
+        }
+      },
+      {
+        "title": "Verilog: Hierarchy",
+        "properties": {
+          "verilog.hierarchy.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable best-effort project-aware HDL module hierarchy."
+          },
+          "verilog.hierarchy.maxDepth": {
+            "scope": "window",
+            "type": "number",
+            "default": 20,
+            "minimum": 1,
+            "markdownDescription": "Maximum recursion depth for the best-effort HDL hierarchy tree."
+          },
+          "verilog.hierarchy.showUnresolved": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Show unresolved module instantiations in the HDL hierarchy and explorer."
+          },
+          "verilog.hdlExplorer.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable the HDL Explorer tree view."
           }
         }
       },
@@ -901,6 +940,22 @@
         "title": "Verilog: Show Project Modules"
       },
       {
+        "command": "verilog.refreshHierarchy",
+        "title": "Verilog: Refresh Hierarchy"
+      },
+      {
+        "command": "verilog.refreshHdlExplorer",
+        "title": "Verilog: Refresh HDL Explorer"
+      },
+      {
+        "command": "verilog.openModuleFromExplorer",
+        "title": "Verilog: Open Module From Explorer"
+      },
+      {
+        "command": "verilog.openInstanceFromExplorer",
+        "title": "Verilog: Open Instance From Explorer"
+      },
+      {
         "command": "verilog.openFliplot",
         "title": "Verilog: Open Fliplot Waveform Viewer"
       },
@@ -909,6 +964,23 @@
         "title": "Verilog: Open Waveform"
       }
     ],
+    "views": {
+      "explorer": [
+        {
+          "id": "verilog.hdlExplorer",
+          "name": "HDL Explorer"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "verilog.refreshHdlExplorer",
+          "when": "view == verilog.hdlExplorer",
+          "group": "navigation"
+        }
+      ]
+    },
     "customEditors": [
       {
         "viewType": "verilog.fliplotEditor",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,11 +23,13 @@ import { InstantiationService } from './hdl/InstantiationService';
 import { CompletionService } from './hdl/CompletionService';
 import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
 import { HoverService } from './hdl/HoverService';
+import { HierarchyService } from './hierarchy/HierarchyService';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
 import { IndexService } from './semantic/IndexService';
 import { VerilogWorkspaceSymbolProvider } from './providers/WorkspaceSymbolProvider';
+import { HdlExplorerProvider, registerHdlExplorerCommands } from './views/HdlExplorerProvider';
 
 let ctagsManager: CtagsManager | undefined;
 const extensionID: string = 'mshr-h.veriloghdl';
@@ -56,8 +58,17 @@ export async function activate(context: vscode.ExtensionContext) {
   const completionService = new CompletionService(projectService, indexService, ctagsManager);
   const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
   const hoverService = new HoverService(projectService, indexService, ctagsManager);
-  context.subscriptions.push(projectService, indexService, new ProjectWatcher(projectService));
+  const hierarchyService = new HierarchyService(projectService, indexService);
+  const hdlExplorerProvider = new HdlExplorerProvider(projectService, indexService, hierarchyService);
+  context.subscriptions.push(projectService, indexService, hierarchyService, hdlExplorerProvider, new ProjectWatcher(projectService));
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
+  context.subscriptions.push(...registerHdlExplorerCommands(hierarchyService, hdlExplorerProvider));
+  context.subscriptions.push(
+    vscode.window.createTreeView('verilog.hdlExplorer', {
+      treeDataProvider: hdlExplorerProvider,
+      showCollapseAll: true,
+    })
+  );
   void projectService.reload('activation');
 
   // Configure Document Symbol Provider

--- a/src/hierarchy/HierarchyBuilder.ts
+++ b/src/hierarchy/HierarchyBuilder.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+import * as fs from 'fs/promises';
+import * as vscode from 'vscode';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+import type { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+import type {
+  HierarchyBuildOptions,
+  HierarchyInstanceNode,
+  HierarchyNode,
+  HierarchySnapshot,
+  ModuleInstanceRecord,
+} from './HierarchyTypes';
+import { InstanceScanner } from './InstanceScanner';
+
+export class HierarchyBuilder {
+  constructor(private readonly scanner = new InstanceScanner()) {}
+
+  async build(
+    projectSnapshot: ProjectSnapshot,
+    index: SemanticIndex,
+    options: HierarchyBuildOptions
+  ): Promise<HierarchySnapshot> {
+    if (!options.enabled || projectSnapshot.compileUnits.length === 0) {
+      return createEmptyHierarchy(projectSnapshot.version);
+    }
+
+    const instances = await this.scanInstances(projectSnapshot);
+    const modules = index.getAllModules();
+    const instancesByParent = groupInstancesByParent(instances);
+    const resolvedInstanceKeys = new Set(
+      instances
+        .map((instance) => findBestModule(index.findModules(instance.moduleName), instance.compileUnitId))
+        .filter((moduleRecord): moduleRecord is ModuleRecord => moduleRecord !== undefined)
+        .map(moduleKey)
+    );
+    const roots = selectRootModules(projectSnapshot, modules, resolvedInstanceKeys).map((moduleRecord) =>
+      buildNode(moduleRecord, index, instancesByParent, options, 0, new Set())
+    );
+    const unresolvedInstances = options.showUnresolved ? findUnresolvedInstances(instances, index) : [];
+    return {
+      version: projectSnapshot.version,
+      roots,
+      unresolvedInstances,
+      allInstances: instances.slice(),
+    };
+  }
+
+  private async scanInstances(projectSnapshot: ProjectSnapshot): Promise<ModuleInstanceRecord[]> {
+    const instances: ModuleInstanceRecord[] = [];
+    for (const compileUnit of projectSnapshot.compileUnits) {
+      for (const file of compileUnit.files) {
+        try {
+          const text = await fs.readFile(file.uri.fsPath, 'utf8');
+          instances.push(...this.scanner.scan(text, file.uri, compileUnit.id));
+        } catch {
+          // Project loading already reports missing or unreadable files; hierarchy stays best-effort.
+        }
+      }
+    }
+    return instances;
+  }
+}
+
+function buildNode(
+  moduleRecord: ModuleRecord,
+  index: SemanticIndex,
+  instancesByParent: Map<string, ModuleInstanceRecord[]>,
+  options: HierarchyBuildOptions,
+  depth: number,
+  visited: Set<string>
+): HierarchyNode {
+  const key = moduleKey(moduleRecord);
+  const nextVisited = new Set(visited);
+  nextVisited.add(key);
+  const childInstances = instancesByParent.get(key) ?? [];
+  const resolvedInstances: HierarchyInstanceNode[] = [];
+  const unresolvedInstances: HierarchyInstanceNode[] = [];
+
+  for (const instance of childInstances) {
+    const resolvedModule = findBestModule(index.findModules(instance.moduleName), instance.compileUnitId);
+    const instanceNode: HierarchyInstanceNode = {
+      instanceName: instance.instanceName,
+      moduleName: instance.moduleName,
+      resolvedModule,
+      location: new vscode.Location(instance.uri, instance.selectionRange),
+    };
+    if (!resolvedModule) {
+      if (options.showUnresolved) {
+        unresolvedInstances.push(instanceNode);
+      }
+      continue;
+    }
+    const childKey = moduleKey(resolvedModule);
+    if (depth + 1 < options.maxDepth && !nextVisited.has(childKey)) {
+      instanceNode.children = buildNode(
+        resolvedModule,
+        index,
+        instancesByParent,
+        options,
+        depth + 1,
+        nextVisited
+      );
+    }
+    resolvedInstances.push(instanceNode);
+  }
+
+  return {
+    moduleName: moduleRecord.name,
+    module: moduleRecord,
+    instances: resolvedInstances,
+    unresolvedInstances,
+  };
+}
+
+function selectRootModules(
+  projectSnapshot: ProjectSnapshot,
+  modules: ModuleRecord[],
+  resolvedInstanceKeys: Set<string>
+): ModuleRecord[] {
+  const configuredTopModules = unique(projectSnapshot.compileUnits.flatMap((compileUnit) => compileUnit.topModules));
+  if (configuredTopModules.length > 0) {
+    const configured = configuredTopModules
+      .map((name) => modules.find((moduleRecord) => moduleRecord.name === name))
+      .filter((moduleRecord): moduleRecord is ModuleRecord => moduleRecord !== undefined);
+    if (configured.length > 0) {
+      return configured;
+    }
+  }
+
+  const inferred = modules.filter((moduleRecord) => !resolvedInstanceKeys.has(moduleKey(moduleRecord)));
+  return inferred.length > 0 ? inferred : modules.slice();
+}
+
+function groupInstancesByParent(instances: ModuleInstanceRecord[]): Map<string, ModuleInstanceRecord[]> {
+  const map = new Map<string, ModuleInstanceRecord[]>();
+  for (const instance of instances) {
+    const key = `${instance.compileUnitId}:${instance.parentModuleName}`;
+    const existing = map.get(key);
+    if (existing) {
+      existing.push(instance);
+    } else {
+      map.set(key, [instance]);
+    }
+  }
+  return map;
+}
+
+function findUnresolvedInstances(
+  instances: ModuleInstanceRecord[],
+  index: SemanticIndex
+): HierarchyInstanceNode[] {
+  return instances
+    .filter((instance) => !findBestModule(index.findModules(instance.moduleName), instance.compileUnitId))
+    .map((instance) => ({
+      instanceName: instance.instanceName,
+      moduleName: instance.moduleName,
+      location: new vscode.Location(instance.uri, instance.selectionRange),
+    }));
+}
+
+function findBestModule(modules: ModuleRecord[], compileUnitId: string): ModuleRecord | undefined {
+  return modules.find((moduleRecord) => moduleRecord.compileUnitId === compileUnitId) ?? modules[0];
+}
+
+function moduleKey(moduleRecord: ModuleRecord): string {
+  return `${moduleRecord.compileUnitId}:${moduleRecord.name}`;
+}
+
+function unique(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    if (value.length === 0 || seen.has(value)) {
+      return false;
+    }
+    seen.add(value);
+    return true;
+  });
+}
+
+export function createEmptyHierarchy(version: number): HierarchySnapshot {
+  return {
+    version,
+    roots: [],
+    unresolvedInstances: [],
+    allInstances: [],
+  };
+}

--- a/src/hierarchy/HierarchyService.ts
+++ b/src/hierarchy/HierarchyService.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import { getExtensionLogger } from '../logging';
+import type { ProjectService } from '../project/ProjectService';
+import type { IndexService } from '../semantic/IndexService';
+import { createEmptyHierarchy, HierarchyBuilder } from './HierarchyBuilder';
+import type { HierarchyBuildOptions, HierarchySnapshot } from './HierarchyTypes';
+
+const logger = getExtensionLogger('Hierarchy', 'Service');
+
+export class HierarchyService implements vscode.Disposable {
+  private readonly emitter = new vscode.EventEmitter<HierarchySnapshot>();
+  private readonly disposables: vscode.Disposable[] = [];
+  private hierarchy = createEmptyHierarchy(0);
+  private rebuildSerial = 0;
+
+  readonly onDidChangeHierarchy = this.emitter.event;
+
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly builder = new HierarchyBuilder()
+  ) {
+    this.disposables.push(
+      this.indexService.onDidChangeIndex(() => {
+        void this.rebuild('index-change');
+      })
+    );
+  }
+
+  getHierarchy(): HierarchySnapshot {
+    return cloneHierarchy(this.hierarchy);
+  }
+
+  async rebuild(reason = 'unspecified'): Promise<HierarchySnapshot> {
+    const serial = this.rebuildSerial + 1;
+    this.rebuildSerial = serial;
+    const projectSnapshot = this.projectService.getSnapshot();
+    const options = getHierarchyBuildOptions();
+    logger.info('Rebuilding Verilog hierarchy', {
+      reason,
+      version: projectSnapshot.version,
+      enabled: options.enabled,
+    });
+    try {
+      const nextHierarchy = await this.builder.build(projectSnapshot, this.indexService.getIndex(), options);
+      if (serial === this.rebuildSerial) {
+        this.hierarchy = nextHierarchy;
+        this.emitter.fire(this.getHierarchy());
+        logger.info('Rebuilt Verilog hierarchy', {
+          version: nextHierarchy.version,
+          roots: nextHierarchy.roots.length,
+          instances: nextHierarchy.allInstances.length,
+          unresolved: nextHierarchy.unresolvedInstances.length,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to rebuild Verilog hierarchy', { reason, error: message });
+      if (serial === this.rebuildSerial) {
+        this.hierarchy = createEmptyHierarchy(projectSnapshot.version);
+        this.emitter.fire(this.getHierarchy());
+      }
+    }
+    return this.getHierarchy();
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.emitter.dispose();
+  }
+}
+
+function getHierarchyBuildOptions(): HierarchyBuildOptions {
+  const config = vscode.workspace.getConfiguration('verilog.hierarchy');
+  return {
+    enabled: config.get<boolean>('enabled', true),
+    maxDepth: Math.max(1, config.get<number>('maxDepth', 20)),
+    showUnresolved: config.get<boolean>('showUnresolved', true),
+  };
+}
+
+function cloneHierarchy(hierarchy: HierarchySnapshot): HierarchySnapshot {
+  return {
+    version: hierarchy.version,
+    roots: hierarchy.roots.map(cloneNode),
+    unresolvedInstances: hierarchy.unresolvedInstances.map(cloneInstanceNode),
+    allInstances: hierarchy.allInstances.map((instance) => ({
+      ...instance,
+      parameterOverrides: instance.parameterOverrides.slice(),
+      portConnections: instance.portConnections.slice(),
+    })),
+  };
+}
+
+function cloneNode(node: HierarchySnapshot['roots'][number]): HierarchySnapshot['roots'][number] {
+  return {
+    moduleName: node.moduleName,
+    module: node.module,
+    instances: node.instances.map(cloneInstanceNode),
+    unresolvedInstances: node.unresolvedInstances.map(cloneInstanceNode),
+  };
+}
+
+function cloneInstanceNode(
+  instance: HierarchySnapshot['unresolvedInstances'][number]
+): HierarchySnapshot['unresolvedInstances'][number] {
+  return {
+    instanceName: instance.instanceName,
+    moduleName: instance.moduleName,
+    resolvedModule: instance.resolvedModule,
+    location: instance.location,
+    children: instance.children ? cloneNode(instance.children) : undefined,
+  };
+}

--- a/src/hierarchy/HierarchyTypes.ts
+++ b/src/hierarchy/HierarchyTypes.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+
+export interface ModuleInstanceRecord {
+  id: string;
+  instanceName: string;
+  moduleName: string;
+  parentModuleName: string;
+  uri: vscode.Uri;
+  range: vscode.Range;
+  selectionRange: vscode.Range;
+  parameterOverrides: string[];
+  portConnections: string[];
+  compileUnitId: string;
+}
+
+export interface HierarchyNode {
+  moduleName: string;
+  module?: ModuleRecord;
+  instances: HierarchyInstanceNode[];
+  unresolvedInstances: HierarchyInstanceNode[];
+}
+
+export interface HierarchyInstanceNode {
+  instanceName: string;
+  moduleName: string;
+  resolvedModule?: ModuleRecord;
+  location: vscode.Location;
+  children?: HierarchyNode;
+}
+
+export interface HierarchySnapshot {
+  version: number;
+  roots: HierarchyNode[];
+  unresolvedInstances: HierarchyInstanceNode[];
+  allInstances: ModuleInstanceRecord[];
+}
+
+export interface HierarchyBuildOptions {
+  enabled: boolean;
+  maxDepth: number;
+  showUnresolved: boolean;
+}

--- a/src/hierarchy/InstanceScanner.ts
+++ b/src/hierarchy/InstanceScanner.ts
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ModuleInstanceRecord } from './HierarchyTypes';
+
+interface ModuleBlock {
+  name: string;
+  bodyStart: number;
+  bodyEnd: number;
+}
+
+interface ParenthesizedSegment {
+  text: string;
+  openOffset: number;
+  closeOffset: number;
+}
+
+const IDENTIFIER = /[A-Za-z_][A-Za-z0-9_$]*/y;
+const REJECT_MODULE_NAMES = new Set([
+  'alias',
+  'always',
+  'always_comb',
+  'always_ff',
+  'always_latch',
+  'and',
+  'assign',
+  'begin',
+  'buf',
+  'bufif0',
+  'bufif1',
+  'case',
+  'casex',
+  'casez',
+  'class',
+  'deassign',
+  'defparam',
+  'end',
+  'endcase',
+  'endclass',
+  'endfunction',
+  'endmodule',
+  'endpackage',
+  'endtask',
+  'for',
+  'force',
+  'forever',
+  'fork',
+  'function',
+  'generate',
+  'if',
+  'initial',
+  'interface',
+  'join',
+  'localparam',
+  'module',
+  'nand',
+  'nor',
+  'not',
+  'notif0',
+  'notif1',
+  'or',
+  'package',
+  'parameter',
+  'pmos',
+  'pullup',
+  'pulldown',
+  'rcmos',
+  'reg',
+  'release',
+  'repeat',
+  'rnmos',
+  'rpmos',
+  'rtran',
+  'rtranif0',
+  'rtranif1',
+  'task',
+  'tran',
+  'tranif0',
+  'tranif1',
+  'tri',
+  'tri0',
+  'tri1',
+  'wand',
+  'while',
+  'wire',
+  'wor',
+  'xnor',
+  'xor',
+]);
+
+export class InstanceScanner {
+  scan(text: string, uri: vscode.Uri, compileUnitId: string): ModuleInstanceRecord[] {
+    try {
+      const masked = maskCommentsAndStrings(text);
+      const lineStarts = computeLineStarts(text);
+      return findModuleBlocks(masked).flatMap((moduleBlock) =>
+        scanModuleBody(masked, text, uri, compileUnitId, lineStarts, moduleBlock)
+      );
+    } catch {
+      return [];
+    }
+  }
+}
+
+function scanModuleBody(
+  masked: string,
+  original: string,
+  uri: vscode.Uri,
+  compileUnitId: string,
+  lineStarts: number[],
+  moduleBlock: ModuleBlock
+): ModuleInstanceRecord[] {
+  const instances: ModuleInstanceRecord[] = [];
+  for (const statement of splitTopLevelStatements(masked, moduleBlock.bodyStart, moduleBlock.bodyEnd)) {
+    const parsed = parseInstanceStatement(masked, statement.start, statement.end);
+    if (!parsed) {
+      continue;
+    }
+    const selectionRange = rangeFromOffset(original, lineStarts, parsed.instanceStart, parsed.instanceName.length);
+    instances.push({
+      id: `${compileUnitId}:${uri.fsPath}:${moduleBlock.name}:${parsed.instanceName}:${parsed.instanceStart}`,
+      instanceName: parsed.instanceName,
+      moduleName: parsed.moduleName,
+      parentModuleName: moduleBlock.name,
+      uri,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, statement.start),
+        positionFromOffset(lineStarts, statement.end + 1)
+      ),
+      selectionRange,
+      parameterOverrides: collectNamedConnections(parsed.parameterText),
+      portConnections: collectNamedConnections(parsed.portText),
+      compileUnitId,
+    });
+  }
+  return instances;
+}
+
+function findModuleBlocks(masked: string): ModuleBlock[] {
+  const blocks: ModuleBlock[] = [];
+  const modulePattern = /\bmodule\s+([A-Za-z_][A-Za-z0-9_$]*)\b/g;
+  for (const match of masked.matchAll(modulePattern)) {
+    const name = match[1] ?? '';
+    const headerStart = match.index ?? 0;
+    const headerEnd = findTopLevelSemicolon(masked, headerStart);
+    if (headerEnd === undefined) {
+      continue;
+    }
+    const endMatch = /\bendmodule\b/g;
+    endMatch.lastIndex = headerEnd + 1;
+    const end = endMatch.exec(masked);
+    if (!end) {
+      continue;
+    }
+    blocks.push({
+      name,
+      bodyStart: headerEnd + 1,
+      bodyEnd: end.index,
+    });
+    modulePattern.lastIndex = end.index + end[0].length;
+  }
+  return blocks;
+}
+
+function findTopLevelSemicolon(text: string, start: number): number | undefined {
+  let depth = 0;
+  for (let index = start; index < text.length; index += 1) {
+    const ch = text[index];
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth += 1;
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === ';' && depth === 0) {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+function splitTopLevelStatements(
+  text: string,
+  start: number,
+  end: number
+): Array<{ start: number; end: number }> {
+  const statements: Array<{ start: number; end: number }> = [];
+  let depth = 0;
+  let statementStart = start;
+  for (let index = start; index < end; index += 1) {
+    const ch = text[index];
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth += 1;
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === ';' && depth === 0) {
+      statements.push({ start: statementStart, end: index });
+      statementStart = index + 1;
+    }
+  }
+  return statements;
+}
+
+interface ParsedInstanceStatement {
+  moduleName: string;
+  instanceName: string;
+  instanceStart: number;
+  parameterText: string;
+  portText: string;
+}
+
+function parseInstanceStatement(
+  text: string,
+  statementStart: number,
+  statementEnd: number
+): ParsedInstanceStatement | undefined {
+  let index = skipWhitespace(text, statementStart, statementEnd);
+  const moduleName = readIdentifier(text, index, statementEnd);
+  if (!moduleName || REJECT_MODULE_NAMES.has(moduleName.text)) {
+    return undefined;
+  }
+  index = skipWhitespace(text, moduleName.end, statementEnd);
+  let parameterText = '';
+  if (text[index] === '#') {
+    index = skipWhitespace(text, index + 1, statementEnd);
+    if (text[index] !== '(') {
+      return undefined;
+    }
+    const parameterList = readParenthesized(text, index, statementEnd);
+    if (!parameterList) {
+      return undefined;
+    }
+    parameterText = parameterList.text;
+    index = skipWhitespace(text, parameterList.closeOffset + 1, statementEnd);
+  }
+
+  const instanceName = readIdentifier(text, index, statementEnd);
+  if (!instanceName || REJECT_MODULE_NAMES.has(instanceName.text)) {
+    return undefined;
+  }
+  index = skipWhitespace(text, instanceName.end, statementEnd);
+  if (text[index] !== '(') {
+    return undefined;
+  }
+  const portList = readParenthesized(text, index, statementEnd);
+  if (!portList) {
+    return undefined;
+  }
+  if (skipWhitespace(text, portList.closeOffset + 1, statementEnd) < statementEnd) {
+    return undefined;
+  }
+  return {
+    moduleName: moduleName.text,
+    instanceName: instanceName.text,
+    instanceStart: instanceName.start,
+    parameterText,
+    portText: portList.text,
+  };
+}
+
+function readIdentifier(
+  text: string,
+  start: number,
+  end: number
+): { text: string; start: number; end: number } | undefined {
+  IDENTIFIER.lastIndex = start;
+  const match = IDENTIFIER.exec(text.slice(0, end));
+  if (!match || match.index !== start) {
+    return undefined;
+  }
+  const value = match[0];
+  return { text: value, start, end: start + value.length };
+}
+
+function readParenthesized(
+  text: string,
+  openOffset: number,
+  endOffset: number
+): ParenthesizedSegment | undefined {
+  let depth = 0;
+  for (let index = openOffset; index < endOffset; index += 1) {
+    const ch = text[index];
+    if (ch === '(') {
+      depth += 1;
+    } else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          text: text.slice(openOffset + 1, index),
+          openOffset,
+          closeOffset: index,
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectNamedConnections(text: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(/\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/g)) {
+    const name = match[1] ?? '';
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+function skipWhitespace(text: string, start: number, end: number): number {
+  let index = start;
+  while (index < end && /\s/.test(text[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+}
+
+function maskCommentsAndStrings(text: string): string {
+  let result = '';
+  let index = 0;
+  while (index < text.length) {
+    const ch = text[index] ?? '';
+    const next = text[index + 1] ?? '';
+    if (ch === '/' && next === '/') {
+      result += '  ';
+      index += 2;
+      while (index < text.length && text[index] !== '\n') {
+        result += ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      result += '  ';
+      index += 2;
+      while (index < text.length) {
+        const blockCh = text[index] ?? '';
+        const blockNext = text[index + 1] ?? '';
+        if (blockCh === '*' && blockNext === '/') {
+          result += '  ';
+          index += 2;
+          break;
+        }
+        result += blockCh === '\n' ? '\n' : ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      result += ' ';
+      index += 1;
+      while (index < text.length) {
+        const stringCh = text[index] ?? '';
+        result += stringCh === '\n' ? '\n' : ' ';
+        if (stringCh === '\\' && index + 1 < text.length) {
+          result += text[index + 1] === '\n' ? '\n' : ' ';
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (stringCh === '"') {
+          break;
+        }
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') {
+      starts.push(i + 1);
+    }
+  }
+  return starts;
+}
+
+function rangeFromOffset(
+  text: string,
+  lineStarts: number[],
+  offset: number,
+  length: number
+): vscode.Range {
+  return new vscode.Range(
+    positionFromOffset(lineStarts, offset),
+    positionFromOffset(lineStarts, Math.min(text.length, offset + length))
+  );
+}
+
+function positionFromOffset(lineStarts: number[], offset: number): vscode.Position {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const value = lineStarts[mid] ?? 0;
+    if (value <= offset) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  const line = Math.max(0, high);
+  return new vscode.Position(line, offset - (lineStarts[line] ?? 0));
+}

--- a/src/project/ProjectLoader.ts
+++ b/src/project/ProjectLoader.ts
@@ -100,6 +100,7 @@ export class ProjectLoader {
         defines: resolved.defines,
         settingsIncludeDirs: settings.includeDirs,
         settingsDefines: settings.defines,
+        settingsTopModules: settings.topModules,
         source: { type: 'filelist', uri: vscode.Uri.file(filelistPath) },
       });
     });
@@ -133,6 +134,7 @@ export class ProjectLoader {
         defines: [],
         settingsIncludeDirs: settings.includeDirs,
         settingsDefines: settings.defines,
+        settingsTopModules: settings.topModules,
         source: { type: 'auto' },
       }),
     ];

--- a/src/project/ProjectModelMerger.ts
+++ b/src/project/ProjectModelMerger.ts
@@ -20,6 +20,7 @@ export interface CompileUnitBuildInput {
   defines: ParsedDefine[];
   settingsIncludeDirs: string[];
   settingsDefines: Record<string, string | boolean | number>;
+  settingsTopModules?: string[];
   source: CompileUnit['source'];
 }
 
@@ -35,7 +36,7 @@ export function buildCompileUnit(input: CompileUnitBuildInput): CompileUnit {
         .concat(input.settingsIncludeDirs.map((includeDir) => resolveSettingsUri(includeDir, input.root)))
     ),
     defines: mergeDefines(input.defines, input.settingsDefines),
-    topModules: [],
+    topModules: input.settingsTopModules?.slice() ?? [],
     source: input.source,
   };
 }

--- a/src/project/providers/SettingsProjectSourceProvider.ts
+++ b/src/project/providers/SettingsProjectSourceProvider.ts
@@ -5,6 +5,7 @@ export interface ProjectSettings {
   enabled: boolean;
   filelists: string[];
   activeTarget: string;
+  topModules: string[];
   includeDirs: string[];
   defines: Record<string, string | boolean | number>;
   exclude: string[];
@@ -17,6 +18,7 @@ export class SettingsProjectSourceProvider {
       enabled: config.get<boolean>('enabled', true),
       filelists: config.get<string[]>('filelists', []),
       activeTarget: config.get<string>('activeTarget', ''),
+      topModules: config.get<string[]>('topModules', []),
       includeDirs: config.get<string[]>('includeDirs', []),
       defines: config.get<Record<string, string | boolean | number>>('defines', {}),
       exclude: config.get<string[]>('exclude', [

--- a/src/semantic/IndexService.ts
+++ b/src/semantic/IndexService.ts
@@ -9,9 +9,12 @@ import { SemanticIndex } from './SemanticIndex';
 const logger = getExtensionLogger('Semantic', 'IndexService');
 
 export class IndexService implements vscode.Disposable {
+  private readonly emitter = new vscode.EventEmitter<SemanticIndex>();
   private readonly disposables: vscode.Disposable[] = [];
   private index = new SemanticIndex(0, []);
   private rebuildSerial = 0;
+
+  readonly onDidChangeIndex = this.emitter.event;
 
   constructor(
     projectService: ProjectService,
@@ -40,6 +43,7 @@ export class IndexService implements vscode.Disposable {
       const symbols = await this.backend.build(snapshot);
       if (serial === this.rebuildSerial) {
         this.index = new SemanticIndex(snapshot.version, symbols);
+        this.emitter.fire(this.index);
         logger.info('Rebuilt Verilog semantic index', {
           version: snapshot.version,
           symbols: symbols.length,
@@ -53,6 +57,7 @@ export class IndexService implements vscode.Disposable {
       });
       if (serial === this.rebuildSerial) {
         this.index = new SemanticIndex(snapshot.version, []);
+        this.emitter.fire(this.index);
       }
     }
     return this.index;
@@ -62,5 +67,6 @@ export class IndexService implements vscode.Disposable {
     for (const disposable of this.disposables) {
       disposable.dispose();
     }
+    this.emitter.dispose();
   }
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -143,6 +143,10 @@ suite('Extension Test Suite', () => {
     assert.ok(commands.includes('verilog.reloadProject'));
     assert.ok(commands.includes('verilog.showProjectStatus'));
     assert.ok(commands.includes('verilog.showProjectModules'));
+    assert.ok(commands.includes('verilog.refreshHierarchy'));
+    assert.ok(commands.includes('verilog.refreshHdlExplorer'));
+    assert.ok(commands.includes('verilog.openModuleFromExplorer'));
+    assert.ok(commands.includes('verilog.openInstanceFromExplorer'));
   });
 
   test('package should contribute project settings', () => {
@@ -159,9 +163,14 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.project.enabled']);
     assert.ok(properties['verilog.project.filelists']);
     assert.ok(properties['verilog.project.activeTarget']);
+    assert.ok(properties['verilog.project.topModules']);
     assert.ok(properties['verilog.project.includeDirs']);
     assert.ok(properties['verilog.project.defines']);
     assert.ok(properties['verilog.project.exclude']);
+    assert.ok(properties['verilog.hierarchy.enabled']);
+    assert.ok(properties['verilog.hierarchy.maxDepth']);
+    assert.ok(properties['verilog.hierarchy.showUnresolved']);
+    assert.ok(properties['verilog.hdlExplorer.enabled']);
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
     assert.ok(properties['verilog.preprocessor.useProjectDefines']);
     assert.ok(properties['verilog.linting.useProjectContext']);
@@ -172,5 +181,15 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.codeActions.fillMissingPorts.enabled']);
     assert.ok(properties['verilog.codeActions.fillMissingParameters.enabled']);
     assert.ok(properties['verilog.codeActions.alignment.enabled']);
+  });
+
+  test('package should contribute HDL Explorer view', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+    ) as {
+      contributes: { views: { explorer: Array<{ id: string; name: string }> } };
+    };
+
+    assert.ok(packageJson.contributes.views.explorer.some((view) => view.id === 'verilog.hdlExplorer'));
   });
 });

--- a/src/test/filelistProject.test.ts
+++ b/src/test/filelistProject.test.ts
@@ -190,6 +190,7 @@ suite('ProjectLoader', () => {
       enabled: true,
       filelists: [],
       activeTarget: '',
+      topModules: [],
       includeDirs: [],
       defines: {},
       exclude: ['**/.git/**', '**/node_modules/**', '**/build/**'],

--- a/src/test/hdlExplorerProvider.test.ts
+++ b/src/test/hdlExplorerProvider.test.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { HdlExplorerProvider } from '../views/HdlExplorerProvider';
+import type { HierarchyService } from '../hierarchy/HierarchyService';
+import type { HierarchySnapshot } from '../hierarchy/HierarchyTypes';
+import type { ProjectService } from '../project/ProjectService';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+import type { HdlExplorerItem } from '../views/HdlExplorerItems';
+
+suite('HdlExplorerProvider', () => {
+  test('produces project, module, package, hierarchy, and unresolved sections', async () => {
+    const moduleRecord = createModuleRecord('top');
+    const packageRecord = createSymbolRecord('pkg', 'package');
+    const provider = createProvider({
+      symbols: [moduleRecord, packageRecord],
+      hierarchy: {
+        version: 1,
+        roots: [{
+          moduleName: 'top',
+          module: moduleRecord,
+          instances: [],
+          unresolvedInstances: [],
+        }],
+        unresolvedInstances: [{
+          instanceName: 'u_missing',
+          moduleName: 'missing',
+          location: new vscode.Location(moduleRecord.uri, moduleRecord.selectionRange),
+        }],
+        allInstances: [],
+      },
+    });
+
+    const root = await children(provider);
+
+    assert.deepStrictEqual(root.map((item) => String(item.label)), [
+      'HDL Project',
+      'Modules',
+      'Packages',
+      'Hierarchy (best-effort)',
+      'Unresolved Instances',
+    ]);
+    assert.ok((await sectionChildren(provider, root, 'Modules')).some((item) => item.label === 'top'));
+    assert.ok((await sectionChildren(provider, root, 'Packages')).some((item) => item.label === 'pkg'));
+    assert.ok((await sectionChildren(provider, root, 'Hierarchy (best-effort)')).some((item) => item.label === 'top'));
+    assert.ok((await sectionChildren(provider, root, 'Unresolved Instances')).some((item) => item.label === 'u_missing : missing'));
+  });
+
+  test('maps module and instance items to source locations', async () => {
+    const moduleRecord = createModuleRecord('top');
+    const instanceLocation = new vscode.Location(moduleRecord.uri, new vscode.Range(2, 4, 2, 11));
+    const provider = createProvider({
+      symbols: [moduleRecord],
+      hierarchy: {
+        version: 1,
+        roots: [{
+          moduleName: 'top',
+          module: moduleRecord,
+          instances: [{
+            instanceName: 'u_child',
+            moduleName: 'child',
+            resolvedModule: createModuleRecord('child'),
+            location: instanceLocation,
+          }],
+          unresolvedInstances: [],
+        }],
+        unresolvedInstances: [],
+        allInstances: [],
+      },
+    });
+
+    const root = await children(provider);
+    const moduleItem = (await sectionChildren(provider, root, 'Modules'))[0];
+    const hierarchyRoot = (await sectionChildren(provider, root, 'Hierarchy (best-effort)'))[0];
+    assert.ok(hierarchyRoot);
+    const instanceItem = (await children(provider, hierarchyRoot))[0];
+
+    assert.strictEqual(moduleItem?.command?.command, 'verilog.openModuleFromExplorer');
+    assert.strictEqual((moduleItem?.command?.arguments?.[0] as vscode.Location).uri.fsPath, moduleRecord.uri.fsPath);
+    assert.strictEqual(instanceItem?.command?.command, 'verilog.openInstanceFromExplorer');
+    assert.strictEqual(instanceItem?.command?.arguments?.[0], instanceLocation);
+  });
+
+  test('hides unresolved section when disabled', async () => {
+    const config = vscode.workspace.getConfiguration();
+    const previous = config.get('verilog.hierarchy.showUnresolved');
+    const provider = createProvider();
+
+    try {
+      await config.update('verilog.hierarchy.showUnresolved', false, vscode.ConfigurationTarget.Global);
+      const root = await children(provider);
+      assert.ok(!root.some((item) => item.label === 'Unresolved Instances'));
+    } finally {
+      await config.update('verilog.hierarchy.showUnresolved', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test('returns disabled item when HDL Explorer is disabled', async () => {
+    const config = vscode.workspace.getConfiguration();
+    const previous = config.get('verilog.hdlExplorer.enabled');
+    const provider = createProvider();
+
+    try {
+      await config.update('verilog.hdlExplorer.enabled', false, vscode.ConfigurationTarget.Global);
+      const root = await children(provider);
+      assert.deepStrictEqual(root.map((item) => item.label), ['HDL Explorer disabled']);
+    } finally {
+      await config.update('verilog.hdlExplorer.enabled', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+});
+
+async function sectionChildren(
+  provider: HdlExplorerProvider,
+  root: HdlExplorerItem[],
+  label: string
+): Promise<HdlExplorerItem[]> {
+  const section = root.find((item) => item.label === label);
+  assert.ok(section, `Expected section ${label}`);
+  return children(provider, section);
+}
+
+async function children(provider: HdlExplorerProvider, element?: HdlExplorerItem): Promise<HdlExplorerItem[]> {
+  return await Promise.resolve(provider.getChildren(element)) ?? [];
+}
+
+function createProvider(input: {
+  symbols?: SymbolRecord[];
+  hierarchy?: HierarchySnapshot;
+  projectSnapshot?: ProjectSnapshot;
+} = {}): HdlExplorerProvider {
+  const projectSnapshot = input.projectSnapshot ?? createProjectSnapshot();
+  const hierarchy = input.hierarchy ?? {
+    version: 1,
+    roots: [],
+    unresolvedInstances: [],
+    allInstances: [],
+  };
+  const noOpEvent = (() => ({ dispose: () => undefined })) as vscode.Event<unknown>;
+  return new HdlExplorerProvider(
+    {
+      getSnapshot: () => projectSnapshot,
+      onDidChangeSnapshot: noOpEvent,
+    } as unknown as ProjectService,
+    {
+      getIndex: () => new SemanticIndex(1, input.symbols ?? []),
+      onDidChangeIndex: noOpEvent,
+    } as unknown as IndexService,
+    {
+      getHierarchy: () => hierarchy,
+      onDidChangeHierarchy: noOpEvent,
+      rebuild: async () => hierarchy,
+    } as unknown as HierarchyService
+  );
+}
+
+function createProjectSnapshot(): ProjectSnapshot {
+  const fileUri = vscode.Uri.file('/workspace/top.sv');
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file('/workspace'),
+    activeTargetId: 'unit',
+    compileUnits: [{
+      id: 'unit',
+      name: 'unit',
+      root: vscode.Uri.file('/workspace'),
+      files: [{
+        uri: fileUri,
+        languageId: 'systemverilog',
+        kind: 'source',
+        order: 0,
+      }],
+      includeDirs: [vscode.Uri.file('/workspace/include')],
+      defines: {
+        SIM: {
+          name: 'SIM',
+          value: true,
+          source: 'settings',
+        },
+      },
+      topModules: [],
+      source: { type: 'settings' },
+    }],
+    diagnostics: [],
+  };
+}
+
+function createModuleRecord(name: string): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module'),
+    kind: 'module',
+    ports: [],
+    parameters: [],
+  };
+}
+
+function createSymbolRecord(name: string, kind: SymbolRecord['kind']): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
+  return {
+    id: `unit:${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId: 'unit',
+  };
+}

--- a/src/test/hierarchyBuilder.test.ts
+++ b/src/test/hierarchyBuilder.test.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { HierarchyBuilder } from '../hierarchy/HierarchyBuilder';
+import type { HierarchyBuildOptions } from '../hierarchy/HierarchyTypes';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
+
+suite('HierarchyBuilder', () => {
+  test('builds simple top child tree', async () => {
+    const root = createTempProject({
+      'top.sv': [
+        'module top;',
+        '  child u_child (.clk(clk));',
+        'endmodule',
+        'module child(input logic clk);',
+        'endmodule',
+      ].join('\n'),
+    });
+    const topUri = vscode.Uri.file(path.join(root, 'top.sv'));
+    const snapshot = createSnapshot(root, [{ uri: topUri, compileUnitId: 'unit' }]);
+    const index = new SemanticIndex(1, [
+      createModuleRecord('top', topUri, 'unit'),
+      createModuleRecord('child', topUri, 'unit'),
+    ]);
+
+    const hierarchy = await new HierarchyBuilder().build(snapshot, index, defaultOptions());
+
+    assert.deepStrictEqual(hierarchy.roots.map((node) => node.moduleName), ['top']);
+    assert.strictEqual(hierarchy.roots[0]?.instances[0]?.instanceName, 'u_child');
+    assert.strictEqual(hierarchy.roots[0]?.instances[0]?.children?.moduleName, 'child');
+  });
+
+  test('handles unresolved instance', async () => {
+    const root = createTempProject({
+      'top.sv': 'module top; missing u_missing (); endmodule',
+    });
+    const topUri = vscode.Uri.file(path.join(root, 'top.sv'));
+    const snapshot = createSnapshot(root, [{ uri: topUri, compileUnitId: 'unit' }]);
+    const index = new SemanticIndex(1, [createModuleRecord('top', topUri, 'unit')]);
+
+    const hierarchy = await new HierarchyBuilder().build(snapshot, index, defaultOptions());
+
+    assert.strictEqual(hierarchy.roots[0]?.unresolvedInstances[0]?.instanceName, 'u_missing');
+    assert.strictEqual(hierarchy.unresolvedInstances[0]?.moduleName, 'missing');
+  });
+
+  test('handles duplicate module names with compile unit preference', async () => {
+    const root = createTempProject({
+      'a.sv': 'module child; endmodule',
+      'b.sv': 'module top; child u_child (); endmodule module child; endmodule',
+    });
+    const aUri = vscode.Uri.file(path.join(root, 'a.sv'));
+    const bUri = vscode.Uri.file(path.join(root, 'b.sv'));
+    const snapshot = createSnapshot(root, [
+      { uri: aUri, compileUnitId: 'unitA' },
+      { uri: bUri, compileUnitId: 'unitB' },
+    ]);
+    const childA = createModuleRecord('child', aUri, 'unitA');
+    const top = createModuleRecord('top', bUri, 'unitB');
+    const childB = createModuleRecord('child', bUri, 'unitB');
+    const index = new SemanticIndex(1, [childA, top, childB]);
+
+    const hierarchy = await new HierarchyBuilder().build(snapshot, index, defaultOptions());
+
+    assert.strictEqual(hierarchy.roots.find((node) => node.moduleName === 'top')?.instances[0]?.resolvedModule, childB);
+  });
+
+  test('handles recursive cyclic hierarchy safely and respects maxDepth', async () => {
+    const root = createTempProject({
+      'cycle.sv': [
+        'module a;',
+        '  b u_b ();',
+        'endmodule',
+        'module b;',
+        '  a u_a ();',
+        'endmodule',
+      ].join('\n'),
+    });
+    const uri = vscode.Uri.file(path.join(root, 'cycle.sv'));
+    const snapshot = createSnapshot(root, [{ uri, compileUnitId: 'unit' }], ['a']);
+    const index = new SemanticIndex(1, [
+      createModuleRecord('a', uri, 'unit'),
+      createModuleRecord('b', uri, 'unit'),
+    ]);
+
+    const hierarchy = await new HierarchyBuilder().build(snapshot, index, { ...defaultOptions(), maxDepth: 2 });
+
+    const child = hierarchy.roots[0]?.instances[0]?.children;
+    assert.strictEqual(hierarchy.roots[0]?.moduleName, 'a');
+    assert.strictEqual(child?.moduleName, 'b');
+    assert.strictEqual(child?.instances[0]?.children, undefined);
+  });
+
+  test('infers top modules and honors configured topModules', async () => {
+    const root = createTempProject({
+      'design.sv': [
+        'module inferred;',
+        '  child u_child ();',
+        'endmodule',
+        'module configured;',
+        'endmodule',
+        'module child;',
+        'endmodule',
+      ].join('\n'),
+    });
+    const uri = vscode.Uri.file(path.join(root, 'design.sv'));
+    const modules = [
+      createModuleRecord('inferred', uri, 'unit'),
+      createModuleRecord('configured', uri, 'unit'),
+      createModuleRecord('child', uri, 'unit'),
+    ];
+    const index = new SemanticIndex(1, modules);
+
+    const inferred = await new HierarchyBuilder().build(
+      createSnapshot(root, [{ uri, compileUnitId: 'unit' }]),
+      index,
+      defaultOptions()
+    );
+    const configured = await new HierarchyBuilder().build(
+      createSnapshot(root, [{ uri, compileUnitId: 'unit' }], ['configured']),
+      index,
+      defaultOptions()
+    );
+
+    assert.deepStrictEqual(inferred.roots.map((node) => node.moduleName), ['inferred', 'configured']);
+    assert.deepStrictEqual(configured.roots.map((node) => node.moduleName), ['configured']);
+  });
+
+  test('returns empty hierarchy when disabled, project empty, or file unreadable', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hierarchy-empty-'));
+    const missingUri = vscode.Uri.file(path.join(root, 'missing.sv'));
+    const builder = new HierarchyBuilder();
+    const disabled = await builder.build(createSnapshot(root, [{ uri: missingUri, compileUnitId: 'unit' }]), new SemanticIndex(1, []), {
+      ...defaultOptions(),
+      enabled: false,
+    });
+    const empty = await builder.build(createSnapshot(root, []), new SemanticIndex(1, []), defaultOptions());
+    const unreadable = await builder.build(
+      createSnapshot(root, [{ uri: missingUri, compileUnitId: 'unit' }]),
+      new SemanticIndex(1, []),
+      defaultOptions()
+    );
+
+    assert.deepStrictEqual(disabled.roots, []);
+    assert.deepStrictEqual(empty.roots, []);
+    assert.deepStrictEqual(unreadable.allInstances, []);
+  });
+});
+
+function createTempProject(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hierarchy-project-'));
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  return root;
+}
+
+function createSnapshot(
+  root: string,
+  files: Array<{ uri: vscode.Uri; compileUnitId: string }>,
+  topModules: string[] = []
+): ProjectSnapshot {
+  const compileUnitIds = [...new Set(files.map((file) => file.compileUnitId))];
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file(root),
+    activeTargetId: '',
+    compileUnits: compileUnitIds.map((compileUnitId) => ({
+      id: compileUnitId,
+      name: compileUnitId,
+      root: vscode.Uri.file(root),
+      files: files
+        .filter((file) => file.compileUnitId === compileUnitId)
+        .map((file, order) => ({
+          uri: file.uri,
+          languageId: 'systemverilog',
+          kind: 'source',
+          order,
+        })),
+      includeDirs: [],
+      defines: {},
+      topModules,
+      source: { type: 'settings' },
+    })),
+    diagnostics: [],
+  };
+}
+
+function createModuleRecord(name: string, uri: vscode.Uri, compileUnitId: string): ModuleRecord {
+  const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
+  return {
+    id: `${compileUnitId}:${name}`,
+    name,
+    kind: 'module',
+    uri,
+    range: selectionRange,
+    selectionRange,
+    compileUnitId,
+    ports: [],
+    parameters: [],
+  };
+}
+
+function defaultOptions(): HierarchyBuildOptions {
+  return {
+    enabled: true,
+    maxDepth: 20,
+    showUnresolved: true,
+  };
+}

--- a/src/test/instanceScanner.test.ts
+++ b/src/test/instanceScanner.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { InstanceScanner } from '../hierarchy/InstanceScanner';
+
+suite('InstanceScanner', () => {
+  test('detects simple instance', () => {
+    const instances = scan([
+      'module top;',
+      '  foo u_foo (',
+      '    .clk(clk)',
+      '  );',
+      'endmodule',
+    ].join('\n'));
+
+    assert.strictEqual(instances.length, 1);
+    assert.strictEqual(instances[0]?.moduleName, 'foo');
+    assert.strictEqual(instances[0]?.instanceName, 'u_foo');
+    assert.strictEqual(instances[0]?.parentModuleName, 'top');
+    assert.deepStrictEqual(instances[0]?.portConnections, ['clk']);
+  });
+
+  test('detects parameterized instance', () => {
+    const instances = scan([
+      'module top;',
+      '  foo #(',
+      '    .WIDTH(32)',
+      '  ) u_foo (',
+      '    .clk(clk)',
+      '  );',
+      'endmodule',
+    ].join('\n'));
+
+    assert.strictEqual(instances.length, 1);
+    assert.deepStrictEqual(instances[0]?.parameterOverrides, ['WIDTH']);
+    assert.deepStrictEqual(instances[0]?.portConnections, ['clk']);
+  });
+
+  test('detects inline parameterized instance', () => {
+    const instances = scan('module top; foo #(.WIDTH(32)) u_foo (.clk(clk)); endmodule');
+
+    assert.strictEqual(instances.length, 1);
+    assert.strictEqual(instances[0]?.moduleName, 'foo');
+    assert.strictEqual(instances[0]?.instanceName, 'u_foo');
+  });
+
+  test('detects multiline instance', () => {
+    const instances = scan([
+      'module top;',
+      '  foo',
+      '  #(',
+      '    .WIDTH(32)',
+      '  )',
+      '  u_foo',
+      '  (',
+      '    .clk(clk)',
+      '  );',
+      'endmodule',
+    ].join('\n'));
+
+    assert.strictEqual(instances.length, 1);
+    assert.strictEqual(instances[0]?.moduleName, 'foo');
+    assert.strictEqual(instances[0]?.instanceName, 'u_foo');
+  });
+
+  test('avoids declaration false positives', () => {
+    const instances = scan([
+      'module top(input logic clk);',
+      'endmodule',
+      'interface bus_if;',
+      'endinterface',
+      'package pkg;',
+      'endpackage',
+      'class c;',
+      'endclass',
+    ].join('\n'));
+
+    assert.deepStrictEqual(instances, []);
+  });
+
+  test('avoids function task class package false positives inside module', () => {
+    const instances = scan([
+      'module top;',
+      '  function void f();',
+      '  endfunction',
+      '  task t();',
+      '  endtask',
+      '  class inner;',
+      '  endclass',
+      '  package p;',
+      '  endpackage',
+      'endmodule',
+    ].join('\n'));
+
+    assert.deepStrictEqual(instances, []);
+  });
+
+  test('avoids procedural keyword false positives and malformed input does not throw', () => {
+    assert.doesNotThrow(() => scan('module top; if (ready) begin foo <= bar; end module '));
+    const instances = scan([
+      'module top;',
+      '  always_ff @(posedge clk) begin',
+      '    if (rst) value <= 0;',
+      '  end',
+      '  and primitive_gate(out, a, b);',
+      'endmodule',
+    ].join('\n'));
+
+    assert.deepStrictEqual(instances, []);
+  });
+});
+
+function scan(text: string): ReturnType<InstanceScanner['scan']> {
+  return new InstanceScanner().scan(text, vscode.Uri.file('/workspace/top.sv'), 'unit');
+}

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -296,6 +296,7 @@ function settings(overrides: Partial<ProjectSettings> = {}): ProjectSettings {
     enabled: true,
     filelists: [],
     activeTarget: '',
+    topModules: [],
     includeDirs: [],
     defines: {},
     exclude: ['**/.git/**', '**/node_modules/**', '**/build/**', '**/sim/**'],

--- a/src/views/HdlExplorerItems.ts
+++ b/src/views/HdlExplorerItems.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CompileUnit, MacroDefine, SourceFileRef } from '../project/ProjectTypes';
+import type { HierarchyInstanceNode, HierarchyNode } from '../hierarchy/HierarchyTypes';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+export type HdlExplorerItemKind =
+  | 'section'
+  | 'info'
+  | 'compileUnit'
+  | 'group'
+  | 'file'
+  | 'symbol'
+  | 'hierarchyModule'
+  | 'hierarchyInstance';
+
+export class HdlExplorerItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    readonly kind: HdlExplorerItemKind,
+    collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None,
+    readonly payload?: unknown
+  ) {
+    super(label, collapsibleState);
+    this.contextValue = kind;
+  }
+}
+
+export function createSectionItem(label: string): HdlExplorerItem {
+  return new HdlExplorerItem(label, 'section', vscode.TreeItemCollapsibleState.Expanded);
+}
+
+export function createInfoItem(label: string, description?: string): HdlExplorerItem {
+  const item = new HdlExplorerItem(label, 'info');
+  item.description = description;
+  return item;
+}
+
+export function createCompileUnitItem(compileUnit: CompileUnit): HdlExplorerItem {
+  const item = new HdlExplorerItem(
+    compileUnit.name,
+    'compileUnit',
+    vscode.TreeItemCollapsibleState.Collapsed,
+    compileUnit
+  );
+  item.description = compileUnit.id;
+  return item;
+}
+
+export function createGroupItem(label: string, payload: unknown): HdlExplorerItem {
+  return new HdlExplorerItem(label, 'group', vscode.TreeItemCollapsibleState.Collapsed, payload);
+}
+
+export function createFileItem(file: SourceFileRef): HdlExplorerItem {
+  const item = new HdlExplorerItem(path.basename(file.uri.fsPath), 'file', vscode.TreeItemCollapsibleState.None, file);
+  item.description = file.kind;
+  item.resourceUri = file.uri;
+  item.command = {
+    command: 'vscode.open',
+    title: 'Open File',
+    arguments: [file.uri],
+  };
+  return item;
+}
+
+export function createDefineItem(name: string, define: MacroDefine): HdlExplorerItem {
+  const item = createInfoItem(name, String(define.value));
+  item.tooltip = `${name} = ${String(define.value)} (${define.source})`;
+  return item;
+}
+
+export function createSymbolItem(symbol: ModuleRecord | SymbolRecord): HdlExplorerItem {
+  const item = new HdlExplorerItem(symbol.name, 'symbol', vscode.TreeItemCollapsibleState.None, symbol);
+  item.description = symbol.compileUnitId;
+  item.resourceUri = symbol.uri;
+  item.command = {
+    command: 'verilog.openModuleFromExplorer',
+    title: 'Open HDL Symbol',
+    arguments: [new vscode.Location(symbol.uri, symbol.selectionRange)],
+  };
+  return item;
+}
+
+export function createHierarchyModuleItem(node: HierarchyNode): HdlExplorerItem {
+  const childCount = node.instances.length + node.unresolvedInstances.length;
+  const item = new HdlExplorerItem(
+    node.moduleName,
+    'hierarchyModule',
+    childCount > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+    node
+  );
+  if (node.module) {
+    item.description = node.module.compileUnitId;
+    item.resourceUri = node.module.uri;
+    item.command = {
+      command: 'verilog.openModuleFromExplorer',
+      title: 'Open HDL Module',
+      arguments: [new vscode.Location(node.module.uri, node.module.selectionRange)],
+    };
+  }
+  return item;
+}
+
+export function createHierarchyInstanceItem(instance: HierarchyInstanceNode): HdlExplorerItem {
+  const childCount = instance.children
+    ? instance.children.instances.length + instance.children.unresolvedInstances.length
+    : 0;
+  const item = new HdlExplorerItem(
+    `${instance.instanceName} : ${instance.moduleName}`,
+    'hierarchyInstance',
+    childCount > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+    instance
+  );
+  item.description = instance.resolvedModule ? undefined : 'unresolved';
+  item.resourceUri = instance.location.uri;
+  item.command = {
+    command: 'verilog.openInstanceFromExplorer',
+    title: 'Open HDL Instance',
+    arguments: [instance.location],
+  };
+  return item;
+}

--- a/src/views/HdlExplorerProvider.ts
+++ b/src/views/HdlExplorerProvider.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { HierarchyService } from '../hierarchy/HierarchyService';
+import type { HierarchyInstanceNode, HierarchyNode } from '../hierarchy/HierarchyTypes';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import {
+  createCompileUnitItem,
+  createDefineItem,
+  createFileItem,
+  createGroupItem,
+  createHierarchyInstanceItem,
+  createHierarchyModuleItem,
+  createInfoItem,
+  createSymbolItem,
+  HdlExplorerItem,
+} from './HdlExplorerItems';
+
+type RootSection = 'project' | 'modules' | 'packages' | 'hierarchy' | 'unresolved';
+type CompileUnitGroup = 'files' | 'includeDirs' | 'defines';
+
+interface SectionPayload {
+  section: RootSection;
+}
+
+interface CompileUnitGroupPayload {
+  group: CompileUnitGroup;
+  compileUnit: CompileUnit;
+}
+
+interface CompileUnitsPayload {
+  group: 'compileUnits';
+  compileUnits: CompileUnit[];
+}
+
+export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerItem>, vscode.Disposable {
+  private readonly emitter = new vscode.EventEmitter<HdlExplorerItem | undefined>();
+  private readonly disposables: vscode.Disposable[] = [];
+
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly hierarchyService: HierarchyService
+  ) {
+    this.disposables.push(
+      projectService.onDidChangeSnapshot(() => this.refresh()),
+      indexService.onDidChangeIndex(() => this.refresh()),
+      hierarchyService.onDidChangeHierarchy(() => this.refresh()),
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (
+          event.affectsConfiguration('verilog.hdlExplorer')
+          || event.affectsConfiguration('verilog.hierarchy')
+        ) {
+          this.refresh();
+        }
+      })
+    );
+  }
+
+  refresh(): void {
+    this.emitter.fire(undefined);
+  }
+
+  getTreeItem(element: HdlExplorerItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: HdlExplorerItem): vscode.ProviderResult<HdlExplorerItem[]> {
+    if (!isHdlExplorerEnabled()) {
+      return [createInfoItem('HDL Explorer disabled', 'verilog.hdlExplorer.enabled=false')];
+    }
+    if (!element) {
+      return this.getRootItems();
+    }
+    if (isSectionPayload(element.payload)) {
+      return this.getSectionChildren(element.payload.section);
+    }
+    if (isCompileUnit(element.payload)) {
+      return this.getCompileUnitChildren(element.payload);
+    }
+    if (isCompileUnitsPayload(element.payload)) {
+      return element.payload.compileUnits.map(createCompileUnitItem);
+    }
+    if (isCompileUnitGroupPayload(element.payload)) {
+      return this.getCompileUnitGroupChildren(element.payload);
+    }
+    if (isHierarchyNode(element.payload)) {
+      return this.getHierarchyNodeChildren(element.payload);
+    }
+    if (isHierarchyInstance(element.payload) && element.payload.children) {
+      return this.getHierarchyNodeChildren(element.payload.children);
+    }
+    return [];
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.emitter.dispose();
+  }
+
+  private getRootItems(): HdlExplorerItem[] {
+    const items = [
+      createRootSectionItem('HDL Project', 'project'),
+      createRootSectionItem('Modules', 'modules'),
+      createRootSectionItem('Packages', 'packages'),
+      createRootSectionItem('Hierarchy (best-effort)', 'hierarchy'),
+    ];
+    if (isShowUnresolvedEnabled()) {
+      items.push(createRootSectionItem('Unresolved Instances', 'unresolved'));
+    }
+    return items;
+  }
+
+  private getSectionChildren(section: RootSection): HdlExplorerItem[] {
+    switch (section) {
+      case 'project':
+        return this.getProjectChildren();
+      case 'modules':
+        return this.indexService.getIndex().getAllModules().map(createSymbolItem);
+      case 'packages':
+        return this.indexService
+          .getIndex()
+          .getAllSymbols()
+          .filter((symbol) => symbol.kind === 'package')
+          .map(createSymbolItem);
+      case 'hierarchy':
+        return this.hierarchyService.getHierarchy().roots.map(createHierarchyModuleItem);
+      case 'unresolved':
+        return this.hierarchyService.getHierarchy().unresolvedInstances.map(createHierarchyInstanceItem);
+    }
+  }
+
+  private getProjectChildren(): HdlExplorerItem[] {
+    const snapshot = this.projectService.getSnapshot();
+    return [
+      createInfoItem('Active Target', snapshot.activeTargetId || '(none)'),
+      createInfoItem('Diagnostics', String(snapshot.diagnostics.length)),
+      createInfoItem('Workspace Root', snapshot.workspaceRoot.fsPath),
+      createGroupItem('Compile Units', { group: 'compileUnits', compileUnits: snapshot.compileUnits }),
+    ];
+  }
+
+  private getCompileUnitChildren(compileUnit: CompileUnit): HdlExplorerItem[] {
+    return [
+      createInfoItem('Id', compileUnit.id),
+      createInfoItem('Source', formatCompileUnitSource(compileUnit)),
+      createGroupItem('Files', { group: 'files', compileUnit }),
+      createGroupItem('Include Dirs', { group: 'includeDirs', compileUnit }),
+      createGroupItem('Defines', { group: 'defines', compileUnit }),
+    ];
+  }
+
+  private getCompileUnitGroupChildren(payload: CompileUnitGroupPayload): HdlExplorerItem[] {
+    switch (payload.group) {
+      case 'files':
+        return payload.compileUnit.files.map(createFileItem);
+      case 'includeDirs':
+        return payload.compileUnit.includeDirs.map((uri) => {
+          const item = createInfoItem(path.basename(uri.fsPath), uri.fsPath);
+          item.resourceUri = uri;
+          return item;
+        });
+      case 'defines':
+        return Object.entries(payload.compileUnit.defines).map(([name, define]) => createDefineItem(name, define));
+    }
+  }
+
+  private getHierarchyNodeChildren(node: HierarchyNode): HdlExplorerItem[] {
+    return [
+      ...node.instances.map(createHierarchyInstanceItem),
+      ...node.unresolvedInstances.map(createHierarchyInstanceItem),
+    ];
+  }
+}
+
+export function registerHdlExplorerCommands(
+  hierarchyService: HierarchyService,
+  provider: HdlExplorerProvider
+): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('verilog.refreshHierarchy', async () => {
+      await hierarchyService.rebuild('command');
+      vscode.window.showInformationMessage('Verilog hierarchy refreshed.');
+    }),
+    vscode.commands.registerCommand('verilog.refreshHdlExplorer', async () => {
+      await hierarchyService.rebuild('explorer-command');
+      provider.refresh();
+    }),
+    vscode.commands.registerCommand('verilog.openModuleFromExplorer', (location: vscode.Location) => openLocation(location)),
+    vscode.commands.registerCommand('verilog.openInstanceFromExplorer', (location: vscode.Location) => openLocation(location)),
+  ];
+}
+
+function createRootSectionItem(label: string, section: RootSection): HdlExplorerItem {
+  return new HdlExplorerItem(label, 'section', vscode.TreeItemCollapsibleState.Expanded, { section });
+}
+
+async function openLocation(location: vscode.Location): Promise<void> {
+  const document = await vscode.workspace.openTextDocument(location.uri);
+  const editor = await vscode.window.showTextDocument(document);
+  editor.revealRange(location.range, vscode.TextEditorRevealType.InCenter);
+  editor.selection = new vscode.Selection(location.range.start, location.range.end);
+}
+
+function isHdlExplorerEnabled(): boolean {
+  return vscode.workspace.getConfiguration('verilog.hdlExplorer').get<boolean>('enabled', true);
+}
+
+function isShowUnresolvedEnabled(): boolean {
+  return vscode.workspace.getConfiguration('verilog.hierarchy').get<boolean>('showUnresolved', true);
+}
+
+function formatCompileUnitSource(compileUnit: CompileUnit): string {
+  return compileUnit.source.uri
+    ? `${compileUnit.source.type} ${compileUnit.source.uri.fsPath}`
+    : compileUnit.source.type;
+}
+
+function isSectionPayload(payload: unknown): payload is SectionPayload {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'section' in payload
+    && typeof (payload as SectionPayload).section === 'string';
+}
+
+function isCompileUnit(payload: unknown): payload is CompileUnit {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'files' in payload
+    && 'includeDirs' in payload
+    && 'defines' in payload;
+}
+
+function isCompileUnitGroupPayload(payload: unknown): payload is CompileUnitGroupPayload {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'group' in payload
+    && 'compileUnit' in payload;
+}
+
+function isCompileUnitsPayload(payload: unknown): payload is CompileUnitsPayload {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'group' in payload
+    && (payload as CompileUnitsPayload).group === 'compileUnits'
+    && 'compileUnits' in payload;
+}
+
+function isHierarchyNode(payload: unknown): payload is HierarchyNode {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'moduleName' in payload
+    && 'instances' in payload
+    && 'unresolvedInstances' in payload;
+}
+
+function isHierarchyInstance(payload: unknown): payload is HierarchyInstanceNode {
+  return typeof payload === 'object'
+    && payload !== null
+    && 'instanceName' in payload
+    && 'moduleName' in payload
+    && 'location' in payload;
+}


### PR DESCRIPTION
## Summary
- Add a best-effort project-aware hierarchy model with instance scanning, hierarchy building, and an async hierarchy service.
- Add an HDL Explorer tree view in the built-in Explorer sidebar for project info, modules, packages, hierarchy roots, and unresolved instances.
- Add hierarchy/explorer settings, top module configuration, refresh/open commands, and command/view contribution tests.

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 279 passing, 3 pending