### PR TITLE
Stabilize project-aware IDE foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The extension can build a lightweight project model for Verilog/SystemVerilog wo
 
 The project model powers cross-file module lookup, include resolution, workspace symbols, hover, completion, module instantiation, HDL Explorer, and compile-unit linting. Existing Ctags behavior remains available as a fallback when the project index has no answer or the project model is disabled with `verilog.project.enabled`.
 
+Project diagnostics with source locations are published to VS Code Problems; diagnostics without a precise location remain visible in Project Status, Doctor, and HDL Explorer. When multiple compile units exist, `verilog.project.activeTarget` can match either a compile unit id or name; if it is empty, a single compile unit is selected automatically.
+
 Use **Verilog: Reload Project**, **Verilog: Show Project Status**, and **Verilog: Show Project Modules** to inspect or refresh the current project model.
 
 ### HDL Explorer And Hierarchy

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { CompletionService } from './hdl/CompletionService';
 import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
 import { HoverService } from './hdl/HoverService';
 import { HierarchyService } from './hierarchy/HierarchyService';
+import { ProjectDiagnosticManager } from './project/ProjectDiagnosticManager';
 import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
@@ -52,6 +53,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(ctagsManager);
 
   const projectService = new ProjectService();
+  const projectDiagnosticManager = new ProjectDiagnosticManager(projectService);
   const indexService = new IndexService(projectService);
   const definitionService = new DefinitionService(projectService, indexService, ctagsManager);
   const instantiationService = new InstantiationService(indexService);
