### PR TITLE
Test slang integration in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,20 @@ jobs:
     name: Upload vsix package
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            slang_asset: slang-macos-arm64.tar.gz
+            slang_sha256: 6d2f86ffedfefe663c6f55fd77348806faafccd69e71f7359986b0c9604f9187
+          - os: ubuntu-latest
+            slang_asset: slang-linux-x86_64.tar.gz
+            slang_sha256: 951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4
+          - os: windows-latest
+            slang_asset: slang-windows-x86_64.zip
+            slang_sha256: 23d0a3d052cf88da13acc8b73161d77e3242ffbc630bb0577a3ccda0e4e39d81
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
+      SLANG_VERSION: v11.0
       VERIBLE_VERSION: v0.0-4071-g8d9f2c97
       VERIBLE_SHA256: bfa43258d9132797ec9dca2a624395bb83967e18b888803c022d1c9a889203b6
     steps:
@@ -23,6 +33,55 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Cache slang
+        id: cache-slang
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/veriloghdl-tools/slang/${{ env.SLANG_VERSION }}/${{ matrix.slang_asset }}
+          key: ${{ runner.os }}-slang-${{ env.SLANG_VERSION }}-${{ matrix.slang_asset }}-${{ matrix.slang_sha256 }}
+      - name: Install slang (Unix)
+        if: runner.os != 'Windows' && steps.cache-slang.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          install_dir="$HOME/.cache/veriloghdl-tools/slang/${SLANG_VERSION}/${{ matrix.slang_asset }}"
+          archive="$RUNNER_TEMP/${{ matrix.slang_asset }}"
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$archive" \
+            "https://github.com/MikePopoloski/slang/releases/download/${SLANG_VERSION}/${{ matrix.slang_asset }}"
+          echo "${{ matrix.slang_sha256 }}  ${archive}" | shasum -a 256 --check -
+          rm -rf "$install_dir"
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" -C "$install_dir"
+          chmod +x "$install_dir/slang"
+      - name: Install slang (Windows)
+        if: runner.os == 'Windows' && steps.cache-slang.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang/$env:SLANG_VERSION/${{ matrix.slang_asset }}"
+          $archive = Join-Path $env:RUNNER_TEMP "${{ matrix.slang_asset }}"
+          curl.exe -fsSL --retry 3 --retry-delay 5 `
+            -o $archive `
+            "https://github.com/MikePopoloski/slang/releases/download/$env:SLANG_VERSION/${{ matrix.slang_asset }}"
+          $actualHash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          if ($actualHash -ne "${{ matrix.slang_sha256 }}") {
+            throw "slang archive hash mismatch: expected ${{ matrix.slang_sha256 }}, got $actualHash"
+          }
+          if (Test-Path $installDir) {
+            Remove-Item -Recurse -Force $installDir
+          }
+          New-Item -ItemType Directory -Force $installDir | Out-Null
+          Expand-Archive -LiteralPath $archive -DestinationPath $installDir
+      - name: Add slang to PATH
+        run: echo "$HOME/.cache/veriloghdl-tools/slang/${SLANG_VERSION}/${{ matrix.slang_asset }}" >> "$GITHUB_PATH"
+        if: runner.os != 'Windows'
+      - name: Add slang to PATH (Windows)
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang/$env:SLANG_VERSION/${{ matrix.slang_asset }}"
+          $installDir | Out-File -FilePath $env:GITHUB_PATH -Append
+        if: runner.os == 'Windows'
+      - name: Verify slang
+        run: slang --version
       - name: Cache Verible (macOS)
         id: cache-verible
         if: runner.os == 'macOS'
@@ -89,6 +148,8 @@ jobs:
       - run: npm run compile
         if: runner.os == 'Windows'
       - run: npm run test:windows
+        if: runner.os == 'Windows'
+      - run: npm run test:windows-slang
         if: runner.os == 'Windows'
       - run: npm run compile
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,7 @@ jobs:
         if: runner.os == 'Linux'
       - run: npm test
         if: runner.os == 'macOS'
-      - run: npm run compile-tests
-        if: runner.os == 'Windows'
-      - run: npm run compile
-        if: runner.os == 'Windows'
-      - run: npm run test:windows
-        if: runner.os == 'Windows'
-      - run: npm run test:windows-slang
+      - run: npm test
         if: runner.os == 'Windows'
       - run: npm run compile
         if: runner.os != 'Windows'

--- a/package.json
+++ b/package.json
@@ -1091,7 +1091,6 @@
     "lint": "eslint src --ext .ts",
     "test": "vscode-test",
     "test:windows": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows]\"",
-    "test:windows-slang": "vscode-test --config .vscode-test.windows.mjs --fgrep \"Slang Linter\"",
     "test:windows-wsl2": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows-wsl2]\"",
     "syntax": "js-yaml ./syntaxes/systemverilog.tmLanguage.yaml >./syntaxes/systemverilog.tmLanguage.json"
   },

--- a/package.json
+++ b/package.json
@@ -1091,6 +1091,7 @@
     "lint": "eslint src --ext .ts",
     "test": "vscode-test",
     "test:windows": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows]\"",
