### PR TITLE
Project-aware Rename MVP

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as DocumentSymbolProvider from './providers/DocumentSymbolProvider';
 import * as HoverProvider from './providers/HoverProvider';
 import * as DefinitionProvider from './providers/DefinitionProvider';
 import * as ReferenceProvider from './providers/ReferenceProvider';
+import * as RenameProvider from './providers/RenameProvider';
 import * as CompletionItemProvider from './providers/CompletionItemProvider';
 import * as CodeActionProvider from './providers/CodeActionProvider';
 import * as ModuleInstantiation from './commands/ModuleInstantiation';
@@ -25,6 +26,7 @@ import { CompletionService } from './hdl/CompletionService';
 import { ModuleInstanceCodeActionService } from './hdl/ModuleInstanceCodeActionService';
 import { HoverService } from './hdl/HoverService';
 import { ReferenceService } from './hdl/ReferenceService';
+import { RenameService } from './hdl/RenameService';
 import { HierarchyService } from './hierarchy/HierarchyService';
 import { ProjectDiagnosticManager } from './project/ProjectDiagnosticManager';
 import { ProjectService } from './project/ProjectService';
@@ -64,6 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const codeActionService = new ModuleInstanceCodeActionService(projectService, indexService);
   const hoverService = new HoverService(projectService, indexService, ctagsManager);
   const referenceService = new ReferenceService(projectService, indexService, ctagsManager);
+  const renameService = new RenameService(projectService, indexService, referenceService);
   const hierarchyService = new HierarchyService(projectService, indexService);
   const semanticDiagnosticService = new SemanticDiagnosticService(projectService, indexService);
   const hdlExplorerProvider = new HdlExplorerProvider(projectService, indexService, hierarchyService);