@@ -60,7 +62,14 @@ export async function activate(context: vscode.ExtensionContext) {
   const hoverService = new HoverService(projectService, indexService, ctagsManager);
   const hierarchyService = new HierarchyService(projectService, indexService);
   const hdlExplorerProvider = new HdlExplorerProvider(projectService, indexService, hierarchyService);
-  context.subscriptions.push(projectService, indexService, hierarchyService, hdlExplorerProvider, new ProjectWatcher(projectService));
+  context.subscriptions.push(
+    projectService,
+    projectDiagnosticManager,
+    indexService,
+    hierarchyService,
+    hdlExplorerProvider,
+    new ProjectWatcher(projectService)
+  );
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
   context.subscriptions.push(...registerHdlExplorerCommands(hierarchyService, hdlExplorerProvider));
   context.subscriptions.push(

--- a/src/hdl/CompletionService.ts
+++ b/src/hdl/CompletionService.ts
@@ -62,10 +62,9 @@ export class CompletionService {
       if (!isInstanceCompletionEnabled(instanceContext.kind)) {
         return { items: [] };
       }
-      const moduleRecord = findBestModuleRecord(
-        this.indexService.getIndex().findModules(instanceContext.moduleName),
-        this.projectService.getPreferredFileContext(document.uri)?.compileUnitId
-      );
+      const moduleRecord = this.indexService
+        .getIndex()
+        .findBestModule(instanceContext.moduleName, this.projectService.getPreferredFileContext(document.uri));
       if (moduleRecord) {
         return {
           items: getInstanceCompletionItems(moduleRecord, instanceContext, document, position),
@@ -176,13 +175,6 @@ function isInstanceCompletionEnabled(kind: InstanceContext['kind']): boolean {
     ? 'verilog.completion.parameters.enabled'
     : 'verilog.completion.ports.enabled';
   return vscode.workspace.getConfiguration().get<boolean>(setting, true);
-}
-
-function findBestModuleRecord(
-  modules: ModuleRecord[],
-  preferredCompileUnitId: string | undefined
-): ModuleRecord | undefined {
-  return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
 }
 
 export function symbolToCompletionItem(

--- a/src/hdl/HoverService.ts
+++ b/src/hdl/HoverService.ts
@@ -66,10 +66,9 @@ export class HoverService {
     if (!word) {
       return undefined;
     }
-    const moduleRecord = this.findBestModuleRecord(
-      this.indexService.getIndex().findModules(word.text),
-      document.uri
-    );
+    const moduleRecord = this.indexService
+      .getIndex()
+      .findBestModule(word.text, this.projectService.getPreferredFileContext(document.uri));
     if (!moduleRecord) {
       return undefined;
     }
@@ -90,10 +89,9 @@ export class HoverService {
       return undefined;
     }
 
-    const moduleRecord = this.findBestModuleRecord(
-      this.indexService.getIndex().findModules(context.moduleName),
-      document.uri
-    );
+    const moduleRecord = this.indexService
+      .getIndex()
+      .findBestModule(context.moduleName, this.projectService.getPreferredFileContext(document.uri));
     if (!moduleRecord) {
       return undefined;
     }
@@ -172,18 +170,12 @@ export class HoverService {
       return undefined;
     }
     const preferredCompileUnitId = this.projectService.getPreferredFileContext(document.uri)?.compileUnitId;
-    const symbol = this.indexService
-      .getIndex()
-      .getAllSymbols()
-      .find((candidate) =>
-        HOVER_SYMBOL_KINDS.has(candidate.kind)
-        && candidate.name === word.text
-        && (!preferredCompileUnitId || candidate.compileUnitId === preferredCompileUnitId)
-      )
-      ?? this.indexService
-        .getIndex()
-        .getAllSymbols()
-        .find((candidate) => HOVER_SYMBOL_KINDS.has(candidate.kind) && candidate.name === word.text);
+    const index = this.indexService.getIndex();
+    const symbol = index.findSymbolsByName(word.text, {
+      compileUnitId: preferredCompileUnitId,
+      kinds: [...HOVER_SYMBOL_KINDS],
+    }).at(0)
+      ?? index.findSymbolsByName(word.text, { kinds: [...HOVER_SYMBOL_KINDS] }).at(0);
     if (!symbol) {
       return undefined;
     }
@@ -206,11 +198,6 @@ export class HoverService {
       return new vscode.Hover(hoverText);
     }
     return undefined;
-  }
-
-  private findBestModuleRecord(modules: ModuleRecord[], documentUri: vscode.Uri): ModuleRecord | undefined {
-    const preferredCompileUnitId = this.projectService.getPreferredFileContext(documentUri)?.compileUnitId;
-    return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
   }
 }
 

--- a/src/hdl/ModuleInstanceCodeActionService.ts
+++ b/src/hdl/ModuleInstanceCodeActionService.ts
@@ -42,10 +42,9 @@ export class ModuleInstanceCodeActionService {
       return [];
     }
 
-    const moduleRecord = findBestModuleRecord(
-      this.indexService.getIndex().findModules(context.moduleName),
-      this.projectService.getPreferredFileContext(document.uri)?.compileUnitId
-    );
+    const moduleRecord = this.indexService
+      .getIndex()
+      .findBestModule(context.moduleName, this.projectService.getPreferredFileContext(document.uri));
     if (!moduleRecord) {
       return [];
     }
@@ -220,13 +219,6 @@ function createCodeAction(result: FillActionBuildResult): vscode.CodeAction {
   const action = new vscode.CodeAction(result.title, vscode.CodeActionKind.QuickFix);
   action.edit = result.edit;
   return action;
-}
-
-function findBestModuleRecord(
-  modules: ModuleRecord[],
-  preferredCompileUnitId: string | undefined
-): ModuleRecord | undefined {
-  return modules.find((moduleRecord) => moduleRecord.compileUnitId === preferredCompileUnitId) ?? modules[0];
 }
 
 function isSettingEnabled(setting: string): boolean {

--- a/src/hierarchy/HierarchyBuilder.ts
+++ b/src/hierarchy/HierarchyBuilder.ts
@@ -30,7 +30,7 @@ export class HierarchyBuilder {
     const instancesByParent = groupInstancesByParent(instances);
     const resolvedInstanceKeys = new Set(
       instances
-        .map((instance) => findBestModule(index.findModules(instance.moduleName), instance.compileUnitId))
+        .map((instance) => index.findBestModule(instance.moduleName, instance.compileUnitId))
         .filter((moduleRecord): moduleRecord is ModuleRecord => moduleRecord !== undefined)
         .map(moduleKey)
     );
@@ -78,7 +78,7 @@ function buildNode(
   const unresolvedInstances: HierarchyInstanceNode[] = [];
 
   for (const instance of childInstances) {
-    const resolvedModule = findBestModule(index.findModules(instance.moduleName), instance.compileUnitId);
+    const resolvedModule = index.findBestModule(instance.moduleName, instance.compileUnitId);
     const instanceNode: HierarchyInstanceNode = {
       instanceName: instance.instanceName,
       moduleName: instance.moduleName,
@@ -151,16 +151,12 @@ function findUnresolvedInstances(
   index: SemanticIndex
 ): HierarchyInstanceNode[] {
   return instances
-    .filter((instance) => !findBestModule(index.findModules(instance.moduleName), instance.compileUnitId))
+    .filter((instance) => !index.findBestModule(instance.moduleName, instance.compileUnitId))
     .map((instance) => ({
       instanceName: instance.instanceName,
       moduleName: instance.moduleName,
       location: new vscode.Location(instance.uri, instance.selectionRange),
     }));
-}
-
-function findBestModule(modules: ModuleRecord[], compileUnitId: string): ModuleRecord | undefined {
-  return modules.find((moduleRecord) => moduleRecord.compileUnitId === compileUnitId) ?? modules[0];
 }
 
 function moduleKey(moduleRecord: ModuleRecord): string {

--- a/src/project/FileContextResolver.ts
+++ b/src/project/FileContextResolver.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import { getActiveCompileUnit } from './ProjectTargetResolver';
 import { cloneDefines, type FileContext, type ProjectSnapshot } from './ProjectTypes';
 
 export class FileContextResolver {
@@ -23,8 +24,9 @@ export class FileContextResolver {
 
   getPreferredFileContext(uri: vscode.Uri): FileContext | undefined {
     const contexts = this.getFileContexts(uri);
+    const activeCompileUnit = getActiveCompileUnit(this.snapshot);
     return (
-      contexts.find((context) => context.compileUnitId === this.snapshot.activeTargetId) ??
+      contexts.find((context) => context.compileUnitId === activeCompileUnit?.id) ??
       contexts.at(0)
     );
   }

--- a/src/project/ProjectCommands.ts
+++ b/src/project/ProjectCommands.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
 import type { IndexService } from '../semantic/IndexService';
+import { getActiveCompileUnit } from './ProjectTargetResolver';
 import type { ProjectService } from './ProjectService';
 import type { FileContext, ProjectDiagnostic, ProjectSnapshot } from './ProjectTypes';
 
@@ -43,12 +44,14 @@ export function registerProjectCommands(
 
 export function renderProjectStatus(projectService: ProjectService): string {
   const snapshot = projectService.getSnapshot();
+  const activeCompileUnit = getActiveCompileUnit(snapshot);
   const lines: string[] = [
     '# Verilog Project Status',
     '',
     `Project enabled: ${isProjectEnabled(snapshot) ? 'yes' : 'no'}`,
     `Workspace root: ${snapshot.workspaceRoot.fsPath}`,
     `Active target: ${snapshot.activeTargetId || '(none)'}`,
+    `Resolved active compile unit: ${activeCompileUnit ? `${activeCompileUnit.name} (${activeCompileUnit.id})` : '(none)'}`,
     `Compile units: ${snapshot.compileUnits.length}`,
     `Files: ${countFiles(snapshot)}`,
     '',

--- a/src/project/ProjectDiagnosticManager.ts
+++ b/src/project/ProjectDiagnosticManager.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ProjectService } from './ProjectService';
+import type { ProjectDiagnostic, ProjectSnapshot } from './ProjectTypes';
+
+export interface ProjectDiagnosticSink {
+  set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void;
+  clear(): void;
+  dispose(): void;
+}
+
+export class ProjectDiagnosticManager implements vscode.Disposable {
+  private readonly disposable: vscode.Disposable;
+
+  constructor(
+    projectService: ProjectService,
+    private readonly sink: ProjectDiagnosticSink = vscode.languages.createDiagnosticCollection('verilog-project')
+  ) {
+    this.disposable = projectService.onDidChangeSnapshot((snapshot) => this.publish(snapshot));
+    this.publish(projectService.getSnapshot());
+  }
+
+  publish(snapshot: ProjectSnapshot): void {
+    this.sink.clear();
+    for (const entry of groupProjectDiagnostics(snapshot.diagnostics).values()) {
+      this.sink.set(entry.uri, entry.diagnostics);
+    }
+  }
+
+  dispose(): void {
+    this.disposable.dispose();
+    this.sink.dispose();
+  }
+}
+
+export interface ProjectDiagnosticEntry {
+  uri: vscode.Uri;
+  diagnostics: vscode.Diagnostic[];
+}
+
+export function groupProjectDiagnostics(
+  projectDiagnostics: readonly ProjectDiagnostic[]
+): Map<string, ProjectDiagnosticEntry> {
+  const grouped = new Map<string, ProjectDiagnosticEntry>();
+  for (const projectDiagnostic of projectDiagnostics) {
+    if (!projectDiagnostic.location) {
+      continue;
+    }
+    const uri = projectDiagnostic.location.uri;
+    const key = uri.toString();
+    const entry = grouped.get(key) ?? { uri, diagnostics: [] };
+    entry.diagnostics.push(toVsCodeDiagnostic(projectDiagnostic));
+    grouped.set(key, entry);
+  }
+  return grouped;
+}
+
+function toVsCodeDiagnostic(projectDiagnostic: ProjectDiagnostic): vscode.Diagnostic {
+  const diagnostic = new vscode.Diagnostic(
+    projectDiagnostic.location?.range ?? new vscode.Range(0, 0, 0, 0),
+    projectDiagnostic.message,
+    toVsCodeSeverity(projectDiagnostic.severity)
+  );
+  diagnostic.source = projectDiagnostic.source;
+  diagnostic.code = projectDiagnostic.code;
+  return diagnostic;
+}
+
+function toVsCodeSeverity(severity: ProjectDiagnostic['severity']): vscode.DiagnosticSeverity {
+  switch (severity) {
+    case 'error':
+      return vscode.DiagnosticSeverity.Error;
+    case 'warning':
+      return vscode.DiagnosticSeverity.Warning;
+    case 'info':
+      return vscode.DiagnosticSeverity.Information;
+  }
+}

--- a/src/project/ProjectLoader.ts
+++ b/src/project/ProjectLoader.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import type { ResolvedFilelist } from '../filelist/FilelistResolver';
 import { getExtensionLogger } from '../logging';
 import { buildCompileUnit } from './ProjectModelMerger';
+import { createActiveTargetDiagnostic } from './ProjectTargetResolver';
 import {
   PROJECT_DIAGNOSTIC_SOURCE,
   type CompileUnit,
@@ -63,6 +64,13 @@ export class ProjectLoader {
       settings.filelists.length > 0
         ? this.loadFilelistCompileUnits(workspaceRoot, settings, diagnostics)
         : await this.loadFallbackCompileUnit(workspaceRoot, settings, diagnostics);
+
+    const activeTargetDiagnostic = createActiveTargetDiagnostic(
+      createSnapshot(version, workspaceRoot, settings.activeTarget, compileUnits, diagnostics)
+    );
+    if (activeTargetDiagnostic) {
+      diagnostics.push(activeTargetDiagnostic);
+    }
 
     logger.info('Loaded Verilog project model', {
       workspaceRoot: workspaceRoot.fsPath,

--- a/src/project/ProjectTargetResolver.ts
+++ b/src/project/ProjectTargetResolver.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+import {
+  PROJECT_DIAGNOSTIC_SOURCE,
+  type CompileUnit,
+  type ProjectDiagnostic,
+  type ProjectSnapshot,
+} from './ProjectTypes';
+
+export function findCompileUnitByTarget(
+  snapshot: ProjectSnapshot,
+  targetId: string
+): CompileUnit | undefined {
+  if (targetId.length === 0) {
+    return snapshot.compileUnits.length === 1 ? snapshot.compileUnits[0] : undefined;
+  }
+  return snapshot.compileUnits.find((compileUnit) => compileUnit.id === targetId)
+    ?? snapshot.compileUnits.find((compileUnit) => compileUnit.name === targetId);
+}
+
+export function getActiveCompileUnit(snapshot: ProjectSnapshot): CompileUnit | undefined {
+  return findCompileUnitByTarget(snapshot, snapshot.activeTargetId);
+}
+
+export function getAvailableCompileUnitLabels(snapshot: ProjectSnapshot): string[] {
+  return snapshot.compileUnits.map((compileUnit) => `${compileUnit.name} (${compileUnit.id})`);
+}
+
+export function createActiveTargetDiagnostic(snapshot: ProjectSnapshot): ProjectDiagnostic | undefined {
+  if (snapshot.activeTargetId.length === 0 || getActiveCompileUnit(snapshot)) {
+    return undefined;
+  }
+  const available = getAvailableCompileUnitLabels(snapshot).join(', ') || '(none)';
+  return {
+    severity: 'warning',
+    message: `Active project target "${snapshot.activeTargetId}" was not found. Available compile units: ${available}.`,
+    source: PROJECT_DIAGNOSTIC_SOURCE,
+    code: 'active-target-not-found',
+  };
+}

--- a/src/semantic/SemanticIndex.ts
+++ b/src/semantic/SemanticIndex.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { FileContext } from '../project/FileContext';
-import type { ModuleRecord, SymbolRecord } from './SymbolRecords';
+import type { ModuleRecord, SymbolRecord, SymbolRecordKind } from './SymbolRecords';
 
 export class SemanticIndex {
   private readonly modulesByName = new Map<string, ModuleRecord[]>();
@@ -37,6 +37,28 @@ export class SemanticIndex {
 
   findModules(name: string): ModuleRecord[] {
     return (this.modulesByName.get(name) ?? []).slice();
+  }
+
+  findBestModule(name: string, context?: FileContext | string): ModuleRecord | undefined {
+    const modules = this.findModules(name);
+    const compileUnitId = typeof context === 'string' ? context : context?.compileUnitId;
+    return modules.find((moduleRecord) => moduleRecord.compileUnitId === compileUnitId) ?? modules[0];
+  }
+
+  getModuleSignature(name: string, context?: FileContext | string): ModuleRecord | undefined {
+    return this.findBestModule(name, context);
+  }
+
+  findSymbolsByName(
+    name: string,
+    options: { compileUnitId?: string; kinds?: SymbolRecordKind[] } = {}
+  ): SymbolRecord[] {
+    const kinds = options.kinds ? new Set(options.kinds) : undefined;
+    return this.symbols.filter((symbol) =>
+      symbol.name === name
+      && (!options.compileUnitId || symbol.compileUnitId === options.compileUnitId)
+      && (!kinds || kinds.has(symbol.kind))
+    );
   }
 
   findPackages(name: string): SymbolRecord[] {

--- a/src/test/filelistProject.test.ts
+++ b/src/test/filelistProject.test.ts
@@ -10,6 +10,10 @@ import { tokenizeFilelist } from '../filelist/FilelistTokenizer';
 import { FileContextResolver } from '../project/FileContextResolver';
 import { ProjectLoader } from '../project/ProjectLoader';
 import { buildCompileUnit } from '../project/ProjectModelMerger';
+import {
+  createActiveTargetDiagnostic,
+  getActiveCompileUnit,
+} from '../project/ProjectTargetResolver';
 import type { ProjectSnapshot } from '../project/ProjectTypes';
 import type { ProjectSettings } from '../project/providers/SettingsProjectSourceProvider';
 
@@ -139,43 +143,54 @@ suite('ProjectModelMerger', () => {
 });
 
 suite('FileContextResolver', () => {
+  test('uses the only compile unit when active target is empty', () => {
+    const file = vscode.Uri.file('/workspace/rtl/top.sv');
+    const snapshot = createSnapshot('', [
+      createCompileUnit('a', 'rtl', file),
+    ]);
+
+    assert.strictEqual(getActiveCompileUnit(snapshot)?.id, 'a');
+    assert.strictEqual(new FileContextResolver(snapshot).getPreferredFileContext(file)?.compileUnitId, 'a');
+  });
+
   test('returns all contexts and prefers the active target', () => {
     const file = vscode.Uri.file('/workspace/rtl/top.sv');
-    const snapshot: ProjectSnapshot = {
-      version: 1,
-      workspaceRoot: vscode.Uri.file('/workspace'),
-      activeTargetId: 'b',
-      compileUnits: [
-        buildCompileUnit({
-          id: 'a',
-          name: 'a',
-          root: vscode.Uri.file('/workspace'),
-          files: [{ resolvedPath: file.fsPath, kind: 'source' }],
-          includeDirs: [],
-          defines: [],
-          settingsIncludeDirs: [],
-          settingsDefines: {},
-          source: { type: 'settings' },
-        }),
-        buildCompileUnit({
-          id: 'b',
-          name: 'b',
-          root: vscode.Uri.file('/workspace'),
-          files: [{ resolvedPath: file.fsPath, kind: 'source' }],
-          includeDirs: [],
-          defines: [],
-          settingsIncludeDirs: [],
-          settingsDefines: {},
-          source: { type: 'settings' },
-        }),
-      ],
-      diagnostics: [],
-    };
+    const snapshot = createSnapshot('b', [
+      createCompileUnit('a', 'a', file),
+      createCompileUnit('b', 'b', file),
+    ]);
 
     const resolver = new FileContextResolver(snapshot);
     assert.deepStrictEqual(resolver.getFileContexts(file).map((context) => context.compileUnitId), ['a', 'b']);
     assert.strictEqual(resolver.getPreferredFileContext(file)?.compileUnitId, 'b');
     assert.strictEqual(resolver.getPreferredFileContext(vscode.Uri.file('/workspace/missing.sv')), undefined);
+  });
+
+  test('active target can match compile unit name', () => {
+    const file = vscode.Uri.file('/workspace/rtl/top.sv');
+    const snapshot = createSnapshot('sim-target', [
+      createCompileUnit('rtl-id', 'rtl-target', file),
+      createCompileUnit('sim-id', 'sim-target', file),
+    ]);
+
+    assert.strictEqual(getActiveCompileUnit(snapshot)?.id, 'sim-id');
+    assert.strictEqual(new FileContextResolver(snapshot).getPreferredFileContext(file)?.compileUnitId, 'sim-id');
+  });
+
+  test('invalid active target creates warning diagnostic and preserves fallback context', () => {
+    const file = vscode.Uri.file('/workspace/rtl/top.sv');
+    const snapshot = createSnapshot('missing-target', [
+      createCompileUnit('a', 'rtl', file),
+      createCompileUnit('b', 'sim', file),
+    ]);
+
+    const diagnostic = createActiveTargetDiagnostic(snapshot);
+
+    assert.strictEqual(diagnostic?.code, 'active-target-not-found');
+    assert.strictEqual(diagnostic?.severity, 'warning');
+    assert.ok(diagnostic?.message.includes('missing-target'));
+    assert.ok(diagnostic?.message.includes('rtl (a)'));
+    assert.strictEqual(new FileContextResolver(snapshot).getPreferredFileContext(file)?.compileUnitId, 'a');
   });
 });
 
@@ -207,3 +222,27 @@ suite('ProjectLoader', () => {
     assert.ok(!snapshot.compileUnits[0]?.files.some((file) => file.uri.fsPath.endsWith('skip.sv')));
   });
 });
+
+function createSnapshot(activeTargetId: string, compileUnits: ProjectSnapshot['compileUnits']): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file('/workspace'),
+    activeTargetId,
+    compileUnits,
+    diagnostics: [],
+  };
+}
+
+function createCompileUnit(id: string, name: string, file: vscode.Uri): ProjectSnapshot['compileUnits'][number] {
+  return buildCompileUnit({
+    id,
+    name,
+    root: vscode.Uri.file('/workspace'),
+    files: [{ resolvedPath: file.fsPath, kind: 'source' }],
+    includeDirs: [],
+    defines: [],
+    settingsIncludeDirs: [],
+    settingsDefines: {},
+    source: { type: 'settings' },
+  });
+}

--- a/src/test/hdlExplorerProvider.test.ts
+++ b/src/test/hdlExplorerProvider.test.ts
@@ -43,6 +43,8 @@ suite('HdlExplorerProvider', () => {
       'Hierarchy (best-effort)',
       'Unresolved Instances',
     ]);
+    const projectItems = await sectionChildren(provider, root, 'HDL Project');
+    assert.ok(projectItems.some((item) => item.label === 'Active Compile Unit'));
     assert.ok((await sectionChildren(provider, root, 'Modules')).some((item) => item.label === 'top'));
     assert.ok((await sectionChildren(provider, root, 'Packages')).some((item) => item.label === 'pkg'));
     assert.ok((await sectionChildren(provider, root, 'Hierarchy (best-effort)')).some((item) => item.label === 'top'));

--- a/src/test/projectDiagnosticManager.test.ts
+++ b/src/test/projectDiagnosticManager.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ProjectDiagnosticManager, type ProjectDiagnosticSink } from '../project/ProjectDiagnosticManager';
+import type { ProjectService } from '../project/ProjectService';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+
+class FakeProjectDiagnosticSink implements ProjectDiagnosticSink {
+  readonly diagnostics = new Map<string, readonly vscode.Diagnostic[]>();
+  clearCalls = 0;
+  disposeCalls = 0;
+
+  set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void {
+    this.diagnostics.set(uri.toString(), diagnostics);
+  }
+
+  clear(): void {
+    this.diagnostics.clear();
+    this.clearCalls += 1;
+  }
+
+  dispose(): void {
+    this.disposeCalls += 1;
+  }
+}
+
+suite('ProjectDiagnosticManager', () => {
+  test('publishes location diagnostics grouped by URI and maps severity', () => {
+    const sink = new FakeProjectDiagnosticSink();
+    const uri = vscode.Uri.file('/workspace/files.f');
+    const manager = new ProjectDiagnosticManager(createProjectService(createSnapshot()), sink);
+
+    manager.publish({
+      ...createSnapshot(),
+      diagnostics: [
+        {
+          severity: 'error',
+          message: 'missing source',
+          source: 'verilog.project',
+          code: 'missing-source-file',
+          location: new vscode.Location(uri, new vscode.Range(1, 2, 1, 3)),
+        },
+        {
+          severity: 'warning',
+          message: 'missing include',
+          source: 'verilog.project',
+          code: 'missing-include-dir',
+          location: new vscode.Location(uri, new vscode.Range(2, 0, 2, 1)),
+        },
+        {
+          severity: 'info',
+          message: 'unlocated info',
+          source: 'verilog.project',
+          code: 'project-info',
+        },
+      ],
+    });
+
+    const diagnostics = sink.diagnostics.get(uri.toString());
+    assert.strictEqual(diagnostics?.length, 2);
+    assert.strictEqual(diagnostics?.[0]?.severity, vscode.DiagnosticSeverity.Error);
+    assert.strictEqual(diagnostics?.[0]?.code, 'missing-source-file');
+    assert.strictEqual(diagnostics?.[1]?.severity, vscode.DiagnosticSeverity.Warning);
+    assert.ok(![...sink.diagnostics.values()].flat().some((diagnostic) => diagnostic.message === 'unlocated info'));
+    manager.dispose();
+  });
+
+  test('clears stale diagnostics on new snapshot', () => {
+    const sink = new FakeProjectDiagnosticSink();
+    const uri = vscode.Uri.file('/workspace/files.f');
+    const manager = new ProjectDiagnosticManager(createProjectService(createSnapshot()), sink);
+
+    manager.publish({
+      ...createSnapshot(),
+      diagnostics: [{
+        severity: 'error',
+        message: 'stale',
+        source: 'verilog.project',
+        location: new vscode.Location(uri, new vscode.Range(0, 0, 0, 1)),
+      }],
+    });
+    assert.strictEqual(sink.diagnostics.size, 1);
+
+    manager.publish(createSnapshot());
+
+    assert.strictEqual(sink.diagnostics.size, 0);
+    assert.ok(sink.clearCalls >= 2);
+    manager.dispose();
+    assert.strictEqual(sink.disposeCalls, 1);
+  });
+});
+
+function createProjectService(snapshot: ProjectSnapshot): ProjectService {
+  return {
+    getSnapshot: () => snapshot,
+    onDidChangeSnapshot: () => ({ dispose: () => undefined }),
+  } as unknown as ProjectService;
+}
+
+function createSnapshot(): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file('/workspace'),
+    activeTargetId: '',
+    compileUnits: [],
+    diagnostics: [],
+  };
+}

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -95,6 +95,16 @@ suite('Minimal IDE Model Stabilization', () => {
       assert.strictEqual(resolver.getPreferredFileContext(vscode.Uri.file(path.join(root, 'outside.sv'))), undefined);
     });
 
+    test('reports invalid active target as a project diagnostic', async () => {
+      const root = fixtureRoot('simple-filelist');
+      const snapshot = await loadFixture(root, settings({ filelists: ['files.f'], activeTarget: 'missing-target' }));
+      const diagnostic = snapshot.diagnostics.find((candidate) => candidate.code === 'active-target-not-found');
+
+      assert.strictEqual(diagnostic?.severity, 'warning');
+      assert.ok(diagnostic?.message.includes('missing-target'));
+      assert.ok(diagnostic?.message.includes('files.f'));
+    });
+
     test('degrades to an empty diagnostic snapshot when loading throws', async () => {
       const service = new ProjectService({
         load: async () => {
@@ -241,6 +251,7 @@ suite('Minimal IDE Model Stabilization', () => {
 
       assert.ok(report.includes('Project enabled: yes'));
       assert.ok(report.includes(`Workspace root: ${root}`));
+      assert.ok(report.includes('Resolved active compile unit: files.f (filelist:0:files.f)'));
       assert.ok(report.includes('Compile units: 1'));
       assert.ok(report.includes('Files: 4'));
       assert.ok(report.includes('Include dirs:'));

--- a/src/test/semanticProject.test.ts
+++ b/src/test/semanticProject.test.ts
@@ -152,3 +152,60 @@ suite('FastIndexerBackend', () => {
     assert.strictEqual(resolved?.fsPath, path.join(inc, 'defs.svh'));
   });
 });
+
+suite('SemanticIndex query helpers', () => {
+  test('findBestModule prefers the requested compile unit for duplicate modules', () => {
+    const first = createModuleRecord('dupe', 'unitA');
+    const second = createModuleRecord('dupe', 'unitB');
+    const index = new SemanticIndex(1, [first, second]);
+
+    assert.strictEqual(index.findBestModule('dupe', 'unitB'), second);
+    assert.strictEqual(index.getModuleSignature('dupe', 'unitA'), first);
+  });
+
+  test('findBestModule falls back to first module when context does not match', () => {
+    const first = createModuleRecord('dupe', 'unitA');
+    const second = createModuleRecord('dupe', 'unitB');
+    const index = new SemanticIndex(1, [first, second]);
+
+    assert.strictEqual(index.findBestModule('dupe', 'missing'), first);
+    assert.strictEqual(index.findBestModule('unknown'), undefined);
+  });
+
+  test('findSymbolsByName filters by name kind and compile unit', () => {
+    const moduleRecord = createModuleRecord('shared', 'unitA');
+    const macroRecord = createSymbolRecord('shared', 'macro', 'unitB');
+    const packageRecord = createSymbolRecord('pkg', 'package', 'unitA');
+    const index = new SemanticIndex(1, [moduleRecord, macroRecord, packageRecord]);
+
+    assert.deepStrictEqual(index.findSymbolsByName('shared', { kinds: ['macro'] }), [macroRecord]);
+    assert.deepStrictEqual(index.findSymbolsByName('shared', { compileUnitId: 'unitA' }), [moduleRecord]);
+    assert.deepStrictEqual(index.findSymbolsByName('pkg', { kinds: ['package'], compileUnitId: 'unitA' }), [packageRecord]);
+  });
+});
+
+function createModuleRecord(name: string, compileUnitId: string): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module', compileUnitId),
+    kind: 'module',
+    ports: [],
+    parameters: [],
+  };
+}
+
+function createSymbolRecord(
+  name: string,
+  kind: ModuleRecord['kind'] | 'macro' | 'package',
+  compileUnitId: string
+) {
+  const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
+  return {
+    id: `${compileUnitId}:${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${compileUnitId}/${name}.sv`),
+    range: selectionRange,
+    selectionRange,
+    compileUnitId,
+  };
+}

--- a/src/views/HdlExplorerProvider.ts
+++ b/src/views/HdlExplorerProvider.ts
@@ -5,6 +5,7 @@ import type { HierarchyService } from '../hierarchy/HierarchyService';
 import type { HierarchyInstanceNode, HierarchyNode } from '../hierarchy/HierarchyTypes';
 import type { ProjectService } from '../project/ProjectService';
 import type { CompileUnit } from '../project/ProjectTypes';
+import { getActiveCompileUnit } from '../project/ProjectTargetResolver';
 import type { IndexService } from '../semantic/IndexService';
 import {
   createCompileUnitItem,
@@ -138,8 +139,10 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
 
   private getProjectChildren(): HdlExplorerItem[] {
     const snapshot = this.projectService.getSnapshot();
+    const activeCompileUnit = getActiveCompileUnit(snapshot);
     return [
       createInfoItem('Active Target', snapshot.activeTargetId || '(none)'),
+      createInfoItem('Active Compile Unit', activeCompileUnit ? `${activeCompileUnit.name} (${activeCompileUnit.id})` : '(none)'),
       createInfoItem('Diagnostics', String(snapshot.diagnostics.length)),
       createInfoItem('Workspace Root', snapshot.workspaceRoot.fsPath),
       createGroupItem('Compile Units', { group: 'compileUnits', compileUnits: snapshot.compileUnits }),


### PR DESCRIPTION
## Summary
- publish project diagnostics with source locations to VS Code Problems
- make active target and compile-unit selection deterministic
- centralize compile-unit-aware SemanticIndex module and symbol lookup helpers
- update completion, hover, code actions, hierarchy, status, and HDL Explorer callers

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 297 passing, 3 pending