+    "test:windows-slang": "vscode-test --config .vscode-test.windows.mjs --fgrep \"Slang Linter\"",
     "test:windows-wsl2": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows-wsl2]\"",
     "syntax": "js-yaml ./syntaxes/systemverilog.tmLanguage.yaml >./syntaxes/systemverilog.tmLanguage.json"
   },

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -65,7 +65,7 @@ export interface ParseSlangDiagnosticsOptions {
 }
 
 export function buildSlangCommand(options: SlangCommandOptions): SlangCommand {
-  const joinPath = options.isWindows ? path.win32.join : path.join;
+  const joinPath = options.isWindows ? path.win32.join : path.posix.join;
   if (options.isWindows && options.useWSL) {
     return {
       command: joinPath(options.linterInstalledPath, 'wsl'),

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -60,6 +60,7 @@ export interface ParseSlangDiagnosticsOptions {
   documentPath: string;
   isWindows: boolean;
   useWSL: boolean;
+  cwd?: string;
   convertToWslPath?: (inputPath: string) => string;
 }
 
@@ -135,6 +136,7 @@ export function parseSlangDiagnosticsByFile(
   const diagnosticsByFile = new Map<string, vscode.Diagnostic[]>();
   const re = /(.+?):(\d+):(\d+):\s(note|warning|error):\s(.*?)(\[-W(.*)\]|$)/;
   const convertToWslPath = options.convertToWslPath ?? ((inputPath: string) => inputPath);
+  const pathApi = options.isWindows && !options.useWSL ? path.win32 : path.posix;
 
   options.stderr.split(/\r?\n/g).forEach((line) => {
     const rex = line.match(re);
@@ -147,6 +149,12 @@ export function parseSlangDiagnosticsByFile(
       if (options.useWSL) {
         filePath = convertToWslPath(filePath);
       } else {
+        filePath = filePath.replace(/\\/g, '/');
+      }
+    }
+    if (options.cwd && !pathApi.isAbsolute(filePath)) {
+      filePath = pathApi.resolve(options.cwd, filePath);
+      if (options.isWindows && !options.useWSL) {
         filePath = filePath.replace(/\\/g, '/');
       }
     }
@@ -338,6 +346,7 @@ export default class SlangLinter extends BaseLinter {
         documentPath,
         isWindows,
         useWSL: this.useWSL,
+        cwd,
       });
       this.logger.info`${diagnostics.length} errors/warnings returned`;
       this.publishDocumentDiagnosticsIfCurrent(doc, run, diagnostics);
@@ -379,6 +388,7 @@ export default class SlangLinter extends BaseLinter {
         documentPath: ownerDocumentPath,
         isWindows,
         useWSL: this.useWSL,
+        cwd,
       });
       const diagnosticsByUri: DiagnosticMap = new Map();
       diagnosticsByFile.forEach((diagnostics, fileName) => {

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -96,7 +96,7 @@ export interface ConvertDiagnosticPathsFromWslOptions {
 }
 
 export function buildVerilatorCommand(options: VerilatorCommandOptions): VerilatorCommand {
-  const joinPath = options.isWindows ? path.win32.join : path.join;
+  const joinPath = options.isWindows ? path.win32.join : path.posix.join;
   if (options.isWindows && options.useWSL) {
     return {
       command: joinPath(options.linterInstalledPath, 'wsl'),

--- a/src/test/compileUnitLintArgs.test.ts
+++ b/src/test/compileUnitLintArgs.test.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   buildIcarusCompileUnitArgs,
@@ -14,12 +15,13 @@ import type { CompileUnitLintContext } from '../linter/ProjectLintContext';
 suite('CompileUnitLintArgs', () => {
   test('generates Slang args with include dirs, defines, custom args, and source order', () => {
     const context = createContext();
+    const docFolder = path.dirname(context.ownerDocument.uri.fsPath);
     const includePath = context.includeDirs[0]?.fsPath;
     const firstSourcePath = context.files[0]?.uri.fsPath;
     const secondSourcePath = context.files[1]?.uri.fsPath;
 
     const args = buildSlangCompileUnitArgs({
-      docFolder: '/workspace/rtl',
+      docFolder,
       includePaths: getCompileUnitIncludePaths(context),
       defineArgs: getCompileUnitDefineArgs(context),
       customArguments: '--flag "two words"',
@@ -28,9 +30,9 @@ suite('CompileUnitLintArgs', () => {
 
     assert.deepStrictEqual(args, [
       '-I',
-      '/workspace/rtl',
+      docFolder,
       '-I',
-      '/workspace/inc',
+      includePath,
       '-D',
       'SIM',
       '-D',
@@ -45,13 +47,14 @@ suite('CompileUnitLintArgs', () => {
 
   test('generates Verilator args with source order', () => {
     const context = createContext();
+    const docFolder = path.dirname(context.ownerDocument.uri.fsPath);
     const includePath = context.includeDirs[0]?.fsPath;
     const firstSourcePath = context.files[0]?.uri.fsPath;
     const secondSourcePath = context.files[1]?.uri.fsPath;
 
     const args = buildVerilatorCompileUnitArgs({
       languageId: 'systemverilog',
-      docFolder: '/workspace/rtl',
+      docFolder,
       includePaths: getCompileUnitIncludePaths(context),
       defineArgs: getCompileUnitDefineArgs(context),
       customArguments: '-Wall',
@@ -61,7 +64,7 @@ suite('CompileUnitLintArgs', () => {
     assert.deepStrictEqual(args, [
       '-sv',
       '--lint-only',
-      '-I/workspace/rtl',
+      `-I${docFolder}`,
       `-I${includePath}`,
       '-DSIM',
       '-DWIDTH=32',

--- a/src/test/compileUnitLintArgs.test.ts
+++ b/src/test/compileUnitLintArgs.test.ts
@@ -14,6 +14,9 @@ import type { CompileUnitLintContext } from '../linter/ProjectLintContext';
 suite('CompileUnitLintArgs', () => {
   test('generates Slang args with include dirs, defines, custom args, and source order', () => {
     const context = createContext();
+    const includePath = context.includeDirs[0]?.fsPath;
+    const firstSourcePath = context.files[0]?.uri.fsPath;
+    const secondSourcePath = context.files[1]?.uri.fsPath;
 
     const args = buildSlangCompileUnitArgs({
       docFolder: '/workspace/rtl',
@@ -34,13 +37,17 @@ suite('CompileUnitLintArgs', () => {
       'WIDTH=32',
       '--flag',
       'two words',
-      '/workspace/rtl/a.sv',
-      '/workspace/rtl/b.sv',
+      firstSourcePath,
+      secondSourcePath,
     ]);
+    assert.strictEqual(args[3], includePath);
   });
 
   test('generates Verilator args with source order', () => {
     const context = createContext();
+    const includePath = context.includeDirs[0]?.fsPath;
+    const firstSourcePath = context.files[0]?.uri.fsPath;
+    const secondSourcePath = context.files[1]?.uri.fsPath;
 
     const args = buildVerilatorCompileUnitArgs({
       languageId: 'systemverilog',
@@ -55,17 +62,20 @@ suite('CompileUnitLintArgs', () => {
       '-sv',
       '--lint-only',
       '-I/workspace/rtl',
-      '-I/workspace/inc',
+      `-I${includePath}`,
       '-DSIM',
       '-DWIDTH=32',
       '-Wall',
-      '/workspace/rtl/a.sv',
-      '/workspace/rtl/b.sv',
+      firstSourcePath,
+      secondSourcePath,
     ]);
   });
 
   test('generates Icarus args with standards and source order', () => {
     const context = createContext();
+    const includePath = context.includeDirs[0]?.fsPath;
+    const firstSourcePath = context.files[0]?.uri.fsPath;
+    const secondSourcePath = context.files[1]?.uri.fsPath;
     const standards = new Map<string, string>([['systemverilog', 'SystemVerilog2012']]);
 
     const args = buildIcarusCompileUnitArgs({
@@ -82,14 +92,14 @@ suite('CompileUnitLintArgs', () => {
       'null',
       '-g2012',
       '-I',
-      '/workspace/inc',
+      includePath,
       '-D',
       'SIM',
       '-D',
       'WIDTH=32',
       '-Wall',
-      '/workspace/rtl/a.sv',
-      '/workspace/rtl/b.sv',
+      firstSourcePath,
+      secondSourcePath,
     ]);
   });
 });

--- a/src/test/definitionService.test.ts
+++ b/src/test/definitionService.test.ts
@@ -11,6 +11,7 @@ import type { FileContext } from '../project/ProjectTypes';
 import type { IndexService } from '../semantic/IndexService';
 import { SemanticIndex } from '../semantic/SemanticIndex';
 import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../semantic/SymbolRecords';
+import { assertSameFsPath } from './pathTestUtils';
 
 suite('DefinitionService', () => {
   test('resolves module definitions across workspace by module name', async () => {
@@ -41,7 +42,7 @@ suite('DefinitionService', () => {
     const result = await service.provideDefinition(document, new vscode.Position(0, 11));
 
     assert.strictEqual(result.length, 1);
-    assert.strictEqual(result[0]?.targetUri.fsPath, includePath);
+    assertSameFsPath(result[0]?.targetUri.fsPath, includePath);
     assert.strictEqual(result[0]?.targetSelectionRange?.start.line, 0);
   });
 
@@ -67,7 +68,7 @@ suite('DefinitionService', () => {
     const result = await service.provideDefinition(document, new vscode.Position(0, 11));
 
     assert.strictEqual(result.length, 1);
-    assert.strictEqual(result[0]?.targetUri.fsPath, includePath);
+    assertSameFsPath(result[0]?.targetUri.fsPath, includePath);
   });
 
   test('falls back to ctags when project index has no definition', async () => {

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -15,6 +15,7 @@ import {
   type DoctorReport,
 } from '../commands/Doctor';
 import type { ToolRunOptions, ToolRunResult } from '../tools/ToolRunner';
+import { displayPath } from './pathTestUtils';
 
 function makeDeps(options: {
   executables?: Record<string, string | undefined>;
@@ -79,7 +80,7 @@ suite('Doctor', () => {
     assert.strictEqual(expandPathVariables('~'), os.homedir());
     assert.strictEqual(
       expandPathVariables('~/settings.toml'),
-      `${os.homedir()}/settings.toml`
+      path.join(os.homedir(), 'settings.toml')
     );
   });
 
@@ -174,7 +175,9 @@ suite('Doctor', () => {
 
     assert.ok(
       checks.some(
-        (check) => check.status === 'warn' && check.message.includes('/workspace/rtl/include')
+        (check) =>
+          check.status === 'warn' &&
+          displayPath(check.message).includes('/workspace/rtl/include')
       )
     );
     assert.ok(!checks.some((check) => check.status === 'error'));

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { getRepositoryRoot } from './pathTestUtils';
 
 const EXTENSION_ID = 'mshr-h.veriloghdl';
 
@@ -151,7 +152,7 @@ suite('Extension Test Suite', () => {
 
   test('package should contribute project settings', () => {
     const packageJson = JSON.parse(
-      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+      fs.readFileSync(path.join(getRepositoryRoot(), 'package.json'), 'utf8')
     ) as {
       contributes: { configuration: Array<{ properties: Record<string, unknown> }> };
     };
@@ -196,7 +197,7 @@ suite('Extension Test Suite', () => {
 
   test('package should contribute HDL Explorer view', () => {
     const packageJson = JSON.parse(
-      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+      fs.readFileSync(path.join(getRepositoryRoot(), 'package.json'), 'utf8')
     ) as {
       contributes: { views: { explorer: Array<{ id: string; name: string }> } };
     };

--- a/src/test/filelistProject.test.ts
+++ b/src/test/filelistProject.test.ts
@@ -140,8 +140,8 @@ suite('ProjectModelMerger', () => {
     assert.strictEqual(compileUnit.defines.WIDTH?.source, 'settings');
     assert.strictEqual(compileUnit.defines.SIM?.value, true);
     assert.deepStrictEqual(compileUnit.includeDirs.map((uri) => uri.fsPath), [
-      '/workspace/inc',
-      '/workspace/settings_inc',
+      path.join(root.fsPath, 'inc'),
+      path.join(root.fsPath, 'settings_inc'),
     ]);
   });
 });

--- a/src/test/format.test.ts
+++ b/src/test/format.test.ts
@@ -24,7 +24,7 @@ suite('Formatting', () => {
     );
     const args = buildVerilogFormatArgs(
       '/tmp/input.v',
-      '${env:VERILOG_FORMAT_TEST_HOME}/.verilog-format.properties',
+      path.join('${env:VERILOG_FORMAT_TEST_HOME}', '.verilog-format.properties'),
       undefined,
       (candidate) => candidate === settingsPath
     );

--- a/src/test/moduleInstanceCodeActionService.test.ts
+++ b/src/test/moduleInstanceCodeActionService.test.ts
@@ -25,7 +25,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       'foo u_foo (',
       '  .clk    (clk),',
       '  .rst_n  (rst_n),',
@@ -51,7 +51,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       'foo u_foo (',
       '  .rst_n  (reset_n),',
       '  .clk    (clk),',
@@ -71,7 +71,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       'foo u_foo (',
       '    .clk  (clk),',
       '    .rst_n(rst_n)',
@@ -94,7 +94,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       '  foo u_foo (',
       '    .clk  (clk),',
       '    .rst_n(rst_n)',
@@ -117,7 +117,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Ports');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       'foo u_foo (',
       '  .clk  (clk),',
       '  .rst_n(rst_n),',
@@ -140,7 +140,7 @@ suite('ModuleInstanceCodeActionService', () => {
 
     const action = getAction(service, document, position, 'Verilog: Fill Missing Parameters');
 
-    assert.strictEqual(applyWorkspaceEdit(document, action.edit), [
+    assert.strictEqual(normalizeLineEndings(applyWorkspaceEdit(document, action.edit)), [
       'foo #(',
       '  .WIDTH(32),',
       '  .DEPTH(DEPTH)',
@@ -223,6 +223,10 @@ function applyWorkspaceEdit(document: vscode.TextDocument, edit: vscode.Workspac
       const end = document.offsetAt(textEdit.range.end);
       return `${text.slice(0, start)}${textEdit.newText}${text.slice(end)}`;
     }, document.getText());
+}
+
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n/g, '\n');
 }
 
 function createService(symbols: SymbolRecord[]): ModuleInstanceCodeActionService {

--- a/src/test/moduleInstantiation.test.ts
+++ b/src/test/moduleInstantiation.test.ts
@@ -109,7 +109,7 @@ suite('Module Instantiation', () => {
       assert.strictEqual(shouldShowParentDirectory(activeDir, firstRoot), false);
       assert.strictEqual(shouldShowParentDirectory(activeDir), false);
     } finally {
-      fs.rmSync(tempRoot, { recursive: true, force: true });
+      cleanupTempRoot(tempRoot);
     }
   });
 
@@ -135,7 +135,7 @@ suite('Module Instantiation', () => {
       assert.strictEqual(snippet, undefined, 'Expected no snippet when ctags is disabled');
     } finally {
       await ctagsConfig.update('enabled', previousEnabled, vscode.ConfigurationTarget.Global);
-      fs.rmSync(tempRoot, { recursive: true, force: true });
+      await cleanupTempRootAfterEditorUse(tempRoot);
     }
   });
 
@@ -181,10 +181,30 @@ suite('Module Instantiation', () => {
       assert.ok(value.includes(');'), 'Snippet should include closing');
     } finally {
       await ctagsConfig.update('path', previousPath, vscode.ConfigurationTarget.Global);
-      fs.rmSync(tempRoot, { recursive: true, force: true });
+      await cleanupTempRootAfterEditorUse(tempRoot);
     }
   });
 });
+
+async function cleanupTempRootAfterEditorUse(tempRoot: string): Promise<void> {
+  await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  cleanupTempRoot(tempRoot);
+}
+
+function cleanupTempRoot(tempRoot: string): void {
+  try {
+    fs.rmSync(tempRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: process.platform === 'win32' ? 10 : 0,
+      retryDelay: 100,
+    });
+  } catch (err) {
+    if (process.platform !== 'win32') {
+      throw err;
+    }
+  }
+}
 
 function createModuleRecord(name: string, parameterNames: string[], portNames: string[]): ModuleRecord {
   const uri = vscode.Uri.file(`/workspace/${name}.sv`);

--- a/src/test/pathTestUtils.ts
+++ b/src/test/pathTestUtils.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'mshr-h.veriloghdl';
+
+export function getRepositoryRoot(): string {
+  return vscode.extensions.getExtension(EXTENSION_ID)?.extensionPath
+    ?? path.resolve(__dirname, '..', '..', '..');
+}
+
+export function normalizeFsPath(inputPath: string): string {
+  const normalized = path.normalize(inputPath).replace(/\\/g, '/');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+export function sameFsPath(actual: string | undefined, expected: string): boolean {
+  return actual !== undefined && normalizeFsPath(actual) === normalizeFsPath(expected);
+}
+
+export function assertSameFsPath(actual: string | undefined, expected: string): void {
+  assert.ok(
+    sameFsPath(actual, expected),
+    `Expected filesystem path ${actual ?? '(undefined)'} to equal ${expected}`
+  );
+}
+
+export function endsWithPathSegments(inputPath: string | undefined, ...segments: string[]): boolean {
+  if (inputPath === undefined) {
+    return false;
+  }
+  return normalizeFsPath(inputPath).endsWith(normalizeFsPath(path.join(...segments)));
+}
+
+export function displayPath(inputPath: string): string {
+  return inputPath.replace(/\\/g, '/');
+}

--- a/src/test/projectLintContext.test.ts
+++ b/src/test/projectLintContext.test.ts
@@ -28,7 +28,7 @@ suite('Project lint context', () => {
       await config.update('useProjectContext', true, vscode.ConfigurationTarget.Global);
       const context = getLintProjectContext(projectService, document);
 
-      assert.deepStrictEqual(context.includePaths, ['/workspace/inc']);
+      assert.deepStrictEqual(context.includePaths, [vscode.Uri.file('/workspace/inc').fsPath]);
       assert.deepStrictEqual(context.defineArgs, ['SIM', 'WIDTH=32']);
     } finally {
       await config.update('useProjectContext', previous, vscode.ConfigurationTarget.Global);
@@ -104,9 +104,11 @@ suite('Project lint context', () => {
     assert.strictEqual(context.compileUnit.id, 'unit');
     assert.deepStrictEqual(context.files.map((file) => file.uri.fsPath), [
       document.uri.fsPath,
-      '/workspace/b.sv',
+      vscode.Uri.file('/workspace/b.sv').fsPath,
     ]);
-    assert.deepStrictEqual(context.includeDirs.map((uri) => uri.fsPath), ['/workspace/inc']);
+    assert.deepStrictEqual(context.includeDirs.map((uri) => uri.fsPath), [
+      vscode.Uri.file('/workspace/inc').fsPath,
+    ]);
   });
 
   test('returns undefined when active document has no compile unit membership', async () => {

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -19,6 +19,7 @@ import { FastIndexerBackend } from '../semantic/backends/FastIndexerBackend';
 import { IndexService } from '../semantic/IndexService';
 import { SemanticIndex } from '../semantic/SemanticIndex';
 import type { SymbolRecord } from '../semantic/SymbolRecords';
+import { assertSameFsPath, endsWithPathSegments, getRepositoryRoot } from './pathTestUtils';
 
 suite('Minimal IDE Model Stabilization', () => {
   suite('ProjectService and ProjectLoader fixtures', () => {
@@ -28,7 +29,7 @@ suite('Minimal IDE Model Stabilization', () => {
 
       assert.strictEqual(snapshot.compileUnits.length, 1);
       assert.strictEqual(snapshot.compileUnits[0]?.files.length, 4);
-      assert.ok(snapshot.compileUnits[0]?.includeDirs.some((uri) => uri.fsPath.endsWith('rtl/include')));
+      assert.ok(snapshot.compileUnits[0]?.includeDirs.some((uri) => endsWithPathSegments(uri.fsPath, 'rtl', 'include')));
       assert.strictEqual(snapshot.compileUnits[0]?.defines.SIMPLE_PROJECT?.value, true);
       assert.strictEqual(snapshot.diagnostics.length, 0);
     });
@@ -38,9 +39,9 @@ suite('Minimal IDE Model Stabilization', () => {
       const snapshot = await loadFixture(root, settings({ filelists: ['files.f'] }));
 
       const unit = snapshot.compileUnits[0];
-      assert.ok(unit?.files.some((file) => file.uri.fsPath.endsWith('rtl/foo.sv')));
-      assert.ok(unit?.files.some((file) => file.uri.fsPath.endsWith('include/defs.svh')));
-      assert.ok(unit?.includeDirs.some((uri) => uri.fsPath.endsWith('include')));
+      assert.ok(unit?.files.some((file) => endsWithPathSegments(file.uri.fsPath, 'rtl', 'foo.sv')));
+      assert.ok(unit?.files.some((file) => endsWithPathSegments(file.uri.fsPath, 'include', 'defs.svh')));
+      assert.ok(unit?.includeDirs.some((uri) => endsWithPathSegments(uri.fsPath, 'include')));
       assert.strictEqual(unit?.defines.NESTED_PROJECT?.value, true);
     });
 
@@ -55,7 +56,7 @@ suite('Minimal IDE Model Stabilization', () => {
       assert.ok(codes.includes('missing-include-dir'));
       assert.ok(codes.includes('missing-source-file'));
       assert.ok(snapshot.diagnostics.every((diagnostic) => diagnostic.message.length > 0));
-      assert.strictEqual(missingFilelist?.location?.uri.fsPath, path.join(root, 'files.f'));
+      assertSameFsPath(missingFilelist?.location?.uri.fsPath, path.join(root, 'files.f'));
     });
 
     test('creates fallback auto-discovery compile unit and respects exclude patterns', async function () {
@@ -64,8 +65,8 @@ suite('Minimal IDE Model Stabilization', () => {
       const snapshot = await loadFixture(root, settings({ exclude: ['**/foo.sv'] }));
 
       assert.strictEqual(snapshot.compileUnits[0]?.id, 'auto:workspace');
-      assert.ok(snapshot.compileUnits[0]?.files.some((file) => file.uri.fsPath.endsWith('top.sv')));
-      assert.ok(!snapshot.compileUnits[0]?.files.some((file) => file.uri.fsPath.endsWith('foo.sv')));
+      assert.ok(snapshot.compileUnits[0]?.files.some((file) => endsWithPathSegments(file.uri.fsPath, 'top.sv')));
+      assert.ok(!snapshot.compileUnits[0]?.files.some((file) => endsWithPathSegments(file.uri.fsPath, 'foo.sv')));
       assert.ok(snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'fallback-discovery'));
     });
 
@@ -154,7 +155,10 @@ suite('Minimal IDE Model Stabilization', () => {
       const context = resolver.getPreferredFileContext(topUri);
 
       assert.ok(context);
-      assert.strictEqual(index.resolveInclude('"defs.svh"', context)?.fsPath, path.join(root, 'rtl', 'include', 'defs.svh'));
+      assertSameFsPath(
+        index.resolveInclude('"defs.svh"', context)?.fsPath,
+        path.join(root, 'rtl', 'include', 'defs.svh')
+      );
     });
 
     test('supports full rebuild after ProjectSnapshot changes', async () => {
@@ -252,7 +256,7 @@ suite('Minimal IDE Model Stabilization', () => {
       const report = renderProjectStatus(service);
 
       assert.ok(report.includes('Project enabled: yes'));
-      assert.ok(report.includes(`Workspace root: ${root}`));
+      assert.ok(report.includes(`Workspace root: ${vscode.Uri.file(root).fsPath}`));
       assert.ok(report.includes('Resolved active compile unit: files.f (filelist:0:files.f)'));
       assert.ok(report.includes('Compile units: 1'));
       assert.ok(report.includes('Files: 4'));
@@ -301,7 +305,7 @@ suite('Minimal IDE Model Stabilization', () => {
 });
 
 function fixtureRoot(name: string): string {
-  return path.join(process.cwd(), 'test', 'fixtures', 'hdl-projects', name);
+  return path.join(getRepositoryRoot(), 'test', 'fixtures', 'hdl-projects', name);
 }
 
 function settings(overrides: Partial<ProjectSettings> = {}): ProjectSettings {

--- a/src/test/semanticProject.test.ts
+++ b/src/test/semanticProject.test.ts
@@ -10,6 +10,7 @@ import { FastIndexerBackend } from '../semantic/backends/FastIndexerBackend';
 import { FastScanner } from '../semantic/backends/FastScanner';
 import { SemanticIndex } from '../semantic/SemanticIndex';
 import type { ModuleRecord } from '../semantic/SymbolRecords';
+import { assertSameFsPath } from './pathTestUtils';
 
 suite('FastScanner', () => {
   test('detects project symbols and basic module ports and parameters', () => {
@@ -149,7 +150,7 @@ suite('FastIndexerBackend', () => {
     };
 
     const resolved = new SemanticIndex(1, []).resolveInclude('"defs.svh"', context);
-    assert.strictEqual(resolved?.fsPath, path.join(inc, 'defs.svh'));
+    assertSameFsPath(resolved?.fsPath, path.join(inc, 'defs.svh'));
   });
 });
 

--- a/src/test/slang.test.ts
+++ b/src/test/slang.test.ts
@@ -1,15 +1,161 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import {
+import which from 'which';
+import LinterDiagnosticManager from '../linter/LinterDiagnosticManager';
+import LintRunManager from '../linter/LintRunManager';
+import type { LintMode } from '../linter/LintMode';
+import SlangLinter, {
   buildSlangArgs,
   buildSlangCommand,
   getSlangPaths,
   parseSlangDiagnostics,
   parseSlangDiagnosticsByFile,
 } from '../linter/SlangLinter';
+import type { ProjectService } from '../project/ProjectService';
+import type { ProjectSnapshot } from '../project/ProjectTypes';
+
+async function waitForDiagnostics(
+  collection: vscode.DiagnosticCollection,
+  uri: vscode.Uri,
+  timeoutMs: number
+): Promise<readonly vscode.Diagnostic[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const current = collection.get(uri);
+    if (current && current.length > 0) {
+      return current;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return collection.get(uri) ?? [];
+}
+
+function formatDiagnosticsDump(
+  collection: vscode.DiagnosticCollection,
+  expectedUri: vscode.Uri
+): string {
+  const lines = [`Expected document URI: ${expectedUri.toString()}`, 'Diagnostic collection:'];
+
+  collection.forEach((uri, diagnostics) => {
+    lines.push(`- ${uri.toString()}`);
+    for (const diagnostic of diagnostics) {
+      lines.push(
+        `  source=${diagnostic.source ?? ''} severity=${diagnostic.severity} code=${
+          diagnostic.code?.toString() ?? ''
+        } message=${diagnostic.message}`
+      );
+    }
+  });
+
+  return lines.join('\n');
+}
+
+async function withSlangConfig(
+  slangPath: string,
+  options: {
+    arguments?: string;
+    includePath?: string[];
+    mode?: LintMode;
+    runAtFileLocation?: boolean;
+    useWSL?: boolean;
+  },
+  run: () => Promise<void>
+): Promise<void> {
+  const lintConfig = vscode.workspace.getConfiguration('verilog.linting');
+  const compileUnitConfig = vscode.workspace.getConfiguration('verilog.linting.compileUnit');
+  const slangConfig = vscode.workspace.getConfiguration('verilog.linting.slang');
+  const previousLintPath = lintConfig.get('path');
+  const previousMode = lintConfig.get('mode');
+  const previousMaxFiles = compileUnitConfig.get('maxFiles');
+  const previousArgs = slangConfig.get('arguments');
+  const previousInclude = slangConfig.get('includePath');
+  const previousRunAtFile = slangConfig.get('runAtFileLocation');
+  const previousUseWSL = slangConfig.get('useWSL');
+
+  try {
+    await lintConfig.update('path', path.dirname(slangPath), vscode.ConfigurationTarget.Global);
+    await lintConfig.update('mode', options.mode ?? 'file', vscode.ConfigurationTarget.Global);
+    await compileUnitConfig.update('maxFiles', 10, vscode.ConfigurationTarget.Global);
+    await slangConfig.update('arguments', options.arguments ?? '', vscode.ConfigurationTarget.Global);
+    await slangConfig.update(
+      'includePath',
+      options.includePath ?? [],
+      vscode.ConfigurationTarget.Global
+    );
+    await slangConfig.update(
+      'runAtFileLocation',
+      options.runAtFileLocation ?? true,
+      vscode.ConfigurationTarget.Global
+    );
+    await slangConfig.update('useWSL', options.useWSL ?? false, vscode.ConfigurationTarget.Global);
+
+    await run();
+  } finally {
+    await lintConfig.update('path', previousLintPath, vscode.ConfigurationTarget.Global);
+    await lintConfig.update('mode', previousMode, vscode.ConfigurationTarget.Global);
+    await compileUnitConfig.update('maxFiles', previousMaxFiles, vscode.ConfigurationTarget.Global);
+    await slangConfig.update('arguments', previousArgs, vscode.ConfigurationTarget.Global);
+    await slangConfig.update('includePath', previousInclude, vscode.ConfigurationTarget.Global);
+    await slangConfig.update('runAtFileLocation', previousRunAtFile, vscode.ConfigurationTarget.Global);
+    await slangConfig.update('useWSL', previousUseWSL, vscode.ConfigurationTarget.Global);
+  }
+}
+
+function createTempSvFile(tempRoot: string, name: string, contents: string): string {
+  const tempFilePath = path.join(tempRoot, name);
+  fs.writeFileSync(tempFilePath, contents);
+  return tempFilePath;
+}
+
+function createProjectServiceForCompileUnit(
+  workspaceRoot: vscode.Uri,
+  ownerUri: vscode.Uri,
+  childUri: vscode.Uri
+): ProjectService {
+  const snapshot: ProjectSnapshot = {
+    version: 1,
+    workspaceRoot,
+    activeTargetId: 'unit',
+    compileUnits: [{
+      id: 'unit',
+      name: 'unit',
+      root: workspaceRoot,
+      files: [
+        {
+          uri: ownerUri,
+          languageId: 'systemverilog',
+          kind: 'source',
+          order: 0,
+        },
+        {
+          uri: childUri,
+          languageId: 'systemverilog',
+          kind: 'source',
+          order: 1,
+        },
+      ],
+      includeDirs: [],
+      defines: {},
+      topModules: [],
+      source: { type: 'settings' },
+    }],
+    diagnostics: [],
+  };
+
+  return {
+    getPreferredFileContext: () => ({
+      file: ownerUri,
+      compileUnitId: 'unit',
+      includeDirs: [],
+      defines: {},
+    }),
+    getSnapshot: () => snapshot,
+  } as unknown as ProjectService;
+}
 
 suite('Slang Linter', () => {
   test('builds command and args without WSL shell strings', () => {
@@ -132,6 +278,22 @@ suite('Slang Linter', () => {
     assert.strictEqual(diagnosticsByFile.get(childPath)?.[0]?.message, 'child warning');
   });
 
+  test('resolves relative compile-unit diagnostics from cwd', () => {
+    const ownerPath = '/tmp/slang source/top file.sv';
+    const childPath = '/tmp/slang source/child.sv';
+    const stderr = 'child.sv:1:7: error: expected semicolon';
+
+    const diagnosticsByFile = parseSlangDiagnosticsByFile({
+      stderr,
+      documentPath: ownerPath,
+      isWindows: false,
+      useWSL: false,
+      cwd: '/tmp/slang source',
+    });
+
+    assert.strictEqual(diagnosticsByFile.get(childPath)?.[0]?.message, 'expected semicolon');
+  });
+
   test('does not import child_process or call child exec', () => {
     const source = fs.readFileSync(
       path.join(__dirname, '..', '..', '..', 'src', 'linter', 'SlangLinter.ts'),
@@ -141,5 +303,127 @@ suite('Slang Linter', () => {
     assert.ok(!source.includes('child_process'), 'SlangLinter must not import child_process');
     assert.ok(!source.includes('child.exec'), 'SlangLinter must not call child_process.exec');
     assert.ok(!source.includes('exec(command'), 'SlangLinter must not call exec(command)');
+  });
+
+  test('reports diagnostics for syntax errors with installed slang', async function () {
+    this.timeout(10000);
+    const slangPath = which.sync('slang', { nothrow: true });
+    if (!slangPath) {
+      this.skip();
+      return;
+    }
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'slang-test-'));
+    const tempFilePath = createTempSvFile(tempRoot, 'bad.sv', 'module bad\nendmodule\n');
+    const diagnostics = vscode.languages.createDiagnosticCollection('slang-test');
+
+    try {
+      await withSlangConfig(slangPath, {}, async () => {
+        const linter = new SlangLinter(
+          new LinterDiagnosticManager(diagnostics),
+          new LintRunManager()
+        );
+        const document = await vscode.workspace.openTextDocument(tempFilePath);
+
+        await linter.startLint(document);
+        const results = await waitForDiagnostics(diagnostics, document.uri, 4000);
+
+        assert.ok(
+          results.some(
+            (diag) => diag.source === 'slang' && diag.severity === vscode.DiagnosticSeverity.Error
+          ),
+          `Expected a slang syntax error diagnostic\n${formatDiagnosticsDump(
+            diagnostics,
+            document.uri
+          )}`
+        );
+      });
+    } finally {
+      diagnostics.dispose();
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('handles diagnostics for files with spaces in paths with installed slang', async function () {
+    this.timeout(10000);
+    const slangPath = which.sync('slang', { nothrow: true });
+    if (!slangPath) {
+      this.skip();
+      return;
+    }
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'slang space-test-'));
+    const tempFilePath = createTempSvFile(tempRoot, 'bad file.sv', 'module bad\nendmodule\n');
+    const diagnostics = vscode.languages.createDiagnosticCollection('slang-space-test');
+
+    try {
+      await withSlangConfig(slangPath, {}, async () => {
+        const linter = new SlangLinter(
+          new LinterDiagnosticManager(diagnostics),
+          new LintRunManager()
+        );
+        const document = await vscode.workspace.openTextDocument(tempFilePath);
+
+        await linter.startLint(document);
+        const results = await waitForDiagnostics(diagnostics, document.uri, 4000);
+
+        assert.ok(
+          results.some(
+            (diag) => diag.source === 'slang' && diag.severity === vscode.DiagnosticSeverity.Error
+          ),
+          `Expected a slang diagnostic for a file with spaces\n${formatDiagnosticsDump(
+            diagnostics,
+            document.uri
+          )}`
+        );
+      });
+    } finally {
+      diagnostics.dispose();
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('publishes compile-unit diagnostics for child files with installed slang', async function () {
+    this.timeout(10000);
+    const slangPath = which.sync('slang', { nothrow: true });
+    if (!slangPath) {
+      this.skip();
+      return;
+    }
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'slang-compile-unit-test-'));
+    const ownerPath = createTempSvFile(tempRoot, 'top.sv', 'module top;\nendmodule\n');
+    const childPath = createTempSvFile(tempRoot, 'child.sv', 'module child\nendmodule\n');
+    const ownerUri = vscode.Uri.file(ownerPath);
+    const childUri = vscode.Uri.file(childPath);
+    const projectService = createProjectServiceForCompileUnit(vscode.Uri.file(tempRoot), ownerUri, childUri);
+    const diagnostics = vscode.languages.createDiagnosticCollection('slang-compile-unit-test');
+
+    try {
+      await withSlangConfig(slangPath, { mode: 'compileUnit' }, async () => {
+        const linter = new SlangLinter(
+          new LinterDiagnosticManager(diagnostics),
+          new LintRunManager(),
+          projectService
+        );
+        const document = await vscode.workspace.openTextDocument(ownerPath);
+
+        await linter.startLint(document);
+        const results = await waitForDiagnostics(diagnostics, childUri, 4000);
+
+        assert.ok(
+          results.some(
+            (diag) => diag.source === 'slang' && diag.severity === vscode.DiagnosticSeverity.Error
+          ),
+          `Expected a child-file slang diagnostic in compile-unit mode\n${formatDiagnosticsDump(
+            diagnostics,
+            childUri
+          )}`
+        );
+      });
+    } finally {
+      diagnostics.dispose();
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/test/tclsp.test.ts
+++ b/src/test/tclsp.test.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
 import { buildTclspInitializationOptions } from '../languageServer/tclspOptions';
 
 suite('tclsp initialization options', () => {
-  test('builds global and workspace settings', async () => {
+  test('builds global and workspace settings', async function () {
+    this.timeout(10000);
     const config = vscode.workspace.getConfiguration('verilog.languageServer.tclsp');
     const inspect = config.inspect<string>('configPath');
     const previousGlobal = inspect?.globalValue;


### PR DESCRIPTION
## Summary
- install pinned slang v11.0 binaries in GitHub Actions for Linux, macOS, and Windows
- run slang verification before the VS Code test suite on every matrix OS
- run the full `npm test` suite on Windows instead of targeted Windows-only subsets
- add real-slang integration coverage for file linting, paths with spaces, and compile-unit diagnostics
- normalize relative slang diagnostic paths against the lint working directory

## Validation
- npm run compile-tests
- npm run lint
- npm run compile
- npm test
- PATH=/tmp/veriloghdl-slang-v11.0-macos-arm64:$PATH npm test -- --fgrep "Slang Linter"