@@ -183,6 +186,22 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerReferenceProvider(
       { scheme: 'file', language: 'systemverilog' },
       verilogReferenceProvider
+    )
+  );
+
+  const verilogRenameProvider = new RenameProvider.VerilogRenameProvider(
+    renameService
+  );
+  context.subscriptions.push(
+    vscode.languages.registerRenameProvider(
+      { scheme: 'file', language: 'verilog' },
+      verilogRenameProvider
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerRenameProvider(
+      { scheme: 'file', language: 'systemverilog' },
+      verilogRenameProvider
     )
   );
 

--- a/src/hdl/RenameService.ts
+++ b/src/hdl/RenameService.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import { InstanceScanner } from '../hierarchy/InstanceScanner';
+import type { ModuleInstanceRecord } from '../hierarchy/HierarchyTypes';
+import type { ProjectService } from '../project/ProjectService';
+import type { FileContext } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { scanMacroDefinitions, scanMacroOccurrences } from '../semantic/scanners/OccurrenceScanners';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+import { isModuleContext } from './DefinitionService';
+import type { ReferenceService } from './ReferenceService';
+
+const HDL_LANGUAGES = new Set(['verilog', 'systemverilog']);
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+const WORD_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/;
+
+type RenameTarget =
+  | { kind: 'module'; name: string; range: vscode.Range; symbol: ModuleRecord }
+  | { kind: 'macro'; name: string; range: vscode.Range; symbol: SymbolRecord };
+
+interface MacroAtPosition {
+  name: string;
+  range: vscode.Range;
+  isDefinition: boolean;
+}
+
+export class RenameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RenameError';
+  }
+}
+
+export class RenameService {
+  private readonly scanner = new InstanceScanner();
+
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly indexService: IndexService,
+    private readonly referenceService: ReferenceService
+  ) {}
+
+  async prepareRename(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Range | { range: vscode.Range; placeholder: string } | undefined> {
+    if (token.isCancellationRequested) {
+      return undefined;
+    }
+    const target = this.findRenameTarget(document, position);
+    return target ? { range: target.range, placeholder: target.name } : undefined;
+  }
+
+  async provideRenameEdits(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    newName: string,
+    token: vscode.CancellationToken
+  ): Promise<vscode.WorkspaceEdit | undefined> {
+    if (token.isCancellationRequested) {
+      return undefined;
+    }
+    const target = this.findRenameTarget(document, position);
+    if (!target) {
+      throw new RenameError('Rename is only supported for module names and source-defined macros.');
+    }
+    validateNewName(newName, target.kind);
+
+    const references = await this.referenceService.provideReferences(
+      document,
+      position,
+      { includeDeclaration: true },
+      token
+    );
+    if (token.isCancellationRequested) {
+      return undefined;
+    }
+    const matchingReferences = await filterExistingFileReferences(references.filter(isNonEmptyReference));
+    if (matchingReferences.length === 0) {
+      throw new RenameError('No safe references were found for this rename.');
+    }
+
+    const edit = new vscode.WorkspaceEdit();
+    for (const location of matchingReferences) {
+      edit.replace(location.uri, location.range, newName);
+    }
+    return edit;
+  }
+
+  private findRenameTarget(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): RenameTarget | undefined {
+    if (!HDL_LANGUAGES.has(document.languageId)) {
+      return undefined;
+    }
+
+    return this.findMacroTarget(document, position) ?? this.findModuleTarget(document, position);
+  }
+
+  private findModuleTarget(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): RenameTarget | undefined {
+    const wordRange = document.getWordRangeAtPosition(position, WORD_PATTERN);
+    if (!wordRange) {
+      return undefined;
+    }
+    const word = document.getText(wordRange);
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    if (!fileContext) {
+      return undefined;
+    }
+    const moduleName = isModuleContext(document, wordRange, word)
+      ? word
+      : this.findInstanceModuleAtPosition(document, position, fileContext.compileUnitId)?.moduleName;
+    if (!moduleName) {
+      return undefined;
+    }
+
+    const moduleRecord = this.indexService.getIndex().findBestModule(moduleName, fileContext);
+    if (!moduleRecord || moduleRecord.compileUnitId !== fileContext.compileUnitId) {
+      return undefined;
+    }
+    return { kind: 'module', name: moduleRecord.name, range: wordRange, symbol: moduleRecord };
+  }
+
+  private findInstanceModuleAtPosition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    compileUnitId = ''
+  ): ModuleInstanceRecord | undefined {
+    return this.scanner
+      .scan(document.getText(), document.uri, compileUnitId)
+      .find((instance) => rangeContains(instance.moduleNameRange, position));
+  }
+
+  private findMacroTarget(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): RenameTarget | undefined {
+    const macro = getMacroAtPosition(document, position);
+    if (!macro) {
+      return undefined;
+    }
+
+    const fileContext = this.projectService.getPreferredFileContext(document.uri);
+    if (!fileContext) {
+      return undefined;
+    }
+    const sourceMacro = findSourceMacro(macro.name, fileContext, this.indexService);
+    if (!sourceMacro) {
+      return undefined;
+    }
+    return { kind: 'macro', name: macro.name, range: macro.range, symbol: sourceMacro };
+  }
+}
+
+function validateNewName(newName: string, kind: RenameTarget['kind']): void {
+  if (newName.length === 0) {
+    throw new RenameError('Rename target cannot be empty.');
+  }
+  if (newName.startsWith('\\')) {
+    throw new RenameError('Escaped identifiers are not supported by Verilog rename.');
+  }
+  if (kind === 'macro' && newName.startsWith('`')) {
+    throw new RenameError('Enter the macro name without the leading backtick.');
+  }
+  if (!IDENTIFIER_PATTERN.test(newName)) {
+    throw new RenameError('Rename target must be a Verilog identifier: [A-Za-z_][A-Za-z0-9_$]*.');
+  }
+}
+
+function isNonEmptyReference(location: vscode.Location): boolean {
+  return location.uri.scheme === 'file' && !location.range.isEmpty;
+}
+
+async function filterExistingFileReferences(locations: vscode.Location[]): Promise<vscode.Location[]> {
+  const existing: vscode.Location[] = [];
+  for (const location of locations) {
+    try {
+      await vscode.workspace.fs.stat(location.uri);
+      existing.push(location);
+    } catch {
+      // Stale index entries should not produce edits for missing files.
+    }
+  }
+  return existing;
+}
+
+function getMacroAtPosition(document: vscode.TextDocument, position: vscode.Position): MacroAtPosition | undefined {
+  const text = document.getText();
+  for (const definition of scanMacroDefinitions(text)) {
+    if (rangeContains(definition.range, position)) {
+      return { name: definition.name, range: definition.range, isDefinition: true };
+    }
+  }
+  for (const occurrence of scanMacroOccurrences(text)) {
+    if (!occurrence.isDirective && rangeContains(occurrence.range, position)) {
+      return { name: occurrence.name, range: occurrence.range, isDefinition: false };
+    }
+  }
+  return undefined;
+}
+
+function findSourceMacro(
+  name: string,
+  context: FileContext,
+  indexService: IndexService
+): SymbolRecord | undefined {
+  return indexService.getIndex()
+    .findSymbolsByName(name, { compileUnitId: context.compileUnitId, kinds: ['macro'] })
+    .at(0);
+}
+
+function rangeContains(range: vscode.Range, position: vscode.Position): boolean {
+  return range.start.isBeforeOrEqual(position) && range.end.isAfterOrEqual(position);
+}

