### PR TITLE
Expand project-aware definitions

### DIFF
--- a/src/hdl/DefinitionService.ts
+++ b/src/hdl/DefinitionService.ts
@@ -4,10 +4,17 @@ import { CtagsManager } from '../ctags';
 import type { ProjectService } from '../project/ProjectService';
 import type { FileContext } from '../project/ProjectTypes';
 import type { IndexService } from '../semantic/IndexService';
-import type { ModuleRecord } from '../semantic/SymbolRecords';
+import { scanInstanceContext, type InstanceConnection } from '../semantic/InstanceContextScanner';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
 
 const HDL_LANGUAGES = new Set(['verilog', 'systemverilog']);
 const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/;
+const INDEXED_SYMBOL_KINDS: SymbolRecord['kind'][] = [
+  'package',
+  'interface',
+  'class',
+  'typedef',
+];
 const MODULE_CONTEXT_KEYWORDS = new Set([
   'assign',
   'begin',
@@ -44,6 +51,16 @@ export class DefinitionService {
       return [includeLink];
     }
 
+    const macroLink = this.findMacroDefinition(document, position);
+    if (macroLink) {
+      return [macroLink];
+    }
+
+    const instanceLink = this.findInstanceConnectionDefinition(document, position);
+    if (instanceLink) {
+      return [instanceLink];
+    }
+
     const wordRange = document.getWordRangeAtPosition(position, WORD_PATTERN);
     if (!wordRange || wordRange.isEmpty) {
       return this.ctagsManager.findSymbol(document, position);
@@ -51,13 +68,24 @@ export class DefinitionService {
 
     const word = document.getText(wordRange);
     if (isModuleContext(document, wordRange, word)) {
-      const moduleLinks = this.indexService
-        .getIndex()
-        .findModules(word)
-        .map(moduleRecordToDefinitionLink);
+      const context = this.projectService.getPreferredFileContext(document.uri);
+      const moduleRecord = context
+        ? this.indexService.getIndex().findBestModule(word, context)
+        : undefined;
+      const moduleLinks = moduleRecord
+        ? [moduleRecordToDefinitionLink(moduleRecord)]
+        : this.indexService
+          .getIndex()
+          .findModules(word)
+          .map((candidate) => symbolRecordToDefinitionLink(candidate));
       if (moduleLinks.length > 0) {
         return moduleLinks;
       }
+    }
+
+    const symbolLinks = this.findIndexedSymbolDefinitions(document, wordRange, word);
+    if (symbolLinks.length > 0) {
+      return symbolLinks;
     }
 
     return this.ctagsManager.findSymbol(document, position);
@@ -91,13 +119,89 @@ export class DefinitionService {
       targetSelectionRange: targetRange,
     };
   }
+
+  private findMacroDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.DefinitionLink | undefined {
+    const macro = getMacroAtPosition(document, position);
+    if (!macro) {
+      return undefined;
+    }
+
+    const context = this.projectService.getPreferredFileContext(document.uri);
+    const projectDefine = context?.defines[macro.name];
+    if (projectDefine?.location) {
+      return locationToDefinitionLink(projectDefine.location, macro.range);
+    }
+
+    const index = this.indexService.getIndex();
+    const sourceMacro = (context
+      ? index.findSymbolsByName(macro.name, { compileUnitId: context.compileUnitId, kinds: ['macro'] }).at(0)
+      : undefined)
+      ?? index.findSymbolsByName(macro.name, { kinds: ['macro'] }).at(0);
+    return sourceMacro ? symbolRecordToDefinitionLink(sourceMacro, macro.range) : undefined;
+  }
+
+  private findInstanceConnectionDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.DefinitionLink | undefined {
+    const offset = document.offsetAt(position);
+    const context = scanInstanceContext(document.getText(), offset);
+    if (!context) {
+      return undefined;
+    }
+    const connection = context.connections.find((candidate) => isOffsetOnConnectionName(candidate, offset));
+    if (!connection) {
+      return undefined;
+    }
+
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    const moduleRecord = this.indexService.getIndex().findBestModule(context.moduleName, fileContext);
+    if (!moduleRecord) {
+      return undefined;
+    }
+
+    const symbol = context.kind === 'parameters'
+      ? moduleRecord.parameters.find((parameter) => parameter.name === connection.name)
+      : moduleRecord.ports.find((port) => port.name === connection.name);
+    return symbol ? symbolRecordToDefinitionLink(symbol, connectionNameRange(document, connection)) : undefined;
+  }
+
+  private findIndexedSymbolDefinitions(
+    document: vscode.TextDocument,
+    wordRange: vscode.Range,
+    word: string
+  ): vscode.DefinitionLink[] {
+    const index = this.indexService.getIndex();
+    const context = this.projectService.getPreferredFileContext(document.uri);
+    const preferredMatches = context
+      ? index.findSymbolsByName(word, {
+        compileUnitId: context.compileUnitId,
+        kinds: INDEXED_SYMBOL_KINDS,
+      })
+      : [];
+    const matches = preferredMatches.length > 0
+      ? preferredMatches
+      : index.findSymbolsByName(word, { kinds: INDEXED_SYMBOL_KINDS });
+    return matches.map((symbol) => symbolRecordToDefinitionLink(symbol, wordRange));
+  }
 }
 
 export function moduleRecordToDefinitionLink(moduleRecord: ModuleRecord): vscode.DefinitionLink {
+  return symbolRecordToDefinitionLink(moduleRecord);
+}
+
+export function symbolRecordToDefinitionLink(
+  symbolRecord: SymbolRecord,
+  originSelectionRange?: vscode.Range
+): vscode.DefinitionLink {
   return {
-    targetUri: moduleRecord.uri,
-    targetRange: moduleRecord.range,
-    targetSelectionRange: moduleRecord.selectionRange,
+    originSelectionRange,
+    targetUri: symbolRecord.uri,
+    targetRange: symbolRecord.range,
+    targetSelectionRange: symbolRecord.selectionRange,
   };
 }
 
@@ -133,6 +237,53 @@ interface IncludeAtPosition {
   includeText: string;
   pathStart: number;
   pathEnd: number;
+}
+
+interface MacroAtPosition {
+  name: string;
+  range: vscode.Range;
+}
+
+function getMacroAtPosition(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): MacroAtPosition | undefined {
+  const line = stripLineComment(document.lineAt(position.line).text);
+  const macroPattern = /`([A-Za-z_][A-Za-z0-9_$]*)/g;
+  for (const match of line.matchAll(macroPattern)) {
+    const name = match[1] ?? '';
+    const start = (match.index ?? 0) + 1;
+    const end = start + name.length;
+    if (position.character >= start && position.character <= end) {
+      return {
+        name,
+        range: new vscode.Range(position.line, start, position.line, end),
+      };
+    }
+  }
+  return undefined;
+}
+
+function isOffsetOnConnectionName(connection: InstanceConnection, offset: number): boolean {
+  const start = connection.startOffset + 1;
+  return offset >= start && offset <= start + connection.name.length;
+}
+
+function connectionNameRange(document: vscode.TextDocument, connection: InstanceConnection): vscode.Range {
+  const start = connection.startOffset + 1;
+  return new vscode.Range(document.positionAt(start), document.positionAt(start + connection.name.length));
+}
+
+function locationToDefinitionLink(
+  location: vscode.Location,
+  originSelectionRange?: vscode.Range
+): vscode.DefinitionLink {
+  return {
+    originSelectionRange,
+    targetUri: location.uri,
+    targetRange: location.range,
+    targetSelectionRange: location.range,
+  };
 }
 
 function getIncludeAtPosition(line: string, character: number): IncludeAtPosition | undefined {

--- a/src/test/definitionService.test.ts
+++ b/src/test/definitionService.test.ts
@@ -10,7 +10,7 @@ import type { ProjectService } from '../project/ProjectService';
 import type { FileContext } from '../project/ProjectTypes';
 import type { IndexService } from '../semantic/IndexService';
 import { SemanticIndex } from '../semantic/SemanticIndex';
-import type { ModuleRecord } from '../semantic/SymbolRecords';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
 
 suite('DefinitionService', () => {
   test('resolves module definitions across workspace by module name', async () => {
@@ -100,6 +100,192 @@ suite('DefinitionService', () => {
     assert.strictEqual(fallbackCalled, true);
     assert.deepStrictEqual(result, fallbackLinks);
   });
+
+  test('resolves macro usage to indexed source define', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: '`SIM\n',
+    });
+    const macroRecord = createSymbolRecord('SIM', 'macro', vscode.Uri.file('/workspace/defs.svh'));
+    const service = createDefinitionService(new SemanticIndex(1, [macroRecord]));
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 2));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, macroRecord.uri.fsPath);
+    assert.strictEqual(result[0]?.targetSelectionRange?.start.character, macroRecord.selectionRange.start.character);
+  });
+
+  test('resolves macro usage to project define location when available', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: '`PROJECT_MACRO\n',
+    });
+    const uri = vscode.Uri.file('/workspace/files.f');
+    const location = new vscode.Location(uri, new vscode.Range(3, 8, 3, 21));
+    const service = createDefinitionService(
+      new SemanticIndex(1, []),
+      {
+        file: document.uri,
+        compileUnitId: 'unit',
+        includeDirs: [],
+        defines: {
+          PROJECT_MACRO: {
+            name: 'PROJECT_MACRO',
+            value: true,
+            source: 'filelist',
+            location,
+          },
+        },
+      }
+    );
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 3));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, uri.fsPath);
+    assert.deepStrictEqual(result[0]?.targetSelectionRange, location.range);
+  });
+
+  test('falls back to ctags for macro project define without location', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: '`NO_LOCATION\n',
+    });
+    const targetRange = new vscode.Range(0, 1, 0, 12);
+    const fallbackLinks: vscode.DefinitionLink[] = [
+      {
+        targetUri: document.uri,
+        targetRange,
+        targetSelectionRange: targetRange,
+      },
+    ];
+    let fallbackCalled = false;
+    const service = createDefinitionService(
+      new SemanticIndex(1, []),
+      {
+        file: document.uri,
+        compileUnitId: 'unit',
+        includeDirs: [],
+        defines: {
+          NO_LOCATION: {
+            name: 'NO_LOCATION',
+            value: true,
+            source: 'settings',
+          },
+        },
+      },
+      {
+        findSymbol: async () => {
+          fallbackCalled = true;
+          return fallbackLinks;
+        },
+      } as unknown as CtagsManager
+    );
+
+    const result = await service.provideDefinition(document, new vscode.Position(0, 2));
+
+    assert.strictEqual(fallbackCalled, true);
+    assert.deepStrictEqual(result, fallbackLinks);
+  });
+
+  test('resolves named instance port to module port declaration', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'my_mod u_my_mod (',
+        '  .clk(clk)',
+        ');',
+      ].join('\n'),
+    });
+    const port = createPortRecord('clk', vscode.Uri.file('/workspace/my_mod.sv'), 'unit');
+    const moduleRecord = createModuleRecord('my_mod', vscode.Uri.file('/workspace/my_mod.sv'), 'unit', [port]);
+    const service = createDefinitionService(new SemanticIndex(1, [moduleRecord, port]));
+
+    const result = await service.provideDefinition(document, new vscode.Position(1, 4));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, port.uri.fsPath);
+    assert.deepStrictEqual(result[0]?.targetSelectionRange, port.selectionRange);
+  });
+
+  test('resolves named instance parameter to module parameter declaration', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'my_mod #(',
+        '  .WIDTH(32)',
+        ') u_my_mod (',
+        '  .clk(clk)',
+        ');',
+      ].join('\n'),
+    });
+    const parameter = createParameterRecord('WIDTH', vscode.Uri.file('/workspace/my_mod.sv'), 'unit');
+    const moduleRecord = createModuleRecord(
+      'my_mod',
+      vscode.Uri.file('/workspace/my_mod.sv'),
+      'unit',
+      [],
+      [parameter]
+    );
+    const service = createDefinitionService(new SemanticIndex(1, [moduleRecord, parameter]));
+
+    const result = await service.provideDefinition(document, new vscode.Position(1, 5));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, parameter.uri.fsPath);
+    assert.deepStrictEqual(result[0]?.targetSelectionRange, parameter.selectionRange);
+  });
+
+  test('uses preferred compile unit for duplicate module instance port lookup', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'my_mod u_my_mod (',
+        '  .clk(clk)',
+        ');',
+      ].join('\n'),
+    });
+    const portA = createPortRecord('clk', vscode.Uri.file('/workspace/unitA/my_mod.sv'), 'unitA');
+    const portB = createPortRecord('clk', vscode.Uri.file('/workspace/unitB/my_mod.sv'), 'unitB');
+    const moduleA = createModuleRecord('my_mod', portA.uri, 'unitA', [portA]);
+    const moduleB = createModuleRecord('my_mod', portB.uri, 'unitB', [portB]);
+    const service = createDefinitionService(
+      new SemanticIndex(1, [moduleA, portA, moduleB, portB]),
+      {
+        file: document.uri,
+        compileUnitId: 'unitB',
+        includeDirs: [],
+        defines: {},
+      }
+    );
+
+    const result = await service.provideDefinition(document, new vscode.Position(1, 4));
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.targetUri.fsPath, portB.uri.fsPath);
+  });
+
+  test('resolves package and typedef definitions from semantic index', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: [
+        'import my_pkg::*;',
+        'type_t value;',
+      ].join('\n'),
+    });
+    const packageRecord = createSymbolRecord('my_pkg', 'package', vscode.Uri.file('/workspace/pkg.sv'));
+    const typedefRecord = createSymbolRecord('type_t', 'typedef', vscode.Uri.file('/workspace/pkg.sv'));
+    const service = createDefinitionService(new SemanticIndex(1, [packageRecord, typedefRecord]));
+
+    const packageResult = await service.provideDefinition(document, new vscode.Position(0, 9));
+    const typedefResult = await service.provideDefinition(document, new vscode.Position(1, 2));
+
+    assert.strictEqual(packageResult.length, 1);
+    assert.strictEqual(packageResult[0]?.targetUri.fsPath, packageRecord.uri.fsPath);
+    assert.strictEqual(typedefResult.length, 1);
+    assert.strictEqual(typedefResult[0]?.targetUri.fsPath, typedefRecord.uri.fsPath);
+  });
 });
 
 function createDefinitionService(
@@ -116,17 +302,59 @@ function createDefinitionService(
   return new DefinitionService(projectService, indexService, ctagsManager);
 }
 
-function createModuleRecord(name: string, uri: vscode.Uri): ModuleRecord {
+function createModuleRecord(
+  name: string,
+  uri: vscode.Uri,
+  compileUnitId = 'unit',
+  ports: PortRecord[] = [],
+  parameters: ParameterRecord[] = []
+): ModuleRecord {
   const selectionRange = new vscode.Range(0, 7, 0, 7 + name.length);
   return {
-    id: `unit:${name}`,
+    id: `${compileUnitId}:${name}`,
     name,
     kind: 'module',
     uri,
     range: new vscode.Range(0, 0, 1, 0),
     selectionRange,
-    compileUnitId: 'unit',
-    ports: [],
-    parameters: [],
+    compileUnitId,
+    ports,
+    parameters,
+  };
+}
+
+function createPortRecord(name: string, uri: vscode.Uri, compileUnitId: string): PortRecord {
+  return {
+    ...createSymbolRecord(name, 'port', uri, compileUnitId, 'my_mod'),
+    kind: 'port',
+    direction: 'input',
+  };
+}
+
+function createParameterRecord(name: string, uri: vscode.Uri, compileUnitId: string): ParameterRecord {
+  return {
+    ...createSymbolRecord(name, 'parameter', uri, compileUnitId, 'my_mod'),
+    kind: 'parameter',
+    defaultValue: '1',
+  };
+}
+
+function createSymbolRecord(
+  name: string,
+  kind: SymbolRecord['kind'],
+  uri: vscode.Uri,
+  compileUnitId = 'unit',
+  containerName?: string
+): SymbolRecord {
+  const selectionRange = new vscode.Range(0, 10, 0, 10 + name.length);
+  return {
+    id: `${compileUnitId}:${kind}:${name}`,
+    name,
+    kind,
+    uri,
+    range: new vscode.Range(0, 0, 1, 0),
+    selectionRange,
+    compileUnitId,
+    containerName,
   };
 }


### PR DESCRIPTION
## Summary
- resolve macro usages through project defines and indexed source macros
- navigate named instance ports and parameters to target module declarations
- resolve package/interface/class/typedef symbols through SemanticIndex before ctags fallback
- keep ctags fallback as the final resolution path

## Validation
- npm run check-types
- npm run lint
- npm run compile-tests
- npm test: 304 passing, 3 pending