### PR TITLE
Add project-aware references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Install it from [VS Code Marketplace](https://marketplace.visualstudio.com/items
 - Optional compile-unit linting for Slang, Verilator, and Icarus Verilog
 - Project-aware HDL editing:
   - Cross-file module and include go-to-definition
+  - Best-effort Find References for project-indexed HDL symbols
   - Hover for modules, ports, parameters, macros, includes, and indexed symbols
   - Workspace symbols for indexed HDL symbols
   - Module, macro, include path, port, and parameter completion
@@ -131,9 +132,11 @@ Hierarchy detection is intentionally lightweight and does not perform full Syste
 
 ### Project-Aware Editing
 
-For Verilog/SystemVerilog files, the project index improves go-to-definition, hover, workspace symbol search, completions, and module instantiation. Module names can resolve across the workspace even when the file name differs from the module name, and `` `include`` paths can resolve through the active file context include directories.
+For Verilog/SystemVerilog files, the project index improves go-to-definition, Find References, hover, workspace symbol search, completions, and module instantiation. Module names can resolve across the workspace even when the file name differs from the module name, and `` `include`` paths can resolve through the active file context include directories.
 
 Completion can suggest indexed module names, macros, include paths, ports, and parameters. Code actions can fill missing named ports or parameters in module instances when the target module is available from the project index.
+
+Find References is project/filelist-aware and best-effort. It supports modules, macros, include paths, and exact-name references for packages, interfaces, classes, and typedefs. It does not perform full SystemVerilog lexical scope resolution.
 
 ### Compile-Unit Linting
 

--- a/package.json
+++ b/package.json
@@ -905,6 +905,18 @@
         }
       },
       {
+        "title": "Verilog: References",
+        "properties": {
+          "verilog.references.maxFiles": {
+            "scope": "window",
+            "type": "number",
+            "default": 1000,
+            "minimum": 1,
+            "markdownDescription": "Maximum number of project files scanned by lightweight project-aware Find References."
+          }
+        }
+      },
+      {
         "title": "Verilog: Code Actions",
         "properties": {
           "verilog.codeActions.fillMissingPorts.enabled": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { CtagsManager } from './ctags';
 import * as DocumentSymbolProvider from './providers/DocumentSymbolProvider';
 import * as HoverProvider from './providers/HoverProvider';
 import * as DefinitionProvider from './providers/DefinitionProvider';
+import * as ReferenceProvider from './providers/ReferenceProvider';
 import * as CompletionItemProvider from './providers/CompletionItemProvider';
 import * as CodeActionProvider from './providers/CodeActionProvider';
 import * as ModuleInstantiation from './commands/ModuleInstantiation';
@@ -23,6 +24,7 @@ import { InstantiationService } from './hdl/InstantiationService';
 import { CompletionService } from './hdl/CompletionService';
 import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
 import { HoverService } from './hdl/HoverService';
+import { ReferenceService } from './hdl/ReferenceService';
 import { HierarchyService } from './hierarchy/HierarchyService';
 import { ProjectDiagnosticManager } from './project/ProjectDiagnosticManager';
 import { ProjectService } from './project/ProjectService';
@@ -61,6 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const completionService = new CompletionService(projectService, indexService, ctagsManager);
   const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
   const hoverService = new HoverService(projectService, indexService, ctagsManager);
+  const referenceService = new ReferenceService(projectService, indexService, ctagsManager);
   const hierarchyService = new HierarchyService(projectService, indexService);
   const semanticDiagnosticService = new SemanticDiagnosticService(projectService, indexService);
   const hdlExplorerProvider = new HdlExplorerProvider(projectService, indexService, hierarchyService);
@@ -164,6 +167,22 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerWorkspaceSymbolProvider(
       new VerilogWorkspaceSymbolProvider(indexService)
+    )
+  );
+
+  const verilogReferenceProvider = new ReferenceProvider.VerilogReferenceProvider(
+    referenceService
+  );
+  context.subscriptions.push(
+    vscode.languages.registerReferenceProvider(
+      { scheme: 'file', language: 'verilog' },
+      verilogReferenceProvider
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerReferenceProvider(
+      { scheme: 'file', language: 'systemverilog' },
+      verilogReferenceProvider
     )
   );
 

--- a/src/hdl/ReferenceService.ts
+++ b/src/hdl/ReferenceService.ts
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT
+import * as fs from 'fs/promises';
+import * as vscode from 'vscode';
+import type { CtagsManager } from '../ctags';
+import { InstanceScanner } from '../hierarchy/InstanceScanner';
+import type { ModuleInstanceRecord } from '../hierarchy/HierarchyTypes';
+import { getExtensionLogger } from '../logging';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit, FileContext, ProjectSnapshot, SourceFileRef } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import {
+  scanIncludeOccurrences,
+  scanMacroDefinitions,
+  scanMacroOccurrences,
+  scanMacroUsages,
+  scanWordOccurrences,
+} from '../semantic/scanners/OccurrenceScanners';
+import type { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+import { isModuleContext } from './DefinitionService';
+
+const logger = getExtensionLogger('HDL', 'References');
+const HDL_LANGUAGES = new Set(['verilog', 'systemverilog']);
+const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/;
+const INDEXED_REFERENCE_KINDS: SymbolRecord['kind'][] = ['package', 'interface', 'class', 'typedef'];
+
+interface ProjectFileEntry {
+  uri: vscode.Uri;
+  compileUnit: CompileUnit;
+  sourceFile: SourceFileRef;
+}
+
+interface IncludeAtPosition {
+  includeText: string;
+  range: vscode.Range;
+}
+
+interface MacroAtPosition {
+  name: string;
+  range: vscode.Range;
+  isDefinition: boolean;
+}
+
+export class ReferenceService {
+  private readonly scanner = new InstanceScanner();
+
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    _ctagsManager?: CtagsManager
+  ) {}
+
+  async provideReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.ReferenceContext,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[]> {
+    if (!HDL_LANGUAGES.has(document.languageId) || token.isCancellationRequested) {
+      return [];
+    }
+
+    const includeReferences = await this.findIncludeReferences(document, position, token);
+    if (includeReferences) {
+      return includeReferences;
+    }
+
+    const macroReferences = await this.findMacroReferences(document, position, context, token);
+    if (macroReferences) {
+      return macroReferences;
+    }
+
+    const moduleReferences = await this.findModuleReferences(document, position, context, token);
+    if (moduleReferences) {
+      return moduleReferences;
+    }
+
+    return this.findIndexedSymbolReferences(document, position, context, token);
+  }
+
+  private async findModuleReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    referenceContext: vscode.ReferenceContext,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[] | undefined> {
+    const wordRange = document.getWordRangeAtPosition(position, WORD_PATTERN);
+    if (!wordRange) {
+      return undefined;
+    }
+    const snapshot = this.projectService.getSnapshot();
+    const index = this.indexService.getIndex();
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    const word = document.getText(wordRange);
+    const targetName = isModuleContext(document, wordRange, word)
+      ? word
+      : this.findInstanceModuleAtPosition(document, position, fileContext?.compileUnitId)?.moduleName;
+    if (!targetName) {
+      return undefined;
+    }
+
+    const moduleRecord = index.findBestModule(targetName, fileContext);
+    if (!moduleRecord) {
+      return undefined;
+    }
+
+    const files = getReferenceFiles(snapshot, fileContext?.compileUnitId ?? moduleRecord.compileUnitId);
+    if (isTooLarge(files.length)) {
+      return [];
+    }
+
+    const locations: vscode.Location[] = [];
+    if (referenceContext.includeDeclaration) {
+      locations.push(new vscode.Location(moduleRecord.uri, moduleRecord.selectionRange));
+    }
+
+    for (const entry of files) {
+      if (token.isCancellationRequested) {
+        return locations;
+      }
+      const text = await readText(entry.uri);
+      if (text === undefined) {
+        continue;
+      }
+      const instances = this.scanner.scan(text, entry.uri, entry.compileUnit.id);
+      for (const instance of instances) {
+        if (isInstanceOfModule(instance, moduleRecord, index)) {
+          locations.push(new vscode.Location(instance.uri, instance.moduleNameRange));
+        }
+      }
+    }
+
+    return sortLocations(deduplicateLocations(locations));
+  }
+
+  private findInstanceModuleAtPosition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    compileUnitId = ''
+  ): ModuleInstanceRecord | undefined {
+    return this.scanner
+      .scan(document.getText(), document.uri, compileUnitId)
+      .find((instance) => rangeContains(instance.moduleNameRange, position));
+  }
+
+  private async findMacroReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    referenceContext: vscode.ReferenceContext,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[] | undefined> {
+    const macro = getMacroAtPosition(document, position);
+    if (!macro) {
+      return undefined;
+    }
+
+    const snapshot = this.projectService.getSnapshot();
+    const index = this.indexService.getIndex();
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    if (!macro.isDefinition && !isMacroKnown(macro.name, fileContext, index)) {
+      return undefined;
+    }
+
+    const files = getReferenceFiles(snapshot, fileContext?.compileUnitId);
+    if (isTooLarge(files.length)) {
+      return [];
+    }
+
+    const locations: vscode.Location[] = [];
+    if (referenceContext.includeDeclaration) {
+      const sourceMacro = findSourceMacro(macro.name, fileContext, index);
+      if (sourceMacro) {
+        locations.push(new vscode.Location(sourceMacro.uri, sourceMacro.selectionRange));
+      } else {
+        const projectDefineLocation = fileContext?.defines[macro.name]?.location;
+        if (projectDefineLocation) {
+          locations.push(projectDefineLocation);
+        }
+      }
+    }
+
+    for (const entry of files) {
+      if (token.isCancellationRequested) {
+        return locations;
+      }
+      const text = await readText(entry.uri);
+      if (text === undefined) {
+        continue;
+      }
+      for (const occurrence of scanMacroUsages(text)) {
+        if (occurrence.name === macro.name) {
+          locations.push(new vscode.Location(entry.uri, occurrence.range));
+        }
+      }
+    }
+
+    return sortLocations(deduplicateLocations(locations));
+  }
+
+  private async findIncludeReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[] | undefined> {
+    const include = getIncludeAtPosition(document, position);
+    if (!include) {
+      return undefined;
+    }
+
+    const snapshot = this.projectService.getSnapshot();
+    const fileContext = this.projectService.getPreferredFileContext(document.uri) ?? createLocalFileContext(document.uri);
+    const target = this.indexService.getIndex().resolveInclude(include.includeText, fileContext);
+    if (!target) {
+      return [new vscode.Location(document.uri, include.range)];
+    }
+
+    const files = getReferenceFiles(snapshot, fileContext.compileUnitId);
+    if (isTooLarge(files.length)) {
+      return [];
+    }
+
+    const locations: vscode.Location[] = [];
+    for (const entry of files) {
+      if (token.isCancellationRequested) {
+        return locations;
+      }
+      const text = await readText(entry.uri);
+      if (text === undefined) {
+        continue;
+      }
+      const context = createFileContext(entry.uri, entry.compileUnit);
+      for (const occurrence of scanIncludeOccurrences(text)) {
+        const resolved = this.indexService.getIndex().resolveInclude(occurrence.includeText, context);
+        if (resolved?.fsPath === target.fsPath) {
+          locations.push(new vscode.Location(entry.uri, occurrence.range));
+        }
+      }
+    }
+
+    return sortLocations(deduplicateLocations(locations));
+  }
+
+  private async findIndexedSymbolReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    referenceContext: vscode.ReferenceContext,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[]> {
+    const wordRange = document.getWordRangeAtPosition(position, WORD_PATTERN);
+    if (!wordRange) {
+      return [];
+    }
+
+    const word = document.getText(wordRange);
+    const snapshot = this.projectService.getSnapshot();
+    const index = this.indexService.getIndex();
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    const preferredSymbols = fileContext
+      ? index.findSymbolsByName(word, { compileUnitId: fileContext.compileUnitId, kinds: INDEXED_REFERENCE_KINDS })
+      : [];
+    const symbols = preferredSymbols.length > 0
+      ? preferredSymbols
+      : index.findSymbolsByName(word, { kinds: INDEXED_REFERENCE_KINDS });
+    if (symbols.length === 0) {
+      return [];
+    }
+
+    const compileUnitId = fileContext?.compileUnitId ?? symbols[0]?.compileUnitId;
+    const files = getReferenceFiles(snapshot, compileUnitId);
+    if (isTooLarge(files.length)) {
+      return [];
+    }
+
+    const locations: vscode.Location[] = [];
+    const declarationSymbols = symbols.filter((candidate) => !compileUnitId || candidate.compileUnitId === compileUnitId);
+    if (referenceContext.includeDeclaration) {
+      for (const symbol of declarationSymbols) {
+        locations.push(new vscode.Location(symbol.uri, symbol.selectionRange));
+      }
+    }
+
+    for (const entry of files) {
+      if (token.isCancellationRequested) {
+        return locations;
+      }
+      const text = await readText(entry.uri);
+      if (text === undefined) {
+        continue;
+      }
+      for (const occurrence of scanWordOccurrences(text, word)) {
+        if (!referenceContext.includeDeclaration && isDeclarationOccurrence(entry.uri, occurrence.range, declarationSymbols)) {
+          continue;
+        }
+        locations.push(new vscode.Location(entry.uri, occurrence.range));
+      }
+    }
+
+    return sortLocations(deduplicateLocations(locations));
+  }
+}
+
+function isInstanceOfModule(
+  instance: ModuleInstanceRecord,
+  moduleRecord: ModuleRecord,
+  index: SemanticIndex
+): boolean {
+  const resolved = index.findBestModule(instance.moduleName, instance.compileUnitId);
+  return resolved?.name === moduleRecord.name && resolved.compileUnitId === moduleRecord.compileUnitId;
+}
+
+function getReferenceFiles(snapshot: ProjectSnapshot, compileUnitId?: string): ProjectFileEntry[] {
+  const compileUnits = compileUnitId
+    ? snapshot.compileUnits.filter((compileUnit) => compileUnit.id === compileUnitId)
+    : snapshot.compileUnits;
+  const files = new Map<string, ProjectFileEntry>();
+  for (const compileUnit of compileUnits) {
+    for (const sourceFile of compileUnit.files) {
+      const key = sourceFile.uri.toString();
+      if (!files.has(key)) {
+        files.set(key, { uri: sourceFile.uri, compileUnit, sourceFile });
+      }
+    }
+  }
+  return [...files.values()];
+}
+
+function isTooLarge(fileCount: number): boolean {
+  const maxFiles = vscode.workspace.getConfiguration().get<number>('verilog.references.maxFiles', 1000);
+  if (fileCount > maxFiles) {
+    logger.warn('Skipping Verilog references because the project is too large', {
+      files: fileCount,
+      maxFiles,
+    });
+    return true;
+  }
+  return false;
+}
+
+async function readText(uri: vscode.Uri): Promise<string | undefined> {
+  try {
+    return await fs.readFile(uri.fsPath, 'utf8');
+  } catch (error) {
+    logger.debug('Skipping unreadable file during reference search', {
+      file: uri.fsPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+function getMacroAtPosition(document: vscode.TextDocument, position: vscode.Position): MacroAtPosition | undefined {
+  const text = document.getText();
+  for (const definition of scanMacroDefinitions(text)) {
+    if (rangeContains(definition.range, position)) {
+      return { name: definition.name, range: definition.range, isDefinition: true };
+    }
+  }
+  for (const occurrence of scanMacroOccurrences(text)) {
+    if (!occurrence.isDirective && rangeContains(occurrence.range, position)) {
+      return { name: occurrence.name, range: occurrence.range, isDefinition: false };
+    }
+  }
+  return undefined;
+}
+
+function getIncludeAtPosition(document: vscode.TextDocument, position: vscode.Position): IncludeAtPosition | undefined {
+  const line = document.lineAt(position.line).text;
+  const includePattern = /`include\s*(["<])([^">]+)[">]/g;
+  for (const match of line.matchAll(includePattern)) {
+    const fullMatch = match[0];
+    const quote = match[1] ?? '"';
+    const pathText = match[2] ?? '';
+    const start = match.index ?? 0;
+    const pathStart = start + fullMatch.indexOf(quote) + 1;
+    const pathEnd = pathStart + pathText.length;
+    if (position.character >= pathStart && position.character <= pathEnd) {
+      return {
+        includeText: `${quote}${pathText}${quote === '<' ? '>' : quote}`,
+        range: new vscode.Range(position.line, pathStart, position.line, pathEnd),
+      };
+    }
+  }
+  return undefined;
+}
+
+function isMacroKnown(
+  name: string,
+  context: FileContext | undefined,
+  index: SemanticIndex
+): boolean {
+  return Boolean(
+    context?.defines[name] ??
+    findSourceMacro(name, context, index)
+  );
+}
+
+function findSourceMacro(
+  name: string,
+  context: FileContext | undefined,
+  index: SemanticIndex
+): SymbolRecord | undefined {
+  return (context
+    ? index.findSymbolsByName(name, { compileUnitId: context.compileUnitId, kinds: ['macro'] }).at(0)
+    : undefined)
+    ?? index.findSymbolsByName(name, { kinds: ['macro'] }).at(0);
+}
+
+function createFileContext(file: vscode.Uri, compileUnit: CompileUnit): FileContext {
+  return {
+    file,
+    compileUnitId: compileUnit.id,
+    includeDirs: compileUnit.includeDirs.slice(),
+    defines: { ...compileUnit.defines },
+  };
+}
+
+function createLocalFileContext(uri: vscode.Uri): FileContext {
+  return {
+    file: uri,
+    compileUnitId: '',
+    includeDirs: [],
+    defines: {},
+  };
+}
+
+function rangeContains(range: vscode.Range, position: vscode.Position): boolean {
+  return range.start.isBeforeOrEqual(position) && range.end.isAfterOrEqual(position);
+}
+
+function isDeclarationOccurrence(
+  uri: vscode.Uri,
+  range: vscode.Range,
+  symbols: readonly SymbolRecord[]
+): boolean {
+  return symbols.some((symbol) =>
+    symbol.uri.toString() === uri.toString() &&
+    symbol.selectionRange.isEqual(range)
+  );
+}
+
+function deduplicateLocations(locations: vscode.Location[]): vscode.Location[] {
+  const seen = new Set<string>();
+  return locations.filter((location) => {
+    const key = `${location.uri.toString()}:${location.range.start.line}:${location.range.start.character}:${location.range.end.line}:${location.range.end.character}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function sortLocations(locations: vscode.Location[]): vscode.Location[] {
+  return locations.slice().sort((left, right) => {
+    const uriCompare = left.uri.fsPath.localeCompare(right.uri.fsPath);
+    if (uriCompare !== 0) {
+      return uriCompare;
+    }
+    return left.range.start.line - right.range.start.line ||
+      left.range.start.character - right.range.start.character;
+  });
+}

--- a/src/providers/ReferenceProvider.ts
+++ b/src/providers/ReferenceProvider.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { ReferenceService } from '../hdl/ReferenceService';
+import { getExtensionLogger } from '../logging';
+
+export class VerilogReferenceProvider implements vscode.ReferenceProvider {
+  private readonly logger = getExtensionLogger('Provider', 'Reference');
+
+  constructor(private readonly referenceService: ReferenceService) {}
+
+  async provideReferences(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.ReferenceContext,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Location[] | undefined> {
+    this.logger.info('References requested', { uri: document.uri.toString() });
+    const references = await this.referenceService.provideReferences(document, position, context, token);
+    this.logger.info('References returned', { count: references.length });
+    return references;
+  }
+}

--- a/src/semantic/SemanticDiagnosticService.ts
+++ b/src/semantic/SemanticDiagnosticService.ts
@@ -9,35 +9,13 @@ import { FileContextResolver } from '../project/FileContextResolver';
 import type { ProjectService } from '../project/ProjectService';
 import type { CompileUnit, FileContext, ProjectSnapshot } from '../project/ProjectTypes';
 import type { IndexService } from './IndexService';
+import { scanIncludeOccurrences, scanMacroUsages } from './scanners/OccurrenceScanners';
 import type { SemanticIndex } from './SemanticIndex';
 import type { ModuleRecord } from './SymbolRecords';
 
 const logger = getExtensionLogger('Semantic', 'Diagnostics');
 const SEMANTIC_DIAGNOSTIC_SOURCE = 'verilog.semantic';
 const REFRESH_DEBOUNCE_MS = 300;
-
-const MACRO_DIRECTIVES = new Set([
-  'begin_keywords',
-  'celldefine',
-  'default_nettype',
-  'define',
-  'else',
-  'elsif',
-  'end_keywords',
-  'endcelldefine',
-  'endif',
-  'ifdef',
-  'ifndef',
-  'include',
-  'line',
-  'nounconnected_drive',
-  'pragma',
-  'resetall',
-  'timescale',
-  'undef',
-  'undefineall',
-  'unconnected_drive',
-]);
 
 export interface SemanticDiagnosticSink {
   set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void;
@@ -53,16 +31,6 @@ interface SemanticDiagnosticSettings {
   unresolvedIncludes: boolean;
   unresolvedMacros: boolean;
   maxFiles: number;
-}
-
-interface IncludeOccurrence {
-  includeText: string;
-  range: vscode.Range;
-}
-
-interface MacroOccurrence {
-  name: string;
-  range: vscode.Range;
 }
 
 export class SemanticDiagnosticService implements vscode.Disposable {
@@ -201,7 +169,7 @@ export class SemanticDiagnosticService implements vscode.Disposable {
     }
 
     if (settings.unresolvedMacros) {
-      for (const occurrence of scanMacroOccurrences(text)) {
+      for (const occurrence of scanMacroUsages(text)) {
         if (!isMacroResolved(occurrence.name, context, index)) {
           addDiagnostic(diagnosticsByUri, uri, {
             range: occurrence.range,
@@ -339,142 +307,6 @@ function getSemanticDiagnosticSettings(): SemanticDiagnosticSettings {
     unresolvedMacros: config.get<boolean>('verilog.semanticDiagnostics.unresolvedMacros.enabled', false),
     maxFiles: config.get<number>('verilog.semanticDiagnostics.maxFiles', 1000),
   };
-}
-
-export function scanIncludeOccurrences(text: string): IncludeOccurrence[] {
-  const masked = maskComments(text);
-  const lineStarts = computeLineStarts(text);
-  const occurrences: IncludeOccurrence[] = [];
-  for (const match of masked.matchAll(/`include\s+(["<])([^">]+)[">]/g)) {
-    const open = match[1] ?? '"';
-    const includePath = match[2] ?? '';
-    const matchOffset = match.index ?? 0;
-    const pathOffsetInMatch = match[0].indexOf(includePath);
-    const pathOffset = matchOffset + pathOffsetInMatch;
-    const close = open === '<' ? '>' : '"';
-    occurrences.push({
-      includeText: `${open}${includePath}${close}`,
-      range: new vscode.Range(
-        positionFromOffset(lineStarts, pathOffset),
-        positionFromOffset(lineStarts, pathOffset + includePath.length)
-      ),
-    });
-  }
-  return occurrences;
-}
-
-export function scanMacroOccurrences(text: string): MacroOccurrence[] {
-  const masked = maskCommentsAndStrings(text);
-  const lineStarts = computeLineStarts(text);
-  const occurrences: MacroOccurrence[] = [];
-  for (const match of masked.matchAll(/`([A-Za-z_][A-Za-z0-9_$]*)/g)) {
-    const name = match[1] ?? '';
-    if (MACRO_DIRECTIVES.has(name)) {
-      continue;
-    }
-    const nameOffset = (match.index ?? 0) + 1;
-    occurrences.push({
-      name,
-      range: new vscode.Range(
-        positionFromOffset(lineStarts, nameOffset),
-        positionFromOffset(lineStarts, nameOffset + name.length)
-      ),
-    });
-  }
-  return occurrences;
-}
-
-function maskComments(text: string): string {
-  let result = '';
-  let index = 0;
-  while (index < text.length) {
-    const ch = text[index] ?? '';
-    const next = text[index + 1] ?? '';
-    if (ch === '/' && next === '/') {
-      result += '  ';
-      index += 2;
-      while (index < text.length && text[index] !== '\n') {
-        result += ' ';
-        index += 1;
-      }
-      continue;
-    }
-    if (ch === '/' && next === '*') {
-      result += '  ';
-      index += 2;
-      while (index < text.length) {
-        const blockCh = text[index] ?? '';
-        const blockNext = text[index + 1] ?? '';
-        if (blockCh === '*' && blockNext === '/') {
-          result += '  ';
-          index += 2;
-          break;
-        }
-        result += blockCh === '\n' ? '\n' : ' ';
-        index += 1;
-      }
-      continue;
-    }
-    result += ch;
-    index += 1;
-  }
-  return result;
-}
-
-function maskCommentsAndStrings(text: string): string {
-  const withoutComments = maskComments(text);
-  let result = '';
-  let index = 0;
-  while (index < withoutComments.length) {
-    const ch = withoutComments[index] ?? '';
-    if (ch === '"') {
-      result += ' ';
-      index += 1;
-      while (index < withoutComments.length) {
-        const stringCh = withoutComments[index] ?? '';
-        result += stringCh === '\n' ? '\n' : ' ';
-        if (stringCh === '\\' && index + 1 < withoutComments.length) {
-          result += withoutComments[index + 1] === '\n' ? '\n' : ' ';
-          index += 2;
-          continue;
-        }
-        index += 1;
-        if (stringCh === '"') {
-          break;
-        }
-      }
-      continue;
-    }
-    result += ch;
-    index += 1;
-  }
-  return result;
-}
-
-function computeLineStarts(text: string): number[] {
-  const starts = [0];
-  for (let i = 0; i < text.length; i += 1) {
-    if (text[i] === '\n') {
-      starts.push(i + 1);
-    }
-  }
-  return starts;
-}
-
-function positionFromOffset(lineStarts: number[], offset: number): vscode.Position {
-  let low = 0;
-  let high = lineStarts.length - 1;
-  while (low <= high) {
-    const mid = Math.floor((low + high) / 2);
-    const value = lineStarts[mid] ?? 0;
-    if (value <= offset) {
-      low = mid + 1;
-    } else {
-      high = mid - 1;
-    }
-  }
-  const line = Math.max(0, high);
-  return new vscode.Position(line, offset - (lineStarts[line] ?? 0));
 }
 
 export function getIncludeSearchDirs(context: FileContext): string[] {

--- a/src/semantic/scanners/OccurrenceScanners.ts
+++ b/src/semantic/scanners/OccurrenceScanners.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+
+export const MACRO_DIRECTIVES = new Set([
+  'begin_keywords',
+  'celldefine',
+  'default_nettype',
+  'define',
+  'else',
+  'elsif',
+  'end_keywords',
+  'endcelldefine',
+  'endif',
+  'ifdef',
+  'ifndef',
+  'include',
+  'line',
+  'nounconnected_drive',
+  'pragma',
+  'resetall',
+  'timescale',
+  'undef',
+  'undefineall',
+  'unconnected_drive',
+]);
+
+export interface IncludeOccurrence {
+  includeText: string;
+  range: vscode.Range;
+}
+
+export interface MacroOccurrence {
+  name: string;
+  range: vscode.Range;
+  isDirective: boolean;
+}
+
+export interface WordOccurrence {
+  text: string;
+  range: vscode.Range;
+}
+
+export function scanIncludeOccurrences(text: string): IncludeOccurrence[] {
+  const masked = maskComments(text);
+  const lineStarts = computeLineStarts(text);
+  const occurrences: IncludeOccurrence[] = [];
+  for (const match of masked.matchAll(/`include\s+(["<])([^">]+)[">]/g)) {
+    const open = match[1] ?? '"';
+    const includePath = match[2] ?? '';
+    const matchOffset = match.index ?? 0;
+    const pathOffsetInMatch = match[0].indexOf(includePath);
+    const pathOffset = matchOffset + pathOffsetInMatch;
+    const close = open === '<' ? '>' : '"';
+    occurrences.push({
+      includeText: `${open}${includePath}${close}`,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, pathOffset),
+        positionFromOffset(lineStarts, pathOffset + includePath.length)
+      ),
+    });
+  }
+  return occurrences;
+}
+
+export function scanMacroOccurrences(text: string): MacroOccurrence[] {
+  const masked = maskCommentsAndStrings(text);
+  const lineStarts = computeLineStarts(text);
+  const occurrences: MacroOccurrence[] = [];
+  for (const match of masked.matchAll(/`([A-Za-z_][A-Za-z0-9_$]*)/g)) {
+    const name = match[1] ?? '';
+    const nameOffset = (match.index ?? 0) + 1;
+    occurrences.push({
+      name,
+      isDirective: MACRO_DIRECTIVES.has(name),
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, nameOffset),
+        positionFromOffset(lineStarts, nameOffset + name.length)
+      ),
+    });
+  }
+  return occurrences;
+}
+
+export function scanMacroUsages(text: string): MacroOccurrence[] {
+  return scanMacroOccurrences(text).filter((occurrence) => !occurrence.isDirective);
+}
+
+export function scanMacroDefinitions(text: string): MacroOccurrence[] {
+  const masked = maskCommentsAndStrings(text);
+  const lineStarts = computeLineStarts(text);
+  const definitions: MacroOccurrence[] = [];
+  for (const match of masked.matchAll(/`define\s+([A-Za-z_][A-Za-z0-9_$]*)/g)) {
+    const name = match[1] ?? '';
+    const nameOffset = (match.index ?? 0) + match[0].lastIndexOf(name);
+    definitions.push({
+      name,
+      isDirective: false,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, nameOffset),
+        positionFromOffset(lineStarts, nameOffset + name.length)
+      ),
+    });
+  }
+  return definitions;
+}
+
+export function scanWordOccurrences(text: string, word: string): WordOccurrence[] {
+  if (!/^[A-Za-z_][A-Za-z0-9_$]*$/.test(word)) {
+    return [];
+  }
+  const masked = maskCommentsAndStrings(text);
+  const lineStarts = computeLineStarts(text);
+  const occurrences: WordOccurrence[] = [];
+  const pattern = new RegExp(`\\b${escapeRegExp(word)}\\b`, 'g');
+  for (const match of masked.matchAll(pattern)) {
+    const offset = match.index ?? 0;
+    occurrences.push({
+      text: word,
+      range: new vscode.Range(
+        positionFromOffset(lineStarts, offset),
+        positionFromOffset(lineStarts, offset + word.length)
+      ),
+    });
+  }
+  return occurrences;
+}
+
+export function maskComments(text: string): string {
+  let result = '';
+  let index = 0;
+  while (index < text.length) {
+    const ch = text[index] ?? '';
+    const next = text[index + 1] ?? '';
+    if (ch === '/' && next === '/') {
+      result += '  ';
+      index += 2;
+      while (index < text.length && text[index] !== '\n') {
+        result += ' ';
+        index += 1;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      result += '  ';
+      index += 2;
+      while (index < text.length) {
+        const blockCh = text[index] ?? '';
+        const blockNext = text[index + 1] ?? '';
+        if (blockCh === '*' && blockNext === '/') {
+          result += '  ';
+          index += 2;
+          break;
+        }
+        result += blockCh === '\n' ? '\n' : ' ';
+        index += 1;
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
+export function maskCommentsAndStrings(text: string): string {
+  const withoutComments = maskComments(text);
+  let result = '';
+  let index = 0;
+  while (index < withoutComments.length) {
+    const ch = withoutComments[index] ?? '';
+    if (ch === '"') {
+      result += ' ';
+      index += 1;
+      while (index < withoutComments.length) {
+        const stringCh = withoutComments[index] ?? '';
+        result += stringCh === '\n' ? '\n' : ' ';
+        if (stringCh === '\\' && index + 1 < withoutComments.length) {
+          result += withoutComments[index + 1] === '\n' ? '\n' : ' ';
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (stringCh === '"') {
+          break;
+        }
+      }
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') {
+      starts.push(i + 1);
+    }
+  }
+  return starts;
+}
+
+function positionFromOffset(lineStarts: number[], offset: number): vscode.Position {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const value = lineStarts[mid] ?? 0;
+    if (value <= offset) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  const line = Math.max(0, high);
+  return new vscode.Position(line, offset - (lineStarts[line] ?? 0));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -188,6 +188,7 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.completion.parameters.enabled']);
     assert.ok(properties['verilog.completion.autoConnectPorts']);
     assert.ok(properties['verilog.completion.autoConnectParameters']);
+    assert.ok(properties['verilog.references.maxFiles']);
     assert.ok(properties['verilog.codeActions.fillMissingPorts.enabled']);
     assert.ok(properties['verilog.codeActions.fillMissingParameters.enabled']);
     assert.ok(properties['verilog.codeActions.alignment.enabled']);

--- a/src/test/referenceProvider.test.ts
+++ b/src/test/referenceProvider.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import type { ReferenceService } from '../hdl/ReferenceService';
+import { VerilogReferenceProvider } from '../providers/ReferenceProvider';
+
+suite('ReferenceProvider', () => {
+  test('returns references from the service', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+    const location = new vscode.Location(document.uri, new vscode.Range(0, 7, 0, 10));
+    const provider = new VerilogReferenceProvider({
+      provideReferences: async () => [location],
+    } as unknown as ReferenceService);
+
+    const result = await provider.provideReferences(
+      document,
+      new vscode.Position(0, 8),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(result, [location]);
+  });
+});

--- a/src/test/referenceService.test.ts
+++ b/src/test/referenceService.test.ts
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ReferenceService } from '../hdl/ReferenceService';
+import { FileContextResolver } from '../project/FileContextResolver';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit, ProjectSnapshot, SourceFileRef } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+suite('ReferenceService', () => {
+  let previousMaxFiles: number | undefined;
+
+  setup(() => {
+    previousMaxFiles = vscode.workspace.getConfiguration().get<number>('verilog.references.maxFiles');
+  });
+
+  teardown(async () => {
+    await vscode.workspace.getConfiguration().update(
+      'verilog.references.maxFiles',
+      previousMaxFiles,
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  test('module declaration returns module instantiations', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  child u0 ();',
+      '  child u1 ();',
+      'endmodule',
+    ].join('\n'));
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri, topUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(childUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 8),
+      { includeDeclaration: false },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${topUri.fsPath}:1:2-1:7`,
+      `${topUri.fsPath}:2:2-2:7`,
+    ]);
+  });
+
+  test('module instantiation type returns declaration and other instantiations', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  child u0 ();',
+      '  child u1 ();',
+      'endmodule',
+    ].join('\n'));
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri, topUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(1, 4),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${childUri.fsPath}:0:7-0:12`,
+      `${topUri.fsPath}:1:2-1:7`,
+      `${topUri.fsPath}:2:2-2:7`,
+    ]);
+  });
+
+  test('includeDeclaration false omits module declaration', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; child u0 (); endmodule\n');
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri, topUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 13),
+      { includeDeclaration: false },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [`${topUri.fsPath}:0:12-0:17`]);
+  });
+
+  test('duplicate module names prefer active compile unit', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; child u0 (); endmodule\n');
+    const childAUri = writeFile(root, 'a/child.sv', 'module child; endmodule\n');
+    const childBUri = writeFile(root, 'b/child.sv', 'module child; endmodule\n');
+    const unitA = createCompileUnit(root, 'unitA', [topUri, childAUri]);
+    const unitB = createCompileUnit(root, 'unitB', [topUri, childBUri]);
+    const childA = createModuleRecord('child', 'unitA', childAUri, new vscode.Range(0, 7, 0, 12));
+    const childB = createModuleRecord('child', 'unitB', childBUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(
+      createSnapshot(root, [unitA, unitB], { activeTargetId: 'unitB' }),
+      [childA, childB]
+    );
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 13),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${childBUri.fsPath}:0:7-0:12`,
+      `${topUri.fsPath}:0:12-0:17`,
+    ]);
+  });
+
+  test('macro definition returns macro usages', async () => {
+    const root = createTempRoot();
+    const defsUri = writeFile(root, 'defs.svh', '`define FOO 1\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; assign a = `FOO; assign b = `FOO(); endmodule\n');
+    const macro = createSymbolRecord('FOO', 'macro', 'unit', defsUri, new vscode.Range(0, 8, 0, 11));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [defsUri, topUri])]), [macro]);
+    const document = await vscode.workspace.openTextDocument(defsUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 9),
+      { includeDeclaration: false },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${topUri.fsPath}:0:24-0:27`,
+      `${topUri.fsPath}:0:41-0:44`,
+    ]);
+  });
+
+  test('macro usage returns definition and other usages', async () => {
+    const root = createTempRoot();
+    const defsUri = writeFile(root, 'defs.svh', '`define FOO 1\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; assign a = `FOO; assign b = `FOO(); endmodule\n');
+    const macro = createSymbolRecord('FOO', 'macro', 'unit', defsUri, new vscode.Range(0, 8, 0, 11));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [defsUri, topUri])]), [macro]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 24),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${defsUri.fsPath}:0:8-0:11`,
+      `${topUri.fsPath}:0:24-0:27`,
+      `${topUri.fsPath}:0:41-0:44`,
+    ]);
+  });
+
+  test('directive keywords are ignored as macro references', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', '`ifdef FOO\n`endif\nmodule top; endmodule\n');
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]), []);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 2),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references, []);
+  });
+
+  test('include path returns include occurrences resolving to the same file', async () => {
+    const root = createTempRoot();
+    const incDir = path.join(root, 'inc');
+    fs.mkdirSync(incDir);
+    const defsUri = writeFile(root, 'inc/defs.svh', '`define FOO\n');
+    const topUri = writeFile(root, 'top.sv', '`include "defs.svh"\nmodule top; endmodule\n');
+    const subUri = writeFile(root, 'sub/sub.sv', '`include "../inc/defs.svh"\nmodule sub; endmodule\n');
+    const compileUnit = createCompileUnit(root, 'unit', [topUri, subUri, defsUri], {
+      includeDirs: [vscode.Uri.file(incDir)],
+    });
+    const service = createService(createSnapshot(root, [compileUnit]), []);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 12),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${subUri.fsPath}:0:10-0:25`,
+      `${topUri.fsPath}:0:10-0:18`,
+    ]);
+  });
+
+  test('typedef exact-name references work in active compile unit', async () => {
+    const root = createTempRoot();
+    const pkgUri = writeFile(root, 'pkg.sv', 'typedef logic [3:0] nibble_t;\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; nibble_t n; endmodule\n');
+    const typedef = createSymbolRecord('nibble_t', 'typedef', 'unit', pkgUri, new vscode.Range(0, 20, 0, 28));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [pkgUri, topUri])]), [typedef]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 13),
+      { includeDeclaration: true },
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(references.map(formatLocation), [
+      `${pkgUri.fsPath}:0:20-0:28`,
+      `${topUri.fsPath}:0:12-0:20`,
+    ]);
+  });
+
+  test('cancellation token is respected', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; child u0 (); endmodule\n');
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [topUri, childUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+    const tokenSource = new vscode.CancellationTokenSource();
+    tokenSource.cancel();
+
+    const references = await service.provideReferences(
+      document,
+      new vscode.Position(0, 13),
+      { includeDeclaration: true },
+      tokenSource.token
+    );
+
+    assert.deepStrictEqual(references, []);
+  });
+});
+
+function createService(snapshot: ProjectSnapshot, symbols: SymbolRecord[]): ReferenceService {
+  const index = new SemanticIndex(snapshot.version, symbols);
+  const projectEmitter = new vscode.EventEmitter<ProjectSnapshot>();
+  const indexEmitter = new vscode.EventEmitter<SemanticIndex>();
+  const projectService = {
+    getSnapshot: () => snapshot,
+    getPreferredFileContext: (uri: vscode.Uri) => new FileContextResolver(snapshot).getPreferredFileContext(uri),
+    onDidChangeSnapshot: projectEmitter.event,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => index,
+    onDidChangeIndex: indexEmitter.event,
+  } as unknown as IndexService;
+  return new ReferenceService(projectService, indexService);
+}
+
+function createTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-references-'));
+}
+
+function writeFile(root: string, relativePath: string, content: string): vscode.Uri {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return vscode.Uri.file(filePath);
+}
+
+function createSnapshot(
+  root: string,
+  compileUnits: CompileUnit[],
+  options: { activeTargetId?: string } = {}
+): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file(root),
+    activeTargetId: options.activeTargetId ?? '',
+    compileUnits,
+    diagnostics: [],
+  };
+}
+
+function createCompileUnit(
+  root: string,
+  id: string,
+  files: vscode.Uri[],
+  options: Partial<Pick<CompileUnit, 'name' | 'includeDirs' | 'defines'>> = {}
+): CompileUnit {
+  return {
+    id,
+    name: options.name ?? id,
+    root: vscode.Uri.file(root),
+    files: files.map((uri, order): SourceFileRef => ({
+      uri,
+      languageId: uri.fsPath.endsWith('.svh') ? 'systemverilog' : 'systemverilog',
+      kind: uri.fsPath.endsWith('.svh') ? 'include' : 'source',
+      order,
+    })),
+    includeDirs: options.includeDirs ?? [],
+    defines: options.defines ?? {},
+    topModules: [],
+    source: { type: 'settings' },
+  };
+}
+
+function createModuleRecord(
+  name: string,
+  compileUnitId: string,
+  uri: vscode.Uri,
+  selectionRange: vscode.Range
+): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module', compileUnitId, uri, selectionRange),
+    kind: 'module',
+    ports: [],
+    parameters: [],
+  };
+}
+
+function createSymbolRecord(
+  name: string,
+  kind: SymbolRecord['kind'],
+  compileUnitId: string,
+  uri: vscode.Uri,
+  selectionRange: vscode.Range
+): SymbolRecord {
+  return {
+    id: `${compileUnitId}:${kind}:${name}:${uri.fsPath}`,
+    name,
+    kind,
+    uri,
+    range: selectionRange,
+    selectionRange,
+    compileUnitId,
+  };
+}
+
+function formatLocation(location: vscode.Location): string {
+  return `${location.uri.fsPath}:${location.range.start.line}:${location.range.start.character}-${location.range.end.line}:${location.range.end.character}`;
+}


### PR DESCRIPTION
## Summary
- add a project-aware ReferenceService and VS Code reference provider for Verilog/SystemVerilog
- support module, macro, include, and exact-name package/interface/class/typedef references
- extract reusable occurrence scanners for macro/include/word scans
- add `verilog.references.maxFiles` to guard large reference searches

## Validation
- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` (324 passing, 3 pending)

## Limitations
- best-effort project-index references only
- no rename, Slang backend, full lexical scope resolution, or full SystemVerilog semantic analysis