--- a/src/providers/RenameProvider.ts
+++ b/src/providers/RenameProvider.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { RenameService } from '../hdl/RenameService';
+import { getExtensionLogger } from '../logging';
+
+export class VerilogRenameProvider implements vscode.RenameProvider {
+  private readonly logger = getExtensionLogger('Provider', 'Rename');
+
+  constructor(private readonly renameService: RenameService) {}
+
+  async prepareRename(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Range | { range: vscode.Range; placeholder: string } | undefined> {
+    this.logger.info('Prepare rename requested', { uri: document.uri.toString() });
+    return this.renameService.prepareRename(document, position, token);
+  }
+
+  async provideRenameEdits(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    newName: string,
+    token: vscode.CancellationToken
+  ): Promise<vscode.WorkspaceEdit | undefined> {
+    this.logger.info('Rename requested', { uri: document.uri.toString() });
+    const edit = await this.renameService.provideRenameEdits(document, position, newName, token);
+    this.logger.info('Rename returned', { changedFiles: edit ? edit.entries().length : 0 });
+    return edit;
+  }
+}

--- a/src/test/renameProvider.test.ts
+++ b/src/test/renameProvider.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import type { RenameService } from '../hdl/RenameService';
+import { VerilogRenameProvider } from '../providers/RenameProvider';
+
+suite('RenameProvider', () => {
+  test('returns prepare rename and edits from the service', async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'systemverilog',
+      content: 'module top; endmodule',
+    });
+    const range = new vscode.Range(0, 7, 0, 10);
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(document.uri, range, 'renamed');
+    const provider = new VerilogRenameProvider({
+      prepareRename: async () => ({ range, placeholder: 'top' }),
+      provideRenameEdits: async () => edit,
+    } as unknown as RenameService);
+
+    const prepared = await provider.prepareRename(
+      document,
+      new vscode.Position(0, 8),
+      new vscode.CancellationTokenSource().token
+    );
+    const result = await provider.provideRenameEdits(
+      document,
+      new vscode.Position(0, 8),
+      'renamed',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(prepared, { range, placeholder: 'top' });
+    assert.strictEqual(result, edit);
+  });
+});

--- a/src/test/renameService.test.ts
+++ b/src/test/renameService.test.ts
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ReferenceService } from '../hdl/ReferenceService';
+import { RenameError, RenameService } from '../hdl/RenameService';
+import { FileContextResolver } from '../project/FileContextResolver';
+import type { ProjectService } from '../project/ProjectService';
+import type { CompileUnit, MacroDefine, ProjectSnapshot, SourceFileRef } from '../project/ProjectTypes';
+import type { IndexService } from '../semantic/IndexService';
+import { SemanticIndex } from '../semantic/SemanticIndex';
+import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
+
+suite('RenameService', () => {
+  test('module declaration rename updates declaration and instantiations', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const topUri = writeFile(root, 'top.sv', [
+      'module top;',
+      '  child u0 ();',
+      '  child #(.WIDTH(1)) u1 ();',
+      'endmodule',
+    ].join('\n'));
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri, topUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(childUri);
+
+    const edit = await service.provideRenameEdits(
+      document,
+      new vscode.Position(0, 8),
+      'new_child',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(formatWorkspaceEdit(edit), [
+      `${childUri.fsPath}:0:7-0:12=new_child`,
+      `${topUri.fsPath}:1:2-1:7=new_child`,
+      `${topUri.fsPath}:2:2-2:7=new_child`,
+    ]);
+  });
+
+  test('module instantiation type rename updates declaration and instantiations', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; child u0 (); child u1 (); endmodule\n');
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri, topUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const prepared = await service.prepareRename(
+      document,
+      new vscode.Position(0, 14),
+      new vscode.CancellationTokenSource().token
+    );
+    const edit = await service.provideRenameEdits(
+      document,
+      new vscode.Position(0, 14),
+      'renamed_child',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(prepared, {
+      range: new vscode.Range(0, 12, 0, 17),
+      placeholder: 'child',
+    });
+    assert.deepStrictEqual(formatWorkspaceEdit(edit), [
+      `${childUri.fsPath}:0:7-0:12=renamed_child`,
+      `${topUri.fsPath}:0:12-0:17=renamed_child`,
+      `${topUri.fsPath}:0:25-0:30=renamed_child`,
+    ]);
+  });
+
+  test('duplicate module names in another compile unit are not edited', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; child u0 (); endmodule\n');
+    const childAUri = writeFile(root, 'a/child.sv', 'module child; endmodule\n');
+    const childBUri = writeFile(root, 'b/child.sv', 'module child; endmodule\n');
+    const unitA = createCompileUnit(root, 'unitA', [topUri, childAUri]);
+    const unitB = createCompileUnit(root, 'unitB', [topUri, childBUri]);
+    const childA = createModuleRecord('child', 'unitA', childAUri, new vscode.Range(0, 7, 0, 12));
+    const childB = createModuleRecord('child', 'unitB', childBUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(
+      createSnapshot(root, [unitA, unitB], { activeTargetId: 'unitB' }),
+      [childA, childB]
+    );
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const edit = await service.provideRenameEdits(
+      document,
+      new vscode.Position(0, 14),
+      'unit_b_child',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(formatWorkspaceEdit(edit), [
+      `${childBUri.fsPath}:0:7-0:12=unit_b_child`,
+      `${topUri.fsPath}:0:12-0:17=unit_b_child`,
+    ]);
+  });
+
+  test('invalid module names are rejected', async () => {
+    const root = createTempRoot();
+    const childUri = writeFile(root, 'child.sv', 'module child; endmodule\n');
+    const child = createModuleRecord('child', 'unit', childUri, new vscode.Range(0, 7, 0, 12));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [childUri])]), [child]);
+    const document = await vscode.workspace.openTextDocument(childUri);
+
+    await assert.rejects(
+      () => service.provideRenameEdits(
+        document,
+        new vscode.Position(0, 8),
+        '1bad',
+        new vscode.CancellationTokenSource().token
+      ),
+      RenameError
+    );
+  });
+
+  test('macro definition rename updates source define and usages', async () => {
+    const root = createTempRoot();
+    const defsUri = writeFile(root, 'defs.svh', '`define FOO 1\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; assign x = `FOO; assign y = `FOO(); endmodule\n');
+    const macro = createSymbolRecord('FOO', 'macro', 'unit', defsUri, new vscode.Range(0, 8, 0, 11));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [defsUri, topUri])]), [macro]);
+    const document = await vscode.workspace.openTextDocument(defsUri);
+
+    const edit = await service.provideRenameEdits(
+      document,
+      new vscode.Position(0, 9),
+      'BAR',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(formatWorkspaceEdit(edit), [
+      `${defsUri.fsPath}:0:8-0:11=BAR`,
+      `${topUri.fsPath}:0:24-0:27=BAR`,
+      `${topUri.fsPath}:0:41-0:44=BAR`,
+    ]);
+  });
+
+  test('macro usage rename updates source define and other usages', async () => {
+    const root = createTempRoot();
+    const defsUri = writeFile(root, 'defs.svh', '`define FOO 1\n');
+    const topUri = writeFile(root, 'top.sv', 'module top; assign x = `FOO; assign y = `FOO(); endmodule\n');
+    const macro = createSymbolRecord('FOO', 'macro', 'unit', defsUri, new vscode.Range(0, 8, 0, 11));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [defsUri, topUri])]), [macro]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const prepared = await service.prepareRename(
+      document,
+      new vscode.Position(0, 25),
+      new vscode.CancellationTokenSource().token
+    );
+    const edit = await service.provideRenameEdits(
+      document,
+      new vscode.Position(0, 25),
+      'BAR',
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(prepared, {
+      range: new vscode.Range(0, 24, 0, 27),
+      placeholder: 'FOO',
+    });
+    assert.deepStrictEqual(formatWorkspaceEdit(edit), [
+      `${defsUri.fsPath}:0:8-0:11=BAR`,
+      `${topUri.fsPath}:0:24-0:27=BAR`,
+      `${topUri.fsPath}:0:41-0:44=BAR`,
+    ]);
+  });
+
+  test('backtick-prefixed macro new names are rejected', async () => {
+    const root = createTempRoot();
+    const defsUri = writeFile(root, 'defs.svh', '`define FOO 1\n');
+    const macro = createSymbolRecord('FOO', 'macro', 'unit', defsUri, new vscode.Range(0, 8, 0, 11));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [defsUri])]), [macro]);
+    const document = await vscode.workspace.openTextDocument(defsUri);
+
+    await assert.rejects(
+      () => service.provideRenameEdits(
+        document,
+        new vscode.Position(0, 9),
+        '`BAR',
+        new vscode.CancellationTokenSource().token
+      ),
+      /without the leading backtick/
+    );
+  });
+
+  test('directive keywords and unsupported targets do not prepare rename', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', [
+      '`ifdef FOO',
+      '`endif',
+      'module top(input clk);',
+      '  logic sig;',
+      'endmodule',
+    ].join('\n'));
+    const top = createModuleRecord('top', 'unit', topUri, new vscode.Range(2, 7, 2, 10));
+    const service = createService(createSnapshot(root, [createCompileUnit(root, 'unit', [topUri])]), [top]);
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const directive = await service.prepareRename(
+      document,
+      new vscode.Position(0, 2),
+      new vscode.CancellationTokenSource().token
+    );
+    const signal = await service.prepareRename(
+      document,
+      new vscode.Position(3, 9),
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.strictEqual(directive, undefined);
+    assert.strictEqual(signal, undefined);
+  });
+
+  test('project macro without source definition is rejected', async () => {
+    const root = createTempRoot();
+    const topUri = writeFile(root, 'top.sv', 'module top; assign x = `PROJECT_MACRO; endmodule\n');
+    const defines: Record<string, MacroDefine> = {
+      PROJECT_MACRO: {
+        name: 'PROJECT_MACRO',
+        value: true,
+        source: 'filelist',
+      },
+    };
+    const service = createService(
+      createSnapshot(root, [createCompileUnit(root, 'unit', [topUri], { defines })]),
+      []
+    );
+    const document = await vscode.workspace.openTextDocument(topUri);
+
+    const prepared = await service.prepareRename(
+      document,
+      new vscode.Position(0, 25),
+      new vscode.CancellationTokenSource().token
+    );
+
+    assert.strictEqual(prepared, undefined);
+    await assert.rejects(
+      () => service.provideRenameEdits(
+        document,
+        new vscode.Position(0, 25),
+        'RENAMED',
+        new vscode.CancellationTokenSource().token
+      ),
+      /source-defined macros/
+    );
+  });
+});
+
+function createService(snapshot: ProjectSnapshot, symbols: SymbolRecord[]): RenameService {
+  const index = new SemanticIndex(snapshot.version, symbols);
+  const projectEmitter = new vscode.EventEmitter<ProjectSnapshot>();
+  const indexEmitter = new vscode.EventEmitter<SemanticIndex>();
+  const projectService = {
+    getSnapshot: () => snapshot,
+    getPreferredFileContext: (uri: vscode.Uri) => new FileContextResolver(snapshot).getPreferredFileContext(uri),
+    onDidChangeSnapshot: projectEmitter.event,
+  } as unknown as ProjectService;
+  const indexService = {
+    getIndex: () => index,
+    onDidChangeIndex: indexEmitter.event,
+  } as unknown as IndexService;
+  const referenceService = new ReferenceService(projectService, indexService);
+  return new RenameService(projectService, indexService, referenceService);
+}
+
+function createTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-rename-'));
+}
+
+function writeFile(root: string, relativePath: string, content: string): vscode.Uri {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return vscode.Uri.file(filePath);
+}
+
+function createSnapshot(
+  root: string,
+  compileUnits: CompileUnit[],
+  options: { activeTargetId?: string } = {}
+): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file(root),
+    activeTargetId: options.activeTargetId ?? '',
+    compileUnits,
+    diagnostics: [],
+  };
+}
+
+function createCompileUnit(
+  root: string,
+  id: string,
+  files: vscode.Uri[],
+  options: Partial<Pick<CompileUnit, 'name' | 'includeDirs' | 'defines'>> = {}
+): CompileUnit {
+  return {
+    id,
+    name: options.name ?? id,
+    root: vscode.Uri.file(root),
+    files: files.map((uri, order): SourceFileRef => ({
+      uri,
+      languageId: 'systemverilog',
+      kind: uri.fsPath.endsWith('.svh') ? 'include' : 'source',
+      order,
+    })),
+    includeDirs: options.includeDirs ?? [],
+    defines: options.defines ?? {},
+    topModules: [],
+    source: { type: 'settings' },
+  };
+}
+
+function createModuleRecord(
+  name: string,
+  compileUnitId: string,
+  uri: vscode.Uri,
+  selectionRange: vscode.Range
+): ModuleRecord {
+  return {
+    ...createSymbolRecord(name, 'module', compileUnitId, uri, selectionRange),
+    kind: 'module',
+    ports: [],
+    parameters: [],
+  };
+}
+
+function createSymbolRecord(
+  name: string,
+  kind: SymbolRecord['kind'],
+  compileUnitId: string,
+  uri: vscode.Uri,
+  selectionRange: vscode.Range
+): SymbolRecord {
+  return {
+    id: `${compileUnitId}:${kind}:${name}:${uri.fsPath}`,
+    name,
+    kind,
+    uri,
+    range: selectionRange,
+    selectionRange,
+    compileUnitId,
+  };
+}
+
+function formatWorkspaceEdit(edit: vscode.WorkspaceEdit | undefined): string[] {
+  assert.ok(edit);
+  return edit.entries().flatMap(([uri, edits]) =>
+    edits.map((textEdit) =>
+      `${uri.fsPath}:${textEdit.range.start.line}:${textEdit.range.start.character}-${textEdit.range.end.line}:${textEdit.range.end.character}=${textEdit.newText}`
+    )
+  );
+}


### PR DESCRIPTION
## Summary

Adds a conservative project-aware Rename MVP for Verilog/SystemVerilog.

- Supports safe module rename from declarations and instantiation type usages.
- Supports source-defined macro rename from `define names and macro usages.
- Registers a VS Code rename provider for Verilog and SystemVerilog.
- Rejects unsupported targets such as ports, parameters, local signals, directives, escaped identifiers, and project-only macros.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run check-types`
- `npm run compile-tests`
- `npm test` with VS Code test runner access: 334 passing, 3 pending
