### PR TITLE
Add project-aware semantic diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -828,6 +828,54 @@
         }
       },
       {
+        "title": "Verilog: Semantic Diagnostics",
+        "properties": {
+          "verilog.semanticDiagnostics.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable lightweight project-aware Verilog/SystemVerilog semantic diagnostics."
+          },
+          "verilog.semanticDiagnostics.unresolvedModules.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Report unresolved module instantiations from the project index."
+          },
+          "verilog.semanticDiagnostics.unknownPorts.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Report named instance port connections that do not exist on the resolved module."
+          },
+          "verilog.semanticDiagnostics.unknownParameters.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Report named parameter overrides that do not exist on the resolved module."
+          },
+          "verilog.semanticDiagnostics.unresolvedIncludes.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Report unresolved `include paths using the active file context."
+          },
+          "verilog.semanticDiagnostics.unresolvedMacros.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Report unresolved macro usages. Disabled by default to avoid noisy diagnostics in macro-heavy projects."
+          },
+          "verilog.semanticDiagnostics.maxFiles": {
+            "scope": "window",
+            "type": "number",
+            "default": 1000,
+            "minimum": 1,
+            "markdownDescription": "Maximum number of project files scanned by lightweight semantic diagnostics."
+          }
+        }
+      },
+      {
         "title": "Verilog: Completion",
         "properties": {
           "verilog.completion.ports.enabled": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { ProjectService } from './project/ProjectService';
 import { ProjectWatcher } from './project/ProjectWatcher';
 import { registerProjectCommands } from './project/ProjectCommands';
 import { IndexService } from './semantic/IndexService';
+import { SemanticDiagnosticService } from './semantic/SemanticDiagnosticService';
 import { VerilogWorkspaceSymbolProvider } from './providers/WorkspaceSymbolProvider';
 import { HdlExplorerProvider, registerHdlExplorerCommands } from './views/HdlExplorerProvider';
 
@@ -61,12 +62,14 @@ export async function activate(context: vscode.ExtensionContext) {
   const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
   const hoverService = new HoverService(projectService, indexService, ctagsManager);
   const hierarchyService = new HierarchyService(projectService, indexService);
+  const semanticDiagnosticService = new SemanticDiagnosticService(projectService, indexService);
   const hdlExplorerProvider = new HdlExplorerProvider(projectService, indexService, hierarchyService);
   context.subscriptions.push(
     projectService,
     projectDiagnosticManager,
     indexService,
     hierarchyService,
+    semanticDiagnosticService,
     hdlExplorerProvider,
     new ProjectWatcher(projectService)
   );

--- a/src/hierarchy/HierarchyTypes.ts
+++ b/src/hierarchy/HierarchyTypes.ts
@@ -2,6 +2,11 @@
 import * as vscode from 'vscode';
 import type { ModuleRecord } from '../semantic/SymbolRecords';
 
+export interface NamedConnectionRecord {
+  name: string;
+  range: vscode.Range;
+}
+
 export interface ModuleInstanceRecord {
   id: string;
   instanceName: string;
@@ -9,9 +14,12 @@ export interface ModuleInstanceRecord {
   parentModuleName: string;
   uri: vscode.Uri;
   range: vscode.Range;
+  moduleNameRange: vscode.Range;
   selectionRange: vscode.Range;
   parameterOverrides: string[];
   portConnections: string[];
+  parameterOverrideConnections: NamedConnectionRecord[];
+  portConnectionRecords: NamedConnectionRecord[];
   compileUnitId: string;
 }
 

--- a/src/hierarchy/InstanceScanner.ts
+++ b/src/hierarchy/InstanceScanner.ts
@@ -116,6 +116,8 @@ function scanModuleBody(
       continue;
     }
     const selectionRange = rangeFromOffset(original, lineStarts, parsed.instanceStart, parsed.instanceName.length);
+    const parameterOverrideConnections = collectNamedConnectionRecords(parsed.parameterSegment, original, lineStarts);
+    const portConnectionRecords = collectNamedConnectionRecords(parsed.portSegment, original, lineStarts);
     instances.push({
       id: `${compileUnitId}:${uri.fsPath}:${moduleBlock.name}:${parsed.instanceName}:${parsed.instanceStart}`,
       instanceName: parsed.instanceName,
@@ -126,9 +128,12 @@ function scanModuleBody(
         positionFromOffset(lineStarts, statement.start),
         positionFromOffset(lineStarts, statement.end + 1)
       ),
+      moduleNameRange: rangeFromOffset(original, lineStarts, parsed.moduleStart, parsed.moduleName.length),
       selectionRange,
-      parameterOverrides: collectNamedConnections(parsed.parameterText),
-      portConnections: collectNamedConnections(parsed.portText),
+      parameterOverrides: parameterOverrideConnections.map((connection) => connection.name),
+      portConnections: portConnectionRecords.map((connection) => connection.name),
+      parameterOverrideConnections,
+      portConnectionRecords,
       compileUnitId,
     });
   }
@@ -200,10 +205,11 @@ function splitTopLevelStatements(
 
 interface ParsedInstanceStatement {
   moduleName: string;
+  moduleStart: number;
   instanceName: string;
   instanceStart: number;
-  parameterText: string;
-  portText: string;
+  parameterSegment?: ParenthesizedSegment;
+  portSegment: ParenthesizedSegment;
 }
 
 function parseInstanceStatement(
@@ -217,7 +223,7 @@ function parseInstanceStatement(
     return undefined;
   }
   index = skipWhitespace(text, moduleName.end, statementEnd);
-  let parameterText = '';
+  let parameterSegment: ParenthesizedSegment | undefined;
   if (text[index] === '#') {
     index = skipWhitespace(text, index + 1, statementEnd);
     if (text[index] !== '(') {
@@ -227,7 +233,7 @@ function parseInstanceStatement(
     if (!parameterList) {
       return undefined;
     }
-    parameterText = parameterList.text;
+    parameterSegment = parameterList;
     index = skipWhitespace(text, parameterList.closeOffset + 1, statementEnd);
   }
 
@@ -248,10 +254,11 @@ function parseInstanceStatement(
   }
   return {
     moduleName: moduleName.text,
+    moduleStart: moduleName.start,
     instanceName: instanceName.text,
     instanceStart: instanceName.start,
-    parameterText,
-    portText: portList.text,
+    parameterSegment,
+    portSegment: portList,
   };
 }
 
@@ -293,17 +300,57 @@ function readParenthesized(
   return undefined;
 }
 
-function collectNamedConnections(text: string): string[] {
-  const names: string[] = [];
+function collectNamedConnectionRecords(
+  segment: ParenthesizedSegment | undefined,
+  original: string,
+  lineStarts: number[]
+): Array<{ name: string; range: vscode.Range }> {
+  if (!segment || !hasOnlyNamedConnections(segment.text)) {
+    return [];
+  }
+  const records: Array<{ name: string; range: vscode.Range }> = [];
   const seen = new Set<string>();
-  for (const match of text.matchAll(/\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/g)) {
+  for (const match of segment.text.matchAll(/\.([A-Za-z_][A-Za-z0-9_$]*)\s*\(/g)) {
     const name = match[1] ?? '';
     if (!seen.has(name)) {
       seen.add(name);
-      names.push(name);
+      const dotOffset = segment.openOffset + 1 + (match.index ?? 0);
+      records.push({
+        name,
+        range: rangeFromOffset(original, lineStarts, dotOffset, name.length + 1),
+      });
     }
   }
-  return names;
+  return records;
+}
+
+function hasOnlyNamedConnections(text: string): boolean {
+  for (const item of splitConnectionItems(text)) {
+    const trimmed = item.trim();
+    if (trimmed.length > 0 && !trimmed.startsWith('.')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function splitConnectionItems(text: string): string[] {
+  const items: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const ch = text[index];
+    if (ch === '(' || ch === '[' || ch === '{') {
+      depth += 1;
+    } else if (ch === ')' || ch === ']' || ch === '}') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === ',' && depth === 0) {
+      items.push(text.slice(start, index));
+      start = index + 1;
+    }
+  }
+  items.push(text.slice(start));
+  return items;
 }
 
 function skipWhitespace(text: string, start: number, end: number): number {

--- a/src/semantic/SemanticDiagnosticService.ts
+++ b/src/semantic/SemanticDiagnosticService.ts
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: MIT
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { InstanceScanner } from '../hierarchy/InstanceScanner';
+import type { ModuleInstanceRecord, NamedConnectionRecord } from '../hierarchy/HierarchyTypes';
+import { getExtensionLogger } from '../logging';
+import { FileContextResolver } from '../project/FileContextResolver';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit, FileContext, ProjectSnapshot } from '../project/ProjectTypes';
+import type { IndexService } from './IndexService';
+import type { SemanticIndex } from './SemanticIndex';
+import type { ModuleRecord } from './SymbolRecords';
+
+const logger = getExtensionLogger('Semantic', 'Diagnostics');
+const SEMANTIC_DIAGNOSTIC_SOURCE = 'verilog.semantic';
+const REFRESH_DEBOUNCE_MS = 300;
+
+const MACRO_DIRECTIVES = new Set([
+  'begin_keywords',
+  'celldefine',
+  'default_nettype',
+  'define',
+  'else',
+  'elsif',
+  'end_keywords',
+  'endcelldefine',
+  'endif',
+  'ifdef',
+  'ifndef',
+  'include',
+  'line',
+  'nounconnected_drive',
+  'pragma',
+  'resetall',
+  'timescale',
+  'undef',
+  'undefineall',
+  'unconnected_drive',
+]);
+
+export interface SemanticDiagnosticSink {
+  set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void;
+  clear(): void;
+  dispose(): void;
+}
+
+interface SemanticDiagnosticSettings {
+  enabled: boolean;
+  unresolvedModules: boolean;
+  unknownPorts: boolean;
+  unknownParameters: boolean;
+  unresolvedIncludes: boolean;
+  unresolvedMacros: boolean;
+  maxFiles: number;
+}
+
+interface IncludeOccurrence {
+  includeText: string;
+  range: vscode.Range;
+}
+
+interface MacroOccurrence {
+  name: string;
+  range: vscode.Range;
+}
+
+export class SemanticDiagnosticService implements vscode.Disposable {
+  private readonly disposables: vscode.Disposable[] = [];
+  private readonly scanner: InstanceScanner;
+  private refreshTimer: NodeJS.Timeout | undefined;
+  private refreshSerial = 0;
+
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly sink: SemanticDiagnosticSink = vscode.languages.createDiagnosticCollection('verilog-semantic'),
+    scanner = new InstanceScanner(),
+    autoRefresh = true
+  ) {
+    this.scanner = scanner;
+    this.disposables.push(
+      projectService.onDidChangeSnapshot(() => this.scheduleRefresh('project-changed')),
+      indexService.onDidChangeIndex(() => this.scheduleRefresh('index-changed'))
+    );
+    if (autoRefresh) {
+      this.scheduleRefresh('activation');
+    }
+  }
+
+  async refresh(reason = 'manual'): Promise<void> {
+    const serial = this.refreshSerial + 1;
+    this.refreshSerial = serial;
+    const settings = getSemanticDiagnosticSettings();
+    if (!settings.enabled) {
+      this.sink.clear();
+      return;
+    }
+
+    const snapshot = this.projectService.getSnapshot();
+    const fileCount = countCompileUnitFiles(snapshot);
+    if (fileCount > settings.maxFiles) {
+      logger.warn('Skipping Verilog semantic diagnostics because the project is too large', {
+        reason,
+        files: fileCount,
+        maxFiles: settings.maxFiles,
+      });
+      this.sink.clear();
+      return;
+    }
+
+    logger.debug('Refreshing Verilog semantic diagnostics', {
+      reason,
+      version: snapshot.version,
+      files: fileCount,
+    });
+
+    const diagnosticsByUri = new Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>();
+    const index = this.indexService.getIndex();
+    const contextResolver = new FileContextResolver(snapshot);
+
+    for (const entry of getUniqueProjectFiles(snapshot)) {
+      try {
+        const text = await fs.readFile(entry.uri.fsPath, 'utf8');
+        if (serial !== this.refreshSerial) {
+          return;
+        }
+        const context = contextResolver.getPreferredFileContext(entry.uri) ?? createFallbackContext(entry.uri, entry.compileUnit);
+        this.collectFileDiagnostics(
+          text,
+          entry.uri,
+          context.compileUnitId,
+          context,
+          index,
+          settings,
+          diagnosticsByUri
+        );
+      } catch (error) {
+        logger.debug('Skipping unreadable file during semantic diagnostics', {
+          file: entry.uri.fsPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (serial !== this.refreshSerial) {
+      return;
+    }
+    this.sink.clear();
+    for (const entry of diagnosticsByUri.values()) {
+      this.sink.set(entry.uri, entry.diagnostics);
+    }
+  }
+
+  dispose(): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.sink.dispose();
+  }
+
+  private scheduleRefresh(reason: string): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+    }
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = undefined;
+      void this.refresh(reason);
+    }, REFRESH_DEBOUNCE_MS);
+  }
+
+  private collectFileDiagnostics(
+    text: string,
+    uri: vscode.Uri,
+    compileUnitId: string,
+    context: FileContext,
+    index: SemanticIndex,
+    settings: SemanticDiagnosticSettings,
+    diagnosticsByUri: Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>
+  ): void {
+    const instances = this.scanner.scan(text, uri, compileUnitId);
+    for (const instance of instances) {
+      this.collectInstanceDiagnostics(instance, index, settings, diagnosticsByUri);
+    }
+
+    if (settings.unresolvedIncludes) {
+      for (const occurrence of scanIncludeOccurrences(text)) {
+        if (!index.resolveInclude(occurrence.includeText, context)) {
+          addDiagnostic(diagnosticsByUri, uri, {
+            range: occurrence.range,
+            message: `Unresolved include: ${occurrence.includeText.slice(1, -1)}`,
+            code: 'unresolved-include',
+            severity: vscode.DiagnosticSeverity.Warning,
+          });
+        }
+      }
+    }
+
+    if (settings.unresolvedMacros) {
+      for (const occurrence of scanMacroOccurrences(text)) {
+        if (!isMacroResolved(occurrence.name, context, index)) {
+          addDiagnostic(diagnosticsByUri, uri, {
+            range: occurrence.range,
+            message: `Unresolved macro: ${occurrence.name}`,
+            code: 'unresolved-macro',
+            severity: vscode.DiagnosticSeverity.Information,
+          });
+        }
+      }
+    }
+  }
+
+  private collectInstanceDiagnostics(
+    instance: ModuleInstanceRecord,
+    index: SemanticIndex,
+    settings: SemanticDiagnosticSettings,
+    diagnosticsByUri: Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>
+  ): void {
+    const moduleRecord = index.findBestModule(instance.moduleName, instance.compileUnitId);
+    if (!moduleRecord) {
+      if (settings.unresolvedModules) {
+        addDiagnostic(diagnosticsByUri, instance.uri, {
+          range: instance.moduleNameRange,
+          message: `Unresolved module instance: ${instance.moduleName}`,
+          code: 'unresolved-module',
+          severity: vscode.DiagnosticSeverity.Warning,
+        });
+      }
+      return;
+    }
+
+    if (settings.unknownPorts) {
+      this.collectUnknownConnections(
+        instance,
+        moduleRecord,
+        instance.portConnectionRecords,
+        new Set(moduleRecord.ports.map((port) => port.name)),
+        'unknown-port',
+        (name) => `Unknown port '${name}' on module '${moduleRecord.name}'`,
+        diagnosticsByUri
+      );
+    }
+
+    if (settings.unknownParameters) {
+      this.collectUnknownConnections(
+        instance,
+        moduleRecord,
+        instance.parameterOverrideConnections,
+        new Set(moduleRecord.parameters.map((parameter) => parameter.name)),
+        'unknown-parameter',
+        (name) => `Unknown parameter '${name}' on module '${moduleRecord.name}'`,
+        diagnosticsByUri
+      );
+    }
+  }
+
+  private collectUnknownConnections(
+    instance: ModuleInstanceRecord,
+    _moduleRecord: ModuleRecord,
+    connections: readonly NamedConnectionRecord[],
+    knownNames: Set<string>,
+    code: string,
+    message: (name: string) => string,
+    diagnosticsByUri: Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>
+  ): void {
+    for (const connection of connections) {
+      if (!knownNames.has(connection.name)) {
+        addDiagnostic(diagnosticsByUri, instance.uri, {
+          range: connection.range,
+          message: message(connection.name),
+          code,
+          severity: vscode.DiagnosticSeverity.Warning,
+        });
+      }
+    }
+  }
+}
+
+function addDiagnostic(
+  diagnosticsByUri: Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>,
+  uri: vscode.Uri,
+  input: { range: vscode.Range; message: string; code: string; severity: vscode.DiagnosticSeverity }
+): void {
+  const diagnostic = new vscode.Diagnostic(input.range, input.message, input.severity);
+  diagnostic.source = SEMANTIC_DIAGNOSTIC_SOURCE;
+  diagnostic.code = input.code;
+  const key = uri.toString();
+  const entry = diagnosticsByUri.get(key) ?? { uri, diagnostics: [] };
+  entry.diagnostics.push(diagnostic);
+  diagnosticsByUri.set(key, entry);
+}
+
+function countCompileUnitFiles(snapshot: ProjectSnapshot): number {
+  return snapshot.compileUnits.reduce((sum, compileUnit) => sum + compileUnit.files.length, 0);
+}
+
+function getUniqueProjectFiles(snapshot: ProjectSnapshot): Array<{ uri: vscode.Uri; compileUnit: CompileUnit }> {
+  const files = new Map<string, { uri: vscode.Uri; compileUnit: CompileUnit }>();
+  for (const compileUnit of snapshot.compileUnits) {
+    for (const file of compileUnit.files) {
+      const key = file.uri.toString();
+      if (!files.has(key)) {
+        files.set(key, { uri: file.uri, compileUnit });
+      }
+    }
+  }
+  return [...files.values()];
+}
+
+function createFallbackContext(file: vscode.Uri, compileUnit: CompileUnit): FileContext {
+  return {
+    file,
+    compileUnitId: compileUnit.id,
+    includeDirs: compileUnit.includeDirs.slice(),
+    defines: { ...compileUnit.defines },
+  };
+}
+
+function isMacroResolved(name: string, context: FileContext, index: SemanticIndex): boolean {
+  return Boolean(
+    context.defines[name] ??
+    index.findSymbolsByName(name, { compileUnitId: context.compileUnitId, kinds: ['macro'] })[0] ??
+    index.findSymbolsByName(name, { kinds: ['macro'] })[0]
+  );
+}
+
+function getSemanticDiagnosticSettings(): SemanticDiagnosticSettings {
+  const config = vscode.workspace.getConfiguration();
+  return {
+    enabled: config.get<boolean>('verilog.semanticDiagnostics.enabled', true),
+    unresolvedModules: config.get<boolean>('verilog.semanticDiagnostics.unresolvedModules.enabled', true),
+    unknownPorts: config.get<boolean>('verilog.semanticDiagnostics.unknownPorts.enabled', true),
+    unknownParameters: config.get<boolean>('verilog.semanticDiagnostics.unknownParameters.enabled', true),
+    unresolvedIncludes: config.get<boolean>('verilog.semanticDiagnostics.unresolvedIncludes.enabled', true),
+    unresolvedMacros: config.get<boolean>('verilog.semanticDiagnostics.unresolvedMacros.enabled', false),
+    maxFiles: config.get<number>('verilog.semanticDiagnostics.maxFiles', 1000),
+  };
+}
+
+export function scanIncludeOccurrences(text: string): IncludeOccurrence[] {
+  const masked = maskComments(text);
+  const lineStarts = computeLineStarts(text);
+  const occurrences: IncludeOccurrence[] = [];
+  for (const match of masked.matchAll(/`include\s+(["<])([^">]+)[">]/g)) {
+    const open = match[1] ?? '"';
+    const includePath = match[2] ?? '';
+    const matchOffset = match.index ?? 0;
+    const pathOffsetInMatch = match[0].indexOf(includePath);
+    const pathOffset = matchOffset + pathOffsetInMatch;
+    const close = open === '<' ? '>' : '"';
+    occurrences.push({
+      includeText: `${open}${includePath}${close}`,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, pathOffset),
+        positionFromOffset(lineStarts, pathOffset + includePath.length)
+      ),
+    });
+  }
+  return occurrences;
+}
+
+export function scanMacroOccurrences(text: string): MacroOccurrence[] {
+  const masked = maskCommentsAndStrings(text);
+  const lineStarts = computeLineStarts(text);
+  const occurrences: MacroOccurrence[] = [];
+  for (const match of masked.matchAll(/`([A-Za-z_][A-Za-z0-9_$]*)/g)) {
+    const name = match[1] ?? '';
+    if (MACRO_DIRECTIVES.has(name)) {
+      continue;
+    }
+    const nameOffset = (match.index ?? 0) + 1;
+    occurrences.push({
+      name,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, nameOffset),
+        positionFromOffset(lineStarts, nameOffset + name.length)
+      ),
+    });
+  }
+  return occurrences;
+}
+
+function maskComments(text: string): string {
+  let result = '';
+  let index = 0;
+  while (index < text.length) {
+    const ch = text[index] ?? '';
+    const next = text[index + 1] ?? '';
+    if (ch === '/' && next === '/') {
+      result += '  ';
+      index += 2;
+      while (index < text.length && text[index] !== '\n') {
+        result += ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      result += '  ';
+      index += 2;
+      while (index < text.length) {
+        const blockCh = text[index] ?? '';
+        const blockNext = text[index + 1] ?? '';
+        if (blockCh === '*' && blockNext === '/') {
+          result += '  ';
+          index += 2;
+          break;
+        }
+        result += blockCh === '\n' ? '\n' : ' ';
+        index += 1;
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
+function maskCommentsAndStrings(text: string): string {
+  const withoutComments = maskComments(text);
+  let result = '';
+  let index = 0;
+  while (index < withoutComments.length) {
+    const ch = withoutComments[index] ?? '';
+    if (ch === '"') {
+      result += ' ';
+      index += 1;
+      while (index < withoutComments.length) {
+        const stringCh = withoutComments[index] ?? '';
+        result += stringCh === '\n' ? '\n' : ' ';
+        if (stringCh === '\\' && index + 1 < withoutComments.length) {
+          result += withoutComments[index + 1] === '\n' ? '\n' : ' ';
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (stringCh === '"') {
+          break;
+        }
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') {
+      starts.push(i + 1);
+    }
+  }
+  return starts;
+}
+
+function positionFromOffset(lineStarts: number[], offset: number): vscode.Position {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const value = lineStarts[mid] ?? 0;
+    if (value <= offset) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  const line = Math.max(0, high);
+  return new vscode.Position(line, offset - (lineStarts[line] ?? 0));
+}
+
+export function getIncludeSearchDirs(context: FileContext): string[] {
+  return [
+    path.dirname(context.file.fsPath),
+    ...context.includeDirs.map((dir) => dir.fsPath),
+  ];
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -171,6 +171,13 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.hierarchy.maxDepth']);
     assert.ok(properties['verilog.hierarchy.showUnresolved']);
     assert.ok(properties['verilog.hdlExplorer.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.unresolvedModules.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.unknownPorts.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.unknownParameters.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.unresolvedIncludes.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.unresolvedMacros.enabled']);
+    assert.ok(properties['verilog.semanticDiagnostics.maxFiles']);
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
     assert.ok(properties['verilog.preprocessor.useProjectDefines']);
     assert.ok(properties['verilog.linting.useProjectContext']);

--- a/src/test/instanceScanner.test.ts
+++ b/src/test/instanceScanner.test.ts
@@ -18,6 +18,11 @@ suite('InstanceScanner', () => {
     assert.strictEqual(instances[0]?.instanceName, 'u_foo');
     assert.strictEqual(instances[0]?.parentModuleName, 'top');
     assert.deepStrictEqual(instances[0]?.portConnections, ['clk']);
+    assert.strictEqual(instances[0]?.moduleNameRange.start.line, 1);
+    assert.strictEqual(instances[0]?.moduleNameRange.start.character, 2);
+    assert.strictEqual(instances[0]?.portConnectionRecords[0]?.name, 'clk');
+    assert.strictEqual(instances[0]?.portConnectionRecords[0]?.range.start.line, 2);
+    assert.strictEqual(instances[0]?.portConnectionRecords[0]?.range.start.character, 4);
   });
 
   test('detects parameterized instance', () => {
@@ -34,6 +39,9 @@ suite('InstanceScanner', () => {
     assert.strictEqual(instances.length, 1);
     assert.deepStrictEqual(instances[0]?.parameterOverrides, ['WIDTH']);
     assert.deepStrictEqual(instances[0]?.portConnections, ['clk']);
+    assert.strictEqual(instances[0]?.parameterOverrideConnections[0]?.name, 'WIDTH');
+    assert.strictEqual(instances[0]?.parameterOverrideConnections[0]?.range.start.line, 2);
+    assert.strictEqual(instances[0]?.parameterOverrideConnections[0]?.range.start.character, 4);
   });
 
   test('detects inline parameterized instance', () => {

--- a/src/test/semanticDiagnosticService.test.ts
+++ b/src/test/semanticDiagnosticService.test.ts
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit, ProjectSnapshot, SourceFileRef } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticDiagnosticService, type SemanticDiagnosticSink } from '../semantic/SemanticDiagnosticService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+class FakeSemanticDiagnosticSink implements SemanticDiagnosticSink {
+  readonly diagnostics = new Map<string, readonly vscode.Diagnostic[]>();
+  clearCalls = 0;
+  disposeCalls = 0;
+
+  set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void {
+    this.diagnostics.set(uri.toString(), diagnostics);
+  }
+
+  clear(): void {
+    this.diagnostics.clear();
+    this.clearCalls += 1;
+  }
+
+  dispose(): void {
+    this.disposeCalls += 1;
+  }
+
+  allDiagnostics(): vscode.Diagnostic[] {
+    return [...this.diagnostics.values()].flat();
+  }
+}
+
+suite('SemanticDiagnosticService', () => {
+  let previousMacroSetting: boolean | undefined;
+  let previousMaxFiles: number | undefined;
+
+  setup(() => {
+    const config = vscode.workspace.getConfiguration();
+    previousMacroSetting = config.get<boolean>('verilog.semanticDiagnostics.unresolvedMacros.enabled');
+    previousMaxFiles = config.get<number>('verilog.semanticDiagnostics.maxFiles');
+  });
+
+  teardown(async () => {
+    const config = vscode.workspace.getConfiguration();
+    await config.update(
+      'verilog.semanticDiagnostics.unresolvedMacros.enabled',
+      previousMacroSetting,
+      vscode.ConfigurationTarget.Global
+    );
+    await config.update(
+      'verilog.semanticDiagnostics.maxFiles',
+      previousMaxFiles,
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  test('reports unresolved module instances and clears after refresh', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  missing u_missing ();',
+      'endmodule',
+    ].join('\n'));
+    const sink = new FakeSemanticDiagnosticSink();
+    let index = new SemanticIndex(1, []);
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]), () => index, sink);
+
+    await service.refresh('test');
+    assertDiagnostic(sink, 'unresolved-module', 'Unresolved module instance: missing');
+
+    index = new SemanticIndex(2, [createModuleRecord('missing', 'unit')]);
+    await service.refresh('fixed');
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    assert.ok(sink.clearCalls >= 2);
+    service.dispose();
+  });
+
+  test('does not report resolved modules', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; child u_child (); endmodule');
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]),
+      () => new SemanticIndex(1, [createModuleRecord('child', 'unit')]),
+      sink
+    );
+
+    await service.refresh('test');
+
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+
+  test('reports unknown named ports and parameters', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  child #(',
+      '    .BAD_PARAM(1)',
+      '  ) u_child (',
+      '    .clk(clk),',
+      '    .bad_port(sig)',
+      '  );',
+      'endmodule',
+    ].join('\n'));
+    const child = createModuleRecord('child', 'unit', {
+      ports: [createPortRecord('clk', 'unit')],
+      parameters: [createParameterRecord('WIDTH', 'unit')],
+    });
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]),
+      () => new SemanticIndex(1, [child]),
+      sink
+    );
+
+    await service.refresh('test');
+
+    assertDiagnostic(sink, 'unknown-port', "Unknown port 'bad_port' on module 'child'");
+    assertDiagnostic(sink, 'unknown-parameter', "Unknown parameter 'BAD_PARAM' on module 'child'");
+    assert.ok(!sink.allDiagnostics().some((diagnostic) => diagnostic.message.includes("'clk'")));
+    service.dispose();
+  });
+
+  test('does not report known named ports and parameters', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  child #(.WIDTH(8)) u_child (.clk(clk));',
+      'endmodule',
+    ].join('\n'));
+    const child = createModuleRecord('child', 'unit', {
+      ports: [createPortRecord('clk', 'unit')],
+      parameters: [createParameterRecord('WIDTH', 'unit')],
+    });
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]),
+      () => new SemanticIndex(1, [child]),
+      sink
+    );
+
+    await service.refresh('test');
+
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+
+  test('reports unresolved includes and clears when the include becomes resolvable', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', '`include "defs.svh"\nmodule top; endmodule\n');
+    const includeDir = vscode.Uri.file(path.join(root, 'include'));
+    fs.mkdirSync(includeDir.fsPath);
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri], { includeDirs: [includeDir] })]),
+      () => new SemanticIndex(1, []),
+      sink
+    );
+
+    await service.refresh('missing');
+    assertDiagnostic(sink, 'unresolved-include', 'Unresolved include: defs.svh');
+
+    fs.writeFileSync(path.join(includeDir.fsPath, 'defs.svh'), '`define SIM\n');
+    await service.refresh('fixed');
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+
+  test('duplicate module names use preferred compile unit context', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; child u_child (.b(sig)); endmodule');
+    const unitA = createCompileUnit(root, 'unitA', [topUri], { name: 'unit A' });
+    const unitB = createCompileUnit(root, 'unitB', [topUri], { name: 'unit B' });
+    const childA = createModuleRecord('child', 'unitA', { ports: [createPortRecord('a', 'unitA')] });
+    const childB = createModuleRecord('child', 'unitB', { ports: [createPortRecord('b', 'unitB')] });
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [unitA, unitB], { activeTargetId: 'unitB' }),
+      () => new SemanticIndex(1, [childA, childB]),
+      sink
+    );
+
+    await service.refresh('test');
+
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+
+  test('unresolved macro diagnostics are disabled by default and informational when enabled', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; assign value = `MISSING; endmodule');
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]),
+      () => new SemanticIndex(1, []),
+      sink
+    );
+
+    await vscode.workspace.getConfiguration().update(
+      'verilog.semanticDiagnostics.unresolvedMacros.enabled',
+      false,
+      vscode.ConfigurationTarget.Global
+    );
+    await service.refresh('disabled');
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+
+    await vscode.workspace.getConfiguration().update(
+      'verilog.semanticDiagnostics.unresolvedMacros.enabled',
+      true,
+      vscode.ConfigurationTarget.Global
+    );
+    await service.refresh('enabled');
+    const diagnostic = assertDiagnostic(sink, 'unresolved-macro', 'Unresolved macro: MISSING');
+    assert.strictEqual(diagnostic.severity, vscode.DiagnosticSeverity.Information);
+    service.dispose();
+  });
+
+  test('project and source macros suppress unresolved macro diagnostics', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; assign a = `PROJECT_DEF; assign b = `SOURCE_DEF; endmodule');
+    const compileUnit = createCompileUnit(root, 'unit', [topUri], {
+      defines: {
+        PROJECT_DEF: { name: 'PROJECT_DEF', value: true, source: 'settings' },
+      },
+    });
+    const sourceMacro = createSymbolRecord('SOURCE_DEF', 'macro', 'unit');
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [compileUnit]),
+      () => new SemanticIndex(1, [sourceMacro]),
+      sink
+    );
+
+    await vscode.workspace.getConfiguration().update(
+      'verilog.semanticDiagnostics.unresolvedMacros.enabled',
+      true,
+      vscode.ConfigurationTarget.Global
+    );
+    await service.refresh('test');
+
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+
+  test('max file guard clears and skips diagnostics', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; missing u_missing (); endmodule');
+    const sink = new FakeSemanticDiagnosticSink();
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]),
+      () => new SemanticIndex(1, []),
+      sink
+    );
+
+    await service.refresh('initial');
+    assertDiagnostic(sink, 'unresolved-module', 'Unresolved module instance: missing');
+
+    await vscode.workspace.getConfiguration().update(
+      'verilog.semanticDiagnostics.maxFiles',
+      0,
+      vscode.ConfigurationTarget.Global
+    );
+    await service.refresh('guard');
+
+    assert.strictEqual(sink.allDiagnostics().length, 0);
+    service.dispose();
+  });
+});
+
+function createService(
+  snapshot: ProjectSnapshot,
+  getIndex: () => SemanticIndex,
+  sink: FakeSemanticDiagnosticSink
+): SemanticDiagnosticService {
+  const projectEmitter = new vscode.EventEmitter<ProjectSnapshot>();
+  const indexEmitter = new vscode.EventEmitter<SemanticIndex>();
+  const projectService = {
+    getSnapshot: () => snapshot,
+    onDidChangeSnapshot: projectEmitter.event,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex,
+    onDidChangeIndex: indexEmitter.event,
+  } as unknown as IndexService;
+  return new SemanticDiagnosticService(projectService, indexService, sink, undefined, false);
+}
+
+function createTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-semantic-diagnostics-'));
+}
+
+function writeFile(root: string, relativePath: string, content: string): vscode.Uri {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return vscode.Uri.file(filePath);
+}
+
+function createSnapshot(
+  root: string,
+  compileUnits: CompileUnit[],
+  options: { activeTargetId?: string } = {}
+): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file(root),
+    activeTargetId: options.activeTargetId ?? '',
+    compileUnits,
+    diagnostics: [],
+  };
+}
+
+function createCompileUnit(
+  root: string,
+  id: string,
+  files: vscode.Uri[],
+  options: Partial<Pick<CompileUnit, 'name' | 'includeDirs' | 'defines'>> = {}
+): CompileUnit {
+  return {
+    id,
+    name: options.name ?? id,
+    root: vscode.Uri.file(root),
+    files: files.map((uri, order): SourceFileRef => ({
+      uri,
+      languageId: 'systemverilog',
+      kind: 'source',
+      order,
+    })),
+    includeDirs: options.includeDirs ?? [],
+    defines: options.defines ?? {},
+    topModules: [],
+    source: { type: 'settings' },
+  };
+}
+
+function createModuleRecord(
+  name: string,
+  compileUnitId: string,
+  options: { ports?: PortRecord[]; parameters?: ParameterRecord[] } = {}
+): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module', compileUnitId),
+    kind: 'module',
+    ports: options.ports ?? [],
+    parameters: options.parameters ?? [],
+  };
+}
+
+function createPortRecord(name: string, compileUnitId: string): PortRecord {
+  return {
+    ...createSymbolRecord(name, 'port', compileUnitId),
+    kind: 'port',
+  };
+}
+
+function createParameterRecord(name: string, compileUnitId: string): ParameterRecord {
+  return {
+    ...createSymbolRecord(name, 'parameter', compileUnitId),
+    kind: 'parameter',
+  };
+}
+
+function createSymbolRecord(
+  name: string,
+  kind: SymbolRecord['kind'],
+  compileUnitId: string
+): SymbolRecord {
+  const range = new vscode.Range(0, 0, 0, name.length);
+  return {
+    id: `${compileUnitId}:${kind}:${name}`,
+    name,
+    kind,
+    uri: vscode.Uri.file(`/workspace/${compileUnitId}/${name}.sv`),
+    range,
+    selectionRange: range,
+    compileUnitId,
+  };
+}
+
+function assertDiagnostic(
+  sink: FakeSemanticDiagnosticSink,
+  code: string,
+  message: string
+): vscode.Diagnostic {
+  const diagnostic = sink.allDiagnostics().find((candidate) =>
+    candidate.code === code && candidate.message === message
+  );
+  assert.ok(diagnostic, `Expected diagnostic ${code}: ${message}`);
+  assert.strictEqual(diagnostic.source, 'verilog.semantic');
+  return diagnostic;
+}


### PR DESCRIPTION
## Summary
- add a lightweight `verilog-semantic` diagnostic collection for project-aware HDL diagnostics
- report unresolved modules, unknown named ports/parameters, unresolved includes, and optional unresolved macros
- extend instance scanning with ranges for module names and named connections without replacing existing hierarchy behavior

## Validation
- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` (313 passing, 3 pending)