### PR TITLE
Publish nested filelist diagnostics to Problems

### DIFF
--- a/src/filelist/FilelistResolver.ts
+++ b/src/filelist/FilelistResolver.ts
@@ -21,11 +21,21 @@ export interface ResolvedFilelist {
   diagnostics: FilelistDiagnostic[];
 }
 
+interface MissingFilelistReference {
+  source: string;
+  line: number;
+  character: number;
+}
+
 export function resolveFilelist(filelistPath: string): ResolvedFilelist {
   return resolveFilelistInternal(path.resolve(filelistPath), []);
 }
 
-function resolveFilelistInternal(filelistPath: string, stack: string[]): ResolvedFilelist {
+function resolveFilelistInternal(
+  filelistPath: string,
+  stack: string[],
+  missingReference?: MissingFilelistReference
+): ResolvedFilelist {
   const resolved: ResolvedFilelist = emptyResolvedFilelist();
   const normalizedPath = path.resolve(filelistPath);
   const containingDir = path.dirname(normalizedPath);
@@ -45,9 +55,11 @@ function resolveFilelistInternal(filelistPath: string, stack: string[]): Resolve
     resolved.diagnostics.push({
       severity: 'error',
       message: `Missing filelist: ${normalizedPath}`,
-      source: normalizedPath,
+      source: missingReference?.source ?? normalizedPath,
       code: 'missing-filelist',
       path: normalizedPath,
+      line: missingReference?.line,
+      character: missingReference?.character,
     });
     return resolved;
   }
@@ -91,7 +103,15 @@ function resolveFilelistInternal(filelistPath: string, stack: string[]): Resolve
   for (const nested of parsed.nestedFilelists) {
     const nestedRef = resolvePathRef(nested, containingDir);
     resolved.nestedFilelists.push(nestedRef);
-    const nestedResolved = resolveFilelistInternal(nestedRef.resolvedPath, stack.concat(normalizedPath));
+    const nestedResolved = resolveFilelistInternal(
+      nestedRef.resolvedPath,
+      stack.concat(normalizedPath),
+      {
+        source: normalizedPath,
+        line: nestedRef.line,
+        character: nestedRef.character,
+      }
+    );
     mergeResolvedFilelist(resolved, nestedResolved);
   }
 

--- a/src/test/filelistProject.test.ts
+++ b/src/test/filelistProject.test.ts
@@ -108,8 +108,12 @@ suite('FilelistResolver', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-filelist-'));
     fs.writeFileSync(path.join(root, 'top.f'), '-f missing.f\n');
     const resolved = resolveFilelist(path.join(root, 'top.f'));
+    const diagnostic = resolved.diagnostics.find((candidate) => candidate.code === 'missing-filelist');
 
-    assert.ok(resolved.diagnostics.some((diagnostic) => diagnostic.code === 'missing-filelist'));
+    assert.ok(diagnostic);
+    assert.strictEqual(diagnostic.source, path.join(root, 'top.f'));
+    assert.strictEqual(diagnostic.line, 0);
+    assert.strictEqual(diagnostic.character, 3);
   });
 });
 

--- a/src/test/projectDiagnosticManager.test.ts
+++ b/src/test/projectDiagnosticManager.test.ts
@@ -35,6 +35,13 @@ suite('ProjectDiagnosticManager', () => {
       diagnostics: [
         {
           severity: 'error',
+          message: 'missing filelist',
+          source: 'verilog.project',
+          code: 'missing-filelist',
+          location: new vscode.Location(uri, new vscode.Range(0, 3, 0, 12)),
+        },
+        {
+          severity: 'warning',
           message: 'missing source',
           source: 'verilog.project',
           code: 'missing-source-file',
@@ -57,10 +64,12 @@ suite('ProjectDiagnosticManager', () => {
     });
 
     const diagnostics = sink.diagnostics.get(uri.toString());
-    assert.strictEqual(diagnostics?.length, 2);
+    assert.strictEqual(diagnostics?.length, 3);
     assert.strictEqual(diagnostics?.[0]?.severity, vscode.DiagnosticSeverity.Error);
-    assert.strictEqual(diagnostics?.[0]?.code, 'missing-source-file');
+    assert.strictEqual(diagnostics?.[0]?.code, 'missing-filelist');
     assert.strictEqual(diagnostics?.[1]?.severity, vscode.DiagnosticSeverity.Warning);
+    assert.strictEqual(diagnostics?.[1]?.code, 'missing-source-file');
+    assert.strictEqual(diagnostics?.[2]?.code, 'missing-include-dir');
     assert.ok(![...sink.diagnostics.values()].flat().some((diagnostic) => diagnostic.message === 'unlocated info'));
     manager.dispose();
   });

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -48,12 +48,14 @@ suite('Minimal IDE Model Stabilization', () => {
       const root = fixtureRoot('malformed-filelist');
       const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
       const codes = snapshot.diagnostics.map((diagnostic) => diagnostic.code);
+      const missingFilelist = snapshot.diagnostics.find((diagnostic) => diagnostic.code === 'missing-filelist');
 
       assert.ok(codes.includes('nested-filelist-cycle'));
       assert.ok(codes.includes('missing-filelist'));
       assert.ok(codes.includes('missing-include-dir'));
       assert.ok(codes.includes('missing-source-file'));
       assert.ok(snapshot.diagnostics.every((diagnostic) => diagnostic.message.length > 0));
+      assert.strictEqual(missingFilelist?.location?.uri.fsPath, path.join(root, 'files.f'));
     });
 
     test('creates fallback auto-discovery compile unit and respects exclude patterns', async function () {


### PR DESCRIPTION
## Summary
- preserve parent filelist token locations for missing nested filelists
- allow nested missing-filelist diagnostics to publish to VS Code Problems
- strengthen filelist and project diagnostic manager tests

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 297 passing, 3 pending