### PR TITLE
Add compile-unit lint mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,29 @@
             "default": false,
             "markdownDescription": "When enabled, pass active project include directories and preprocessor defines to supported lint tools. Existing custom linter arguments are still appended after project context arguments."
           },
+          "verilog.linting.mode": {
+            "scope": "window",
+            "type": "string",
+            "enum": [
+              "file",
+              "compileUnit"
+            ],
+            "default": "file",
+            "markdownDescription": "Choose lint scope. `file` preserves existing current-document linting. `compileUnit` lints the active project compile unit when supported by the selected linter."
+          },
+          "verilog.linting.compileUnit.maxFiles": {
+            "scope": "window",
+            "type": "number",
+            "default": 500,
+            "minimum": 1,
+            "markdownDescription": "Maximum number of source files allowed for automatic compile-unit linting."
+          },
+          "verilog.linting.compileUnit.warnBeforeLargeRun": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Ask for confirmation before manual compile-unit linting when the compile unit exceeds the maximum file guard."
+          },
           "verilog.linting.iverilog.arguments": {
             "scope": "window",
             "type": "string",

--- a/src/commands/Doctor.ts
+++ b/src/commands/Doctor.ts
@@ -14,6 +14,8 @@ import {
 } from '../languageServer/definitions';
 import type { ProjectService } from '../project/ProjectService';
 import { activeEditorContextDiagnostic, summarizeContext } from '../project/ProjectCommands';
+import { getCompileUnitLintContext } from '../linter/ProjectLintContext';
+import { supportsCompileUnitLint, type LintMode } from '../linter/LintMode';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import { expandPathVariables, resolveConfigPath } from '../utils/configPath';
 import { getWorkspaceFolderForUri } from '../utils/workspace';
@@ -66,6 +68,8 @@ export interface LinterDoctorOptions {
   useWSL?: boolean;
   modelsimWork?: string;
   isWindows?: boolean;
+  lintMode?: LintMode;
+  activeCompileUnit?: { id: string; name: string; files: number };
 }
 
 export interface LanguageServerDoctorOptions {
@@ -176,7 +180,7 @@ export async function buildDoctorReport(
   const sections: DoctorSection[] = [
     buildWorkspaceSection(activeDocument, activeWorkspaceFolder),
     await buildCtagsSection(deps, token),
-    await buildLintingSectionFromConfiguration(deps, workspaceFolderPath, token),
+    await buildLintingSectionFromConfiguration(deps, workspaceFolderPath, token, projectService),
     await buildFormattingSection(deps, workspaceFolderPath, token),
     await buildLanguageServersSection(deps, workspaceFolderPaths, token),
     buildProjectSection(projectService),
@@ -342,6 +346,19 @@ export async function buildLinterChecks(
   const checks: DoctorCheck[] = [
     { status: 'info', message: `verilog.linting.linter = ${options.linter}` },
   ];
+  if (options.lintMode) {
+    checks.push({ status: 'info', message: `verilog.linting.mode = ${options.lintMode}` });
+    checks.push({
+      status: options.lintMode === 'compileUnit' && !supportsCompileUnitLint(options.linter) ? 'warn' : 'info',
+      message: `compileUnit support = ${String(supportsCompileUnitLint(options.linter))}`,
+    });
+  }
+  if (options.activeCompileUnit) {
+    checks.push({
+      status: 'info',
+      message: `active compile unit = ${options.activeCompileUnit.name} (${options.activeCompileUnit.id}), files=${options.activeCompileUnit.files}`,
+    });
+  }
 
   if (options.linter === 'none') {
     checks.push({ status: 'info', message: 'no linter selected' });
@@ -516,18 +533,32 @@ async function buildCtagsSection(
 async function buildLintingSectionFromConfiguration(
   deps: DoctorDependencies,
   workspaceFolder?: string,
-  token?: vscode.CancellationToken
+  token?: vscode.CancellationToken,
+  projectService?: ProjectService
 ): Promise<DoctorSection> {
   const lintConfig = vscode.workspace.getConfiguration('verilog.linting');
   const linter = lintConfig.get<string>('linter', 'none');
   const linterPath = lintConfig.get<string>('path', '');
+  const lintMode = lintConfig.get<LintMode>('mode', 'file');
   const specificConfig = linter === 'none' ? undefined : getLinterSpecificConfiguration(linter);
+  const activeDocument = vscode.window.activeTextEditor?.document;
+  const activeCompileUnitContext = activeDocument
+    ? getCompileUnitLintContext(projectService, activeDocument)
+    : undefined;
 
   const checks = await buildLinterChecks(
     {
       linter,
       linterPath,
       workspaceFolder,
+      lintMode,
+      activeCompileUnit: activeCompileUnitContext
+        ? {
+            id: activeCompileUnitContext.compileUnit.id,
+            name: activeCompileUnitContext.compileUnit.name,
+            files: activeCompileUnitContext.files.length,
+          }
+        : undefined,
       includePath: specificConfig?.get<string[]>('includePath', []),
       arguments: specificConfig?.get<string>('arguments', ''),
       runAtFileLocation: specificConfig?.get<boolean>('runAtFileLocation', false),

--- a/src/linter/BaseLinter.ts
+++ b/src/linter/BaseLinter.ts
@@ -6,7 +6,13 @@ import type { ProjectService } from '../project/ProjectService';
 import { getWorkingDirectoryForDocument, resolvePathsForDocument } from '../utils/workspace';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
-import { getLintProjectContext, type LintProjectContext } from './ProjectLintContext';
+import {
+  getCompileUnitLintContext,
+  getLintProjectContext,
+  type CompileUnitLintContext,
+  type LintProjectContext,
+} from './ProjectLintContext';
+import { getLintRunSettings, type LintRunOptions } from './LintMode';
 
 /** Common configuration interface for linters */
 export interface LinterConfig {
@@ -19,6 +25,13 @@ export interface LinterConfig {
   /** Whether to run the linter at the file location */
   runAtFileLocation: boolean;
 }
+
+export type LintDecision =
+  | { kind: 'file' }
+  | { kind: 'compileUnit'; context: CompileUnitLintContext }
+  | { kind: 'skip' };
+
+const DEFAULT_LINT_RUN_OPTIONS: LintRunOptions = { trigger: 'automatic' };
 
 /**
  * Abstract base class for all linters.
@@ -132,10 +145,13 @@ export default abstract class BaseLinter implements vscode.Disposable {
    * Starts the linting process for a document.
    * @param doc - The document to lint
    */
-  public async startLint(doc: vscode.TextDocument): Promise<void> {
+  public async startLint(
+    doc: vscode.TextDocument,
+    options: LintRunOptions = DEFAULT_LINT_RUN_OPTIONS
+  ): Promise<void> {
     const run = this.runManager.beginRun(this.name, doc.uri);
     try {
-      await this.lint(doc, run);
+      await this.lint(doc, run, options);
     } catch (err) {
       this.logger.error`Unexpected lint error: ${err}`;
     } finally {
@@ -181,6 +197,49 @@ export default abstract class BaseLinter implements vscode.Disposable {
     this.publishDiagnosticsIfCurrent(ownerDoc, run, diagnosticsByUri);
   }
 
+  protected async getLintDecision(doc: vscode.TextDocument, options: LintRunOptions): Promise<LintDecision> {
+    const settings = getLintRunSettings();
+    if (settings.mode !== 'compileUnit') {
+      return { kind: 'file' };
+    }
+    const context = getCompileUnitLintContext(this.projectService, doc);
+    if (!context) {
+      this.logger.warn('Compile-unit lint requested but active document has no project compile unit; using file lint.');
+      return { kind: 'file' };
+    }
+    if (context.files.length <= settings.maxFiles) {
+      return { kind: 'compileUnit', context };
+    }
+
+    const message =
+      `Compile-unit lint skipped for ${context.compileUnit.name}: `
+      + `${context.files.length} files exceeds verilog.linting.compileUnit.maxFiles=${settings.maxFiles}.`;
+    if (options.trigger !== 'manual') {
+      this.logger.warn(message);
+      return { kind: 'skip' };
+    }
+    if (!settings.warnBeforeLargeRun) {
+      return { kind: 'compileUnit', context };
+    }
+    const selected = await vscode.window.showWarningMessage(
+      `${message} Run anyway?`,
+      { modal: true },
+      'Run Lint'
+    );
+    return selected === 'Run Lint' ? { kind: 'compileUnit', context } : { kind: 'skip' };
+  }
+
+  protected warnUnsupportedCompileUnitMode(options: LintRunOptions): void {
+    if (getLintRunSettings().mode !== 'compileUnit') {
+      return;
+    }
+    const message = `${this.name} does not support compile-unit lint mode yet; using file lint.`;
+    this.logger.warn(message);
+    if (options.trigger === 'manual') {
+      void vscode.window.showWarningMessage(message);
+    }
+  }
+
   /**
    * Converts a severity string from the linter output to a VS Code DiagnosticSeverity.
    * Must be implemented by subclasses.
@@ -194,5 +253,9 @@ export default abstract class BaseLinter implements vscode.Disposable {
    * Must be implemented by subclasses.
    * @param doc - The document to lint
    */
-  protected abstract lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void>;
+  protected abstract lint(
+    doc: vscode.TextDocument,
+    run: LintRunHandle,
+    options: LintRunOptions
+  ): Promise<void>;
 }

--- a/src/linter/CompileUnitLintArgs.ts
+++ b/src/linter/CompileUnitLintArgs.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+import { splitCommandLineArgs } from '../utils/commandLine';
+import { formatMacroDefine, type CompileUnitLintContext } from './ProjectLintContext';
+
+export interface BuildSlangCompileUnitArgsOptions {
+  docFolder: string;
+  includePaths: string[];
+  defineArgs: string[];
+  customArguments: string;
+  sourcePaths: string[];
+}
+
+export interface BuildVerilatorCompileUnitArgsOptions {
+  languageId: string;
+  docFolder: string;
+  includePaths: string[];
+  defineArgs: string[];
+  customArguments: string;
+  sourcePaths: string[];
+}
+
+export interface BuildIcarusCompileUnitArgsOptions {
+  languageId: string;
+  standards: Map<string, string>;
+  includePaths: string[];
+  defineArgs: string[];
+  customArguments: string;
+  sourcePaths: string[];
+}
+
+const ICARUS_STANDARD_TO_ARG = new Map<string, string>([
+  ['Verilog-95', '-g1995'],
+  ['Verilog-2001', '-g2001'],
+  ['Verilog-2005', '-g2005'],
+  ['SystemVerilog2005', '-g2005-sv'],
+  ['SystemVerilog2009', '-g2009'],
+  ['SystemVerilog2012', '-g2012'],
+]);
+
+export function getCompileUnitSourcePaths(context: CompileUnitLintContext): string[] {
+  return context.files.map((file) => file.uri.fsPath);
+}
+
+export function getCompileUnitIncludePaths(context: CompileUnitLintContext): string[] {
+  return context.includeDirs.map((dir) => dir.fsPath);
+}
+
+export function getCompileUnitDefineArgs(context: CompileUnitLintContext): string[] {
+  return Object.values(context.defines).map(formatMacroDefine);
+}
+
+export function buildSlangCompileUnitArgs(options: BuildSlangCompileUnitArgsOptions): string[] {
+  const args: string[] = ['-I', options.docFolder];
+  for (const includePath of options.includePaths) {
+    args.push('-I', includePath);
+  }
+  for (const defineArg of options.defineArgs) {
+    args.push('-D', defineArg);
+  }
+  args.push(...splitCommandLineArgs(options.customArguments));
+  args.push(...options.sourcePaths);
+  return args;
+}
+
+export function buildVerilatorCompileUnitArgs(options: BuildVerilatorCompileUnitArgsOptions): string[] {
+  const args: string[] = [];
+  if (options.languageId === 'systemverilog') {
+    args.push('-sv');
+  }
+  args.push('--lint-only');
+  args.push(`-I${options.docFolder}`);
+  args.push(...options.includePaths.map((includePath) => `-I${includePath}`));
+  args.push(...options.defineArgs.map((defineArg) => `-D${defineArg}`));
+  args.push(...splitCommandLineArgs(options.customArguments));
+  args.push(...options.sourcePaths);
+  return args;
+}
+
+export function buildIcarusCompileUnitArgs(options: BuildIcarusCompileUnitArgsOptions): string[] {
+  const args: string[] = ['-t', 'null'];
+  const standard = options.standards.get(options.languageId);
+  const standardArg = standard ? ICARUS_STANDARD_TO_ARG.get(standard) : undefined;
+  if (standardArg) {
+    args.push(standardArg);
+  }
+  for (const includePath of options.includePaths) {
+    args.push('-I', includePath);
+  }
+  for (const defineArg of options.defineArgs) {
+    args.push('-D', defineArg);
+  }
+  args.push(...splitCommandLineArgs(options.customArguments));
+  args.push(...options.sourcePaths);
+  return args;
+}

--- a/src/linter/IcarusLinter.ts
+++ b/src/linter/IcarusLinter.ts
@@ -7,6 +7,13 @@ import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import {
+  buildIcarusCompileUnitArgs,
+  getCompileUnitDefineArgs,
+  getCompileUnitIncludePaths,
+  getCompileUnitSourcePaths,
+} from './CompileUnitLintArgs';
+import type { LintRunOptions } from './LintMode';
 
 export { splitCommandLineArgs } from '../utils/commandLine';
 
@@ -171,11 +178,39 @@ export default class IcarusLinter extends BaseLinter {
     return convertIcarusSeverity(kind, msg);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
     this.logger.info`Executing IcarusLinter.lint()`;
 
     const binPath: string = path.join(this.config.linterInstalledPath, 'iverilog');
     this.logger.info`iverilog binary path: ${binPath}`;
+    const decision = await this.getLintDecision(doc, options);
+    if (decision.kind === 'skip') {
+      this.replaceDiagnostics(doc, run, new Map<string, vscode.Diagnostic[]>());
+      return;
+    }
+    if (decision.kind === 'compileUnit') {
+      const args = buildIcarusCompileUnitArgs({
+        languageId: doc.languageId,
+        standards: this.standards,
+        includePaths: this.resolveIncludePaths(this.config.includePath, doc).concat(
+          getCompileUnitIncludePaths(decision.context)
+        ),
+        defineArgs: getCompileUnitDefineArgs(decision.context),
+        customArguments: this.config.arguments,
+        sourcePaths: getCompileUnitSourcePaths(decision.context),
+      });
+      const cwd = this.getWorkingDirectory(doc);
+
+      this.logger.info("Executing compile-unit lint", {
+        command: binPath,
+        args,
+        cwd,
+        compileUnit: decision.context.compileUnit.id,
+      });
+
+      await this.runIcarus(binPath, args, cwd, doc, run);
+      return;
+    }
 
     const args = buildIcarusArgs({
       languageId: doc.languageId,

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -11,6 +11,8 @@ import VeribleVerilogLintLinter from './VeribleVerilogLintLinter';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager from './LintRunManager';
 import type { ProjectService } from '../project/ProjectService';
+import { getCompileUnitLintContext } from './ProjectLintContext';
+import { getLintRunSettings, supportsCompileUnitLint } from './LintMode';
 
 export default class LintManager {
   private subscriptions: vscode.Disposable[];
@@ -183,11 +185,20 @@ export default class LintManager {
       this.logger.error("Linter selection cancelled");
       return;
     }
+    const lintSettings = getLintRunSettings();
+    const compileUnitContext =
+      lintSettings.mode === 'compileUnit' && supportsCompileUnitLint(linterStr.label)
+        ? getCompileUnitLintContext(this.projectService, editor.document)
+        : undefined;
+    const title = compileUnitContext
+      ? `Verilog-HDL/SystemVerilog: Running lint for compile unit ${compileUnitContext.compileUnit.name}...`
+      : 'Verilog-HDL/SystemVerilog: Running lint tool...';
+
     // Create and run the linter with progress bar
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: 'Verilog-HDL/SystemVerilog: Running lint tool...',
+        title,
       },
       async (_progress, _token) => {
         const linter: BaseLinter | null = this.getLinterFromString(linterStr.label);
@@ -199,7 +210,7 @@ export default class LintManager {
 
         try {
           linter.removeFileDiagnostics(editor.document);
-          await linter.startLint(editor.document);
+          await linter.startLint(editor.document, { trigger: 'manual' });
         } finally {
           linter.dispose();
         }

--- a/src/linter/LintMode.ts
+++ b/src/linter/LintMode.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+
+export type LintMode = 'file' | 'compileUnit';
+export type LintRunTrigger = 'automatic' | 'manual';
+
+export interface LintRunOptions {
+  trigger: LintRunTrigger;
+}
+
+export interface CompileUnitLintSettings {
+  mode: LintMode;
+  maxFiles: number;
+  warnBeforeLargeRun: boolean;
+}
+
+const COMPILE_UNIT_LINTERS = new Set(['slang', 'verilator', 'iverilog']);
+
+export function getLintRunSettings(): CompileUnitLintSettings {
+  const lintConfig = vscode.workspace.getConfiguration('verilog.linting');
+  const compileUnitConfig = vscode.workspace.getConfiguration('verilog.linting.compileUnit');
+  return {
+    mode: lintConfig.get<LintMode>('mode', 'file'),
+    maxFiles: Math.max(1, compileUnitConfig.get<number>('maxFiles', 500)),
+    warnBeforeLargeRun: compileUnitConfig.get<boolean>('warnBeforeLargeRun', true),
+  };
+}
+
+export function supportsCompileUnitLint(linterName: string): boolean {
+  return COMPILE_UNIT_LINTERS.has(linterName);
+}

--- a/src/linter/ModelsimLinter.ts
+++ b/src/linter/ModelsimLinter.ts
@@ -7,6 +7,7 @@ import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import type { LintRunOptions } from './LintMode';
 
 export interface BuildModelsimArgsOptions {
   workLibrary: string;
@@ -90,7 +91,8 @@ export default class ModelsimLinter extends BaseLinter {
     return convertModelsimSeverity(severityString);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
+    this.warnUnsupportedCompileUnitMode(options);
     this.logger.info`modelsim lint requested`;
     const cwd: string = this.getWorkingDirectory(doc);
     // no change needed for systemverilog

--- a/src/linter/ProjectLintContext.ts
+++ b/src/linter/ProjectLintContext.ts
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
 import type { ProjectService } from '../project/ProjectService';
-import type { MacroDefine } from '../project/ProjectTypes';
+import type { CompileUnit, FileContext, MacroDefine, SourceFileRef } from '../project/ProjectTypes';
 
 export interface LintProjectContext {
   includePaths: string[];
   defineArgs: string[];
+}
+
+export interface CompileUnitLintContext {
+  ownerDocument: vscode.TextDocument;
+  fileContext: FileContext;
+  compileUnit: CompileUnit;
+  includeDirs: vscode.Uri[];
+  defines: Record<string, MacroDefine>;
+  files: SourceFileRef[];
+  workspaceRoot: vscode.Uri;
 }
 
 export function getLintProjectContext(
@@ -27,4 +37,28 @@ export function getLintProjectContext(
 
 export function formatMacroDefine(define: MacroDefine): string {
   return define.value === true ? define.name : `${define.name}=${define.value}`;
+}
+
+export function getCompileUnitLintContext(
+  projectService: ProjectService | undefined,
+  doc: vscode.TextDocument
+): CompileUnitLintContext | undefined {
+  const fileContext = projectService?.getPreferredFileContext(doc.uri);
+  if (!fileContext) {
+    return undefined;
+  }
+  const snapshot = projectService?.getSnapshot();
+  const compileUnit = snapshot?.compileUnits.find((candidate) => candidate.id === fileContext.compileUnitId);
+  if (!snapshot || !compileUnit) {
+    return undefined;
+  }
+  return {
+    ownerDocument: doc,
+    fileContext,
+    compileUnit,
+    includeDirs: compileUnit.includeDirs.slice(),
+    defines: { ...compileUnit.defines },
+    files: compileUnit.files.slice().sort((a, b) => a.order - b.order),
+    workspaceRoot: snapshot.workspaceRoot,
+  };
 }

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -9,8 +9,15 @@ import { convertToWslPath, type WslPathConversionOptions } from '../tools/WslPat
 import { getWorkspaceRootForDocument } from '../utils/workspace';
 import type { ProjectService } from '../project/ProjectService';
 import { splitCommandLineArgs } from '../utils/commandLine';
-import LinterDiagnosticManager from './LinterDiagnosticManager';
+import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import {
+  buildSlangCompileUnitArgs,
+  getCompileUnitDefineArgs,
+  getCompileUnitIncludePaths,
+  getCompileUnitSourcePaths,
+} from './CompileUnitLintArgs';
+import type { LintRunOptions } from './LintMode';
 
 const isWindows = process.platform === 'win32';
 
@@ -118,7 +125,14 @@ function convertSlangSeverity(severityString: string): vscode.DiagnosticSeverity
 }
 
 export function parseSlangDiagnostics(options: ParseSlangDiagnosticsOptions): vscode.Diagnostic[] {
+  return parseSlangDiagnosticsByFile(options).get(options.documentPath) ?? [];
+}
+
+export function parseSlangDiagnosticsByFile(
+  options: ParseSlangDiagnosticsOptions
+): Map<string, vscode.Diagnostic[]> {
   const diagnostics: vscode.Diagnostic[] = [];
+  const diagnosticsByFile = new Map<string, vscode.Diagnostic[]>();
   const re = /(.+?):(\d+):(\d+):\s(note|warning|error):\s(.*?)(\[-W(.*)\]|$)/;
   const convertToWslPath = options.convertToWslPath ?? ((inputPath: string) => inputPath);
 
@@ -137,23 +151,28 @@ export function parseSlangDiagnostics(options: ParseSlangDiagnosticsOptions): vs
       }
     }
 
-    if (!options.documentPath.endsWith(filePath)) {
-      return;
-    }
-
     const lineNum = Number(rex[2]) - 1;
     const colNum = Number(rex[3]) - 1;
 
-    diagnostics.push({
+    const diagnostic = {
       severity: convertSlangSeverity(rex[4]),
       range: new vscode.Range(lineNum, colNum, lineNum, END_OF_LINE),
-      message: rex[5],
+      message: rex[5].trim(),
       code: rex[7] ? rex[7] : 'error',
       source: 'slang',
-    });
+    };
+    if (options.documentPath.endsWith(filePath)) {
+      diagnostics.push(diagnostic);
+    }
+    const fileDiagnostics = diagnosticsByFile.get(filePath) ?? [];
+    fileDiagnostics.push(diagnostic);
+    diagnosticsByFile.set(filePath, fileDiagnostics);
   });
 
-  return diagnostics;
+  if (diagnostics.length > 0 && !diagnosticsByFile.has(options.documentPath)) {
+    diagnosticsByFile.set(options.documentPath, diagnostics);
+  }
+  return diagnosticsByFile;
 }
 
 export default class SlangLinter extends BaseLinter {
@@ -181,7 +200,7 @@ export default class SlangLinter extends BaseLinter {
     return convertSlangSeverity(severityString);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
     const commandInfo = buildSlangCommand({
       isWindows,
       useWSL: this.useWSL,
@@ -193,6 +212,40 @@ export default class SlangLinter extends BaseLinter {
       commandInfo.command,
       run
     );
+    const decision = await this.getLintDecision(doc, options);
+    if (decision.kind === 'skip') {
+      this.publishDocumentDiagnosticsIfCurrent(doc, run, []);
+      return;
+    }
+    if (decision.kind === 'compileUnit') {
+      const compileUnitPaths = await this.convertCompileUnitPaths(
+        getCompileUnitSourcePaths(decision.context),
+        commandInfo.command,
+        run
+      );
+      const compileUnitIncludePaths = await this.convertCompileUnitPaths(
+        this.resolveIncludePaths(this.config.includePath, doc).concat(getCompileUnitIncludePaths(decision.context)),
+        commandInfo.command,
+        run
+      );
+      const args = commandInfo.leadingArgs.concat(
+        buildSlangCompileUnitArgs({
+          docFolder: paths.docFolder,
+          includePaths: compileUnitIncludePaths,
+          defineArgs: getCompileUnitDefineArgs(decision.context),
+          customArguments: this.config.arguments,
+          sourcePaths: compileUnitPaths,
+        })
+      );
+      this.logger.info("Executing compile-unit lint", {
+        command: commandInfo.command,
+        args,
+        cwd: paths.cwd,
+        compileUnit: decision.context.compileUnit.id,
+      });
+      await this.runSlangCompileUnit(commandInfo.command, args, paths.cwd, paths.docUri, doc, run);
+      return;
+    }
     const args = commandInfo.leadingArgs.concat(
       buildSlangArgs({
         docFolder: paths.docFolder,
@@ -209,6 +262,21 @@ export default class SlangLinter extends BaseLinter {
     this.logger.info("Executing", { command: commandInfo.command, args, cwd: paths.cwd });
 
     await this.runSlang(commandInfo.command, args, paths.cwd, paths.docUri, doc, run);
+  }
+
+  private async convertCompileUnitPaths(
+    paths: string[],
+    wslCommand: string,
+    run: LintRunHandle
+  ): Promise<string[]> {
+    if (!isWindows || !this.useWSL) {
+      return isWindows ? paths.map((inputPath) => inputPath.replace(/\\/g, '/')) : paths;
+    }
+    const conversionOptions: WslPathConversionOptions = {
+      cancellationToken: run.cancellationToken,
+      wslCommand,
+    };
+    return Promise.all(paths.map((inputPath) => convertToWslPath(inputPath, conversionOptions)));
   }
 
   private async getRunPaths(
@@ -273,6 +341,52 @@ export default class SlangLinter extends BaseLinter {
       });
       this.logger.info`${diagnostics.length} errors/warnings returned`;
       this.publishDocumentDiagnosticsIfCurrent(doc, run, diagnostics);
+    } catch (err) {
+      if (err instanceof ToolRunError && err.reason === 'cancelled') {
+        return;
+      }
+      if (err instanceof ToolRunError) {
+        this.logger.error`slang failed: ${err.message}`;
+      } else {
+        this.logger.error`slang exception: ${err}`;
+      }
+      this.publishDocumentDiagnosticsIfCurrent(doc, run, []);
+    }
+  }
+
+  private async runSlangCompileUnit(
+    command: string,
+    args: string[],
+    cwd: string,
+    ownerDocumentPath: string,
+    doc: vscode.TextDocument,
+    run: LintRunHandle
+  ): Promise<void> {
+    try {
+      const result = await runTool({
+        command,
+        args,
+        cwd,
+        collectStdout: true,
+        collectStderr: true,
+        cancellationToken: run.cancellationToken,
+      });
+      if (!run.isCurrent()) {
+        return;
+      }
+      const diagnosticsByFile = parseSlangDiagnosticsByFile({
+        stderr: result.stderr,
+        documentPath: ownerDocumentPath,
+        isWindows,
+        useWSL: this.useWSL,
+      });
+      const diagnosticsByUri: DiagnosticMap = new Map();
+      diagnosticsByFile.forEach((diagnostics, fileName) => {
+        const uri = vscode.Uri.file(fileName);
+        diagnosticsByUri.set(uri.toString(), { uri, diagnostics });
+      });
+      this.logger.info`${diagnosticsByUri.size} files with errors/warnings returned`;
+      this.publishDiagnosticsIfCurrent(doc, run, diagnosticsByUri);
     } catch (err) {
       if (err instanceof ToolRunError && err.reason === 'cancelled') {
         return;

--- a/src/linter/VeribleVerilogLintLinter.ts
+++ b/src/linter/VeribleVerilogLintLinter.ts
@@ -8,6 +8,7 @@ import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import type { LintRunOptions } from './LintMode';
 
 const isWindows = process.platform === 'win32';
 
@@ -100,7 +101,8 @@ export default class VeribleVerilogLintLinter extends BaseLinter {
     return convertVeribleSeverity(message);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
+    this.warnUnsupportedCompileUnitMode(options);
     this.logger.info`Executing VeribleVerilogLintLinter.lint()`;
 
     const binName = isWindows ? 'verible-verilog-lint.exe' : 'verible-verilog-lint';

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -15,6 +15,12 @@ import type { ProjectService } from '../project/ProjectService';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager, { type DiagnosticMap } from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import {
+  getCompileUnitDefineArgs,
+  getCompileUnitIncludePaths,
+  getCompileUnitSourcePaths,
+} from './CompileUnitLintArgs';
+import type { LintRunOptions } from './LintMode';
 
 const isWindows = process.platform === 'win32';
 
@@ -51,6 +57,7 @@ export interface BuildVerilatorArgsOptions {
   defineArgs?: string[];
   customArguments: string;
   documentPath: string;
+  sourcePaths?: string[];
 }
 
 export interface BuildVerilatorRunInputsOptions {
@@ -64,6 +71,7 @@ export interface BuildVerilatorRunInputsOptions {
   includePaths: string[];
   defineArgs?: string[];
   customArguments: string;
+  sourcePaths?: string[];
   cancellationToken?: vscode.CancellationToken;
   convertToWslPathFn?: typeof convertToWslPath;
 }
@@ -139,7 +147,7 @@ export function buildVerilatorArgs(options: BuildVerilatorArgsOptions): string[]
   args.push(...options.includePaths.map((includePath) => `-I${includePath}`));
   args.push(...(options.defineArgs ?? []).map((defineArg) => `-D${defineArg}`));
   args.push(...splitCommandLineArgs(options.customArguments));
-  args.push(options.documentPath);
+  args.push(...(options.sourcePaths ?? [options.documentPath]));
   return args;
 }
 
@@ -156,6 +164,7 @@ export async function buildVerilatorRunInputs(
   let docUri = options.documentPath;
   let docFolder = rawDocFolder;
   let includePaths = options.includePaths;
+  let sourcePaths = options.sourcePaths;
 
   if (options.isWindows) {
     if (options.useWSL) {
@@ -169,9 +178,13 @@ export async function buildVerilatorRunInputs(
       includePaths = await Promise.all(
         options.includePaths.map((includePath) => convert(includePath, conversionOptions))
       );
+      sourcePaths = options.sourcePaths
+        ? await Promise.all(options.sourcePaths.map((sourcePath) => convert(sourcePath, conversionOptions)))
+        : undefined;
     } else {
       docUri = options.documentPath.replace(/\\/g, '/');
       docFolder = rawDocFolder.replace(/\\/g, '/');
+      sourcePaths = options.sourcePaths?.map((sourcePath) => sourcePath.replace(/\\/g, '/'));
     }
   }
 
@@ -191,6 +204,7 @@ export async function buildVerilatorRunInputs(
         defineArgs: options.defineArgs,
         customArguments: options.customArguments,
         documentPath: docUri,
+        sourcePaths,
     })
   );
 
@@ -372,8 +386,13 @@ export default class VerilatorLinter extends BaseLinter {
     return convertVerilatorSeverity(severityString);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
     try {
+      const decision = await this.getLintDecision(doc, options);
+      if (decision.kind === 'skip') {
+        this.replaceDiagnostics(doc, run, new Map<string, vscode.Diagnostic[]>());
+        return;
+      }
       const inputs = await buildVerilatorRunInputs({
         documentPath: doc.uri.fsPath,
         languageId: doc.languageId,
@@ -382,9 +401,16 @@ export default class VerilatorLinter extends BaseLinter {
         runAtFileLocation: this.config.runAtFileLocation,
         workspaceFolder: getWorkspaceRootForDocument(doc),
         linterInstalledPath: this.config.linterInstalledPath,
-        includePaths: this.getConfiguredAndProjectIncludePaths(doc),
-        defineArgs: this.getProjectContext(doc).defineArgs,
+        includePaths: decision.kind === 'compileUnit'
+          ? this.resolveIncludePaths(this.config.includePath, doc).concat(getCompileUnitIncludePaths(decision.context))
+          : this.getConfiguredAndProjectIncludePaths(doc),
+        defineArgs: decision.kind === 'compileUnit'
+          ? getCompileUnitDefineArgs(decision.context)
+          : this.getProjectContext(doc).defineArgs,
         customArguments: this.config.arguments,
+        sourcePaths: decision.kind === 'compileUnit'
+          ? getCompileUnitSourcePaths(decision.context)
+          : undefined,
         cancellationToken: run.cancellationToken,
       });
       if (!run.isCurrent()) {

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -8,6 +8,7 @@ import { runTool, ToolRunError } from '../tools/ToolRunner';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import LinterDiagnosticManager from './LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from './LintRunManager';
+import type { LintRunOptions } from './LintMode';
 
 export interface BuildXvlogArgsOptions {
   languageId: string;
@@ -85,7 +86,8 @@ export default class XvlogLinter extends BaseLinter {
     return convertXvlogSeverity(severityString);
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
+    this.warnUnsupportedCompileUnitMode(options);
     const binPath: string = path.join(this.config.linterInstalledPath, 'xvlog');
 
     const args = buildXvlogArgs({

--- a/src/test/baseLinterRunManager.test.ts
+++ b/src/test/baseLinterRunManager.test.ts
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import BaseLinter from '../linter/BaseLinter';
+import BaseLinter, { type LintDecision } from '../linter/BaseLinter';
 import LintManager from '../linter/LintManager';
 import LinterDiagnosticManager, { type DiagnosticSink } from '../linter/LinterDiagnosticManager';
 import LintRunManager, { type LintRunHandle } from '../linter/LintRunManager';
+import type { LintRunOptions } from '../linter/LintMode';
+import type { ProjectService } from '../project/ProjectService';
 
 class FakeDiagnosticSink implements DiagnosticSink {
   readonly diagnostics = new Map<string, readonly vscode.Diagnostic[]>();
@@ -46,7 +48,8 @@ class Deferred {
 type LintAction = (
   linter: TestLinter,
   doc: vscode.TextDocument,
-  run: LintRunHandle
+  run: LintRunHandle,
+  options: LintRunOptions
 ) => Promise<void>;
 
 class TestLinter extends BaseLinter {
@@ -55,9 +58,10 @@ class TestLinter extends BaseLinter {
   constructor(
     diagnosticManager: LinterDiagnosticManager,
     runManager: LintRunManager,
-    readonly sourceId = 'test-linter'
+    readonly sourceId = 'test-linter',
+    projectService?: ProjectService
   ) {
-    super(sourceId, diagnosticManager, runManager);
+    super(sourceId, diagnosticManager, runManager, projectService);
   }
 
   queueAction(action: LintAction): void {
@@ -82,16 +86,28 @@ class TestLinter extends BaseLinter {
     return vscode.DiagnosticSeverity.Error;
   }
 
-  protected async lint(doc: vscode.TextDocument, run: LintRunHandle): Promise<void> {
+  async decide(doc: vscode.TextDocument, options: LintRunOptions): Promise<LintDecision> {
+    return this.getLintDecision(doc, options);
+  }
+
+  protected async lint(
+    doc: vscode.TextDocument,
+    run: LintRunHandle,
+    options: LintRunOptions
+  ): Promise<void> {
     const action = this.actions.shift();
     if (action) {
-      await action(this, doc, run);
+      await action(this, doc, run, options);
     }
   }
 }
 
 function documentFor(uri: vscode.Uri): vscode.TextDocument {
   return { uri } as vscode.TextDocument;
+}
+
+function docUri(fsPath: string): vscode.Uri {
+  return vscode.Uri.file(fsPath);
 }
 
 function createHarness(sourceId?: string): {
@@ -105,6 +121,52 @@ function createHarness(sourceId?: string): {
   const linter = new TestLinter(new LinterDiagnosticManager(sink), runManager, sourceId);
   const doc = documentFor(vscode.Uri.file('/tmp/top.v'));
   return { sink, runManager, linter, doc };
+}
+
+function createHarnessWithProject(projectService: ProjectService): {
+  sink: FakeDiagnosticSink;
+  runManager: LintRunManager;
+  linter: TestLinter;
+  doc: vscode.TextDocument;
+} {
+  const sink = new FakeDiagnosticSink();
+  const runManager = new LintRunManager();
+  const doc = documentFor(vscode.Uri.file('/tmp/a.sv'));
+  const linter = new TestLinter(new LinterDiagnosticManager(sink), runManager, 'test-linter', projectService);
+  return { sink, runManager, linter, doc };
+}
+
+function createProjectServiceForCompileUnit(ownerUri: vscode.Uri, fileCount: number): ProjectService {
+  const files = Array.from({ length: fileCount }, (_, index) => ({
+    uri: index === 0 ? ownerUri : vscode.Uri.file(`/tmp/${index}.sv`),
+    languageId: 'systemverilog' as const,
+    kind: 'source' as const,
+    order: index,
+  }));
+  return {
+    getPreferredFileContext: () => ({
+      file: ownerUri,
+      compileUnitId: 'unit',
+      includeDirs: [],
+      defines: {},
+    }),
+    getSnapshot: () => ({
+      version: 1,
+      workspaceRoot: vscode.Uri.file('/tmp'),
+      activeTargetId: 'unit',
+      compileUnits: [{
+        id: 'unit',
+        name: 'unit',
+        root: vscode.Uri.file('/tmp'),
+        files,
+        includeDirs: [],
+        defines: {},
+        topModules: [],
+        source: { type: 'settings' },
+      }],
+      diagnostics: [],
+    }),
+  } as unknown as ProjectService;
 }
 
 suite('BaseLinter run management', () => {
@@ -134,6 +196,47 @@ suite('BaseLinter run management', () => {
 
     assert.strictEqual(disposeCount, 1);
     assert.strictEqual((manager as any).linter, null);
+  });
+
+  test('compile-unit maxFiles guard skips automatic runs', async () => {
+    const config = vscode.workspace.getConfiguration('verilog.linting');
+    const compileConfig = vscode.workspace.getConfiguration('verilog.linting.compileUnit');
+    const previousMode = config.get('mode');
+    const previousMaxFiles = compileConfig.get('maxFiles');
+    const { linter, doc } = createHarnessWithProject(createProjectServiceForCompileUnit(docUri('/tmp/a.sv'), 2));
+
+    try {
+      await config.update('mode', 'compileUnit', vscode.ConfigurationTarget.Global);
+      await compileConfig.update('maxFiles', 1, vscode.ConfigurationTarget.Global);
+      const decision = await linter.decide(doc, { trigger: 'automatic' });
+
+      assert.strictEqual(decision.kind, 'skip');
+    } finally {
+      await config.update('mode', previousMode, vscode.ConfigurationTarget.Global);
+      await compileConfig.update('maxFiles', previousMaxFiles, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test('manual compile-unit lint can bypass large-run confirmation when disabled', async () => {
+    const config = vscode.workspace.getConfiguration('verilog.linting');
+    const compileConfig = vscode.workspace.getConfiguration('verilog.linting.compileUnit');
+    const previousMode = config.get('mode');
+    const previousMaxFiles = compileConfig.get('maxFiles');
+    const previousWarn = compileConfig.get('warnBeforeLargeRun');
+    const { linter, doc } = createHarnessWithProject(createProjectServiceForCompileUnit(docUri('/tmp/a.sv'), 2));
+
+    try {
+      await config.update('mode', 'compileUnit', vscode.ConfigurationTarget.Global);
+      await compileConfig.update('maxFiles', 1, vscode.ConfigurationTarget.Global);
+      await compileConfig.update('warnBeforeLargeRun', false, vscode.ConfigurationTarget.Global);
+      const decision = await linter.decide(doc, { trigger: 'manual' });
+
+      assert.strictEqual(decision.kind, 'compileUnit');
+    } finally {
+      await config.update('mode', previousMode, vscode.ConfigurationTarget.Global);
+      await compileConfig.update('maxFiles', previousMaxFiles, vscode.ConfigurationTarget.Global);
+      await compileConfig.update('warnBeforeLargeRun', previousWarn, vscode.ConfigurationTarget.Global);
+    }
   });
 
   test('stale run cannot publish diagnostics', async () => {

--- a/src/test/compileUnitLintArgs.test.ts
+++ b/src/test/compileUnitLintArgs.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+  buildIcarusCompileUnitArgs,
+  buildSlangCompileUnitArgs,
+  buildVerilatorCompileUnitArgs,
+  getCompileUnitDefineArgs,
+  getCompileUnitIncludePaths,
+  getCompileUnitSourcePaths,
+} from '../linter/CompileUnitLintArgs';
+import type { CompileUnitLintContext } from '../linter/ProjectLintContext';
+
+suite('CompileUnitLintArgs', () => {
+  test('generates Slang args with include dirs, defines, custom args, and source order', () => {
+    const context = createContext();
+
+    const args = buildSlangCompileUnitArgs({
+      docFolder: '/workspace/rtl',
+      includePaths: getCompileUnitIncludePaths(context),
+      defineArgs: getCompileUnitDefineArgs(context),
+      customArguments: '--flag "two words"',
+      sourcePaths: getCompileUnitSourcePaths(context),
+    });
+
+    assert.deepStrictEqual(args, [
+      '-I',
+      '/workspace/rtl',
+      '-I',
+      '/workspace/inc',
+      '-D',
+      'SIM',
+      '-D',
+      'WIDTH=32',
+      '--flag',
+      'two words',
+      '/workspace/rtl/a.sv',
+      '/workspace/rtl/b.sv',
+    ]);
+  });
+
+  test('generates Verilator args with source order', () => {
+    const context = createContext();
+
+    const args = buildVerilatorCompileUnitArgs({
+      languageId: 'systemverilog',
+      docFolder: '/workspace/rtl',
+      includePaths: getCompileUnitIncludePaths(context),
+      defineArgs: getCompileUnitDefineArgs(context),
+      customArguments: '-Wall',
+      sourcePaths: getCompileUnitSourcePaths(context),
+    });
+
+    assert.deepStrictEqual(args, [
+      '-sv',
+      '--lint-only',
+      '-I/workspace/rtl',
+      '-I/workspace/inc',
+      '-DSIM',
+      '-DWIDTH=32',
+      '-Wall',
+      '/workspace/rtl/a.sv',
+      '/workspace/rtl/b.sv',
+    ]);
+  });
+
+  test('generates Icarus args with standards and source order', () => {
+    const context = createContext();
+    const standards = new Map<string, string>([['systemverilog', 'SystemVerilog2012']]);
+
+    const args = buildIcarusCompileUnitArgs({
+      languageId: 'systemverilog',
+      standards,
+      includePaths: getCompileUnitIncludePaths(context),
+      defineArgs: getCompileUnitDefineArgs(context),
+      customArguments: '-Wall',
+      sourcePaths: getCompileUnitSourcePaths(context),
+    });
+
+    assert.deepStrictEqual(args, [
+      '-t',
+      'null',
+      '-g2012',
+      '-I',
+      '/workspace/inc',
+      '-D',
+      'SIM',
+      '-D',
+      'WIDTH=32',
+      '-Wall',
+      '/workspace/rtl/a.sv',
+      '/workspace/rtl/b.sv',
+    ]);
+  });
+});
+
+function createContext(): CompileUnitLintContext {
+  const ownerDocument = {
+    uri: vscode.Uri.file('/workspace/rtl/a.sv'),
+  } as vscode.TextDocument;
+  return {
+    ownerDocument,
+    fileContext: {
+      file: ownerDocument.uri,
+      compileUnitId: 'unit',
+      includeDirs: [vscode.Uri.file('/workspace/inc')],
+      defines: {},
+    },
+    compileUnit: {
+      id: 'unit',
+      name: 'unit',
+      root: vscode.Uri.file('/workspace'),
+      files: [
+        {
+          uri: vscode.Uri.file('/workspace/rtl/a.sv'),
+          languageId: 'systemverilog',
+          kind: 'source',
+          order: 0,
+        },
+        {
+          uri: vscode.Uri.file('/workspace/rtl/b.sv'),
+          languageId: 'systemverilog',
+          kind: 'source',
+          order: 1,
+        },
+      ],
+      includeDirs: [vscode.Uri.file('/workspace/inc')],
+      defines: {
+        SIM: { name: 'SIM', value: true, source: 'filelist' },
+        WIDTH: { name: 'WIDTH', value: '32', source: 'filelist' },
+      },
+      topModules: [],
+      source: { type: 'settings' },
+    },
+    includeDirs: [vscode.Uri.file('/workspace/inc')],
+    defines: {
+      SIM: { name: 'SIM', value: true, source: 'filelist' },
+      WIDTH: { name: 'WIDTH', value: '32', source: 'filelist' },
+    },
+    files: [
+      {
+        uri: vscode.Uri.file('/workspace/rtl/a.sv'),
+        languageId: 'systemverilog',
+        kind: 'source',
+        order: 0,
+      },
+      {
+        uri: vscode.Uri.file('/workspace/rtl/b.sv'),
+        languageId: 'systemverilog',
+        kind: 'source',
+        order: 1,
+      },
+    ],
+    workspaceRoot: vscode.Uri.file('/workspace'),
+  };
+}

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -111,6 +111,23 @@ suite('Doctor', () => {
     assert.ok(checks.some((check) => check.status === 'error' && check.message.includes('iverilog')));
   });
 
+  test('linter checks report compile-unit mode support and active compile unit', async () => {
+    const checks = await buildLinterChecks(
+      {
+        linter: 'verible-verilog-lint',
+        linterPath: '',
+        arguments: '',
+        lintMode: 'compileUnit',
+        activeCompileUnit: { id: 'unit', name: 'unit', files: 2 },
+      },
+      makeDeps({ executables: { 'verible-verilog-lint': '/usr/bin/verible-verilog-lint' } })
+    );
+
+    assert.ok(checks.some((check) => check.message === 'verilog.linting.mode = compileUnit'));
+    assert.ok(checks.some((check) => check.status === 'warn' && check.message === 'compileUnit support = false'));
+    assert.ok(checks.some((check) => check.message.includes('active compile unit = unit (unit), files=2')));
+  });
+
   test('disabled language server produces info, not error', async () => {
     const checks = await buildLanguageServerChecks(
       {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -174,6 +174,9 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
     assert.ok(properties['verilog.preprocessor.useProjectDefines']);
     assert.ok(properties['verilog.linting.useProjectContext']);
+    assert.ok(properties['verilog.linting.mode']);
+    assert.ok(properties['verilog.linting.compileUnit.maxFiles']);
+    assert.ok(properties['verilog.linting.compileUnit.warnBeforeLargeRun']);
     assert.ok(properties['verilog.completion.ports.enabled']);
     assert.ok(properties['verilog.completion.parameters.enabled']);
     assert.ok(properties['verilog.completion.autoConnectPorts']);

--- a/src/test/projectLintContext.test.ts
+++ b/src/test/projectLintContext.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { getLintProjectContext } from '../linter/ProjectLintContext';
+import { getCompileUnitLintContext, getLintProjectContext } from '../linter/ProjectLintContext';
 import type { ProjectService } from '../project/ProjectService';
 
 suite('Project lint context', () => {
@@ -51,5 +51,73 @@ suite('Project lint context', () => {
     } finally {
       await config.update('useProjectContext', previous, vscode.ConfigurationTarget.Global);
     }
+  });
+
+  test('resolves compile unit context for active document', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+    const projectService = {
+      getPreferredFileContext: () => ({
+        file: document.uri,
+        compileUnitId: 'unit',
+        includeDirs: [vscode.Uri.file('/workspace/inc')],
+        defines: {},
+      }),
+      getSnapshot: () => ({
+        version: 1,
+        workspaceRoot: vscode.Uri.file('/workspace'),
+        activeTargetId: 'unit',
+        compileUnits: [{
+          id: 'unit',
+          name: 'unit',
+          root: vscode.Uri.file('/workspace'),
+          files: [
+            {
+              uri: vscode.Uri.file('/workspace/b.sv'),
+              languageId: 'systemverilog',
+              kind: 'source',
+              order: 1,
+            },
+            {
+              uri: document.uri,
+              languageId: 'systemverilog',
+              kind: 'source',
+              order: 0,
+            },
+          ],
+          includeDirs: [vscode.Uri.file('/workspace/inc')],
+          defines: {
+            SIM: { name: 'SIM', value: true, source: 'filelist' },
+          },
+          topModules: [],
+          source: { type: 'settings' },
+        }],
+        diagnostics: [],
+      }),
+    } as unknown as ProjectService;
+
+    const context = getCompileUnitLintContext(projectService, document);
+
+    assert.ok(context);
+    assert.strictEqual(context.compileUnit.id, 'unit');
+    assert.deepStrictEqual(context.files.map((file) => file.uri.fsPath), [
+      document.uri.fsPath,
+      '/workspace/b.sv',
+    ]);
+    assert.deepStrictEqual(context.includeDirs.map((uri) => uri.fsPath), ['/workspace/inc']);
+  });
+
+  test('returns undefined when active document has no compile unit membership', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+    const context = getCompileUnitLintContext({
+      getPreferredFileContext: () => undefined,
+    } as unknown as ProjectService, document);
+
+    assert.strictEqual(context, undefined);
   });
 });

--- a/src/test/slang.test.ts
+++ b/src/test/slang.test.ts
@@ -8,6 +8,7 @@ import {
   buildSlangCommand,
   getSlangPaths,
   parseSlangDiagnostics,
+  parseSlangDiagnosticsByFile,
 } from '../linter/SlangLinter';
 
 suite('Slang Linter', () => {
@@ -110,6 +111,25 @@ suite('Slang Linter', () => {
     assert.strictEqual(diagnostics[0].source, 'slang');
     assert.strictEqual(diagnostics[1].severity, vscode.DiagnosticSeverity.Warning);
     assert.strictEqual(diagnostics[1].code, 'unused');
+  });
+
+  test('parses compile-unit diagnostics across multiple files', () => {
+    const ownerPath = '/tmp/slang source/top file.sv';
+    const childPath = '/tmp/slang source/child.sv';
+    const stderr = [
+      `${ownerPath}:3:12: error: top error`,
+      `${childPath}:4:2: warning: child warning [-Wunused]`,
+    ].join('\n');
+
+    const diagnosticsByFile = parseSlangDiagnosticsByFile({
+      stderr,
+      documentPath: ownerPath,
+      isWindows: false,
+      useWSL: false,
+    });
+
+    assert.strictEqual(diagnosticsByFile.get(ownerPath)?.[0]?.message, 'top error');
+    assert.strictEqual(diagnosticsByFile.get(childPath)?.[0]?.message, 'child warning');
   });
 
   test('does not import child_process or call child exec', () => {

--- a/src/test/verilator.test.ts
+++ b/src/test/verilator.test.ts
@@ -230,6 +230,7 @@ suite('Verilator Linter', () => {
       linterInstalledPath: '',
       includePaths: ['C:\\workspace\\include dir'],
       customArguments: '--trace',
+      sourcePaths: ['C:\\workspace\\rtl\\top.sv', 'C:\\workspace\\rtl\\child.sv'],
       convertToWslPathFn: async (inputPath, options) => {
         assert.strictEqual(options?.wslCommand, 'wsl');
         convertedInputs.push(inputPath);
@@ -244,6 +245,8 @@ suite('Verilator Linter', () => {
       'C:\\workspace\\rtl\\top.sv',
       'C:\\workspace\\rtl',
       'C:\\workspace\\include dir',
+      'C:\\workspace\\rtl\\top.sv',
+      'C:\\workspace\\rtl\\child.sv',
     ]);
     assert.deepStrictEqual(inputs.args, [
       'verilator',
@@ -253,6 +256,7 @@ suite('Verilator Linter', () => {
       '-I/mnt/c/workspace/include dir',
       '--trace',
       '/mnt/c/workspace/rtl/top.sv',
+      '/mnt/c/workspace/rtl/child.sv',
     ]);
     assert.ok(
       !inputs.args.some((arg) => arg.includes('C:\\workspace')),


### PR DESCRIPTION
## Summary
- add optional compile-unit lint mode with file mode as the default
- support compile-unit runs for Slang, Verilator, and Icarus
- fall back unsupported linters to file mode with warning/log behavior
- report lint mode and active compile-unit details in Doctor

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 288 passing, 3 pending