### PR TITLE
Actionable HDL Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Use **Verilog: Reload Project**, **Verilog: Show Project Status**, and **Verilog
 
 ### HDL Explorer And Hierarchy
 
-The **HDL Explorer** view appears in VS Code's Explorer sidebar. It shows the active project target, compile units, indexed modules/packages, a best-effort module hierarchy, and unresolved instances when enabled.
+The **HDL Explorer** view appears in VS Code's Explorer sidebar. It shows the active project target, compile units, indexed modules/packages, a best-effort module hierarchy, and unresolved instances when enabled. Explorer context menus provide common project actions such as selecting the active target, opening HDL files or declarations, instantiating modules, filtering hierarchy roots, finding references, and copying paths or defines.
 
 Hierarchy detection is intentionally lightweight and does not perform full SystemVerilog elaboration. Configure top modules with `verilog.project.topModules` when inference is ambiguous, and control hierarchy behavior with `verilog.hierarchy.*` settings.
 

--- a/package.json
+++ b/package.json
@@ -1031,12 +1031,88 @@
         "title": "Verilog: Refresh HDL Explorer"
       },
       {
+        "command": "verilog.setActiveTargetFromExplorer",
+        "title": "Verilog: Set Active Target From Explorer"
+      },
+      {
+        "command": "verilog.selectActiveTarget",
+        "title": "Verilog: Select Active HDL Target"
+      },
+      {
         "command": "verilog.openModuleFromExplorer",
         "title": "Verilog: Open Module From Explorer"
       },
       {
+        "command": "verilog.instantiateModuleFromExplorer",
+        "title": "Verilog: Instantiate Module From Explorer"
+      },
+      {
+        "command": "verilog.showHierarchyFromModule",
+        "title": "Verilog: Show Hierarchy From This Module"
+      },
+      {
+        "command": "verilog.clearHierarchyRootFilter",
+        "title": "Verilog: Clear HDL Hierarchy Root Filter"
+      },
+      {
+        "command": "verilog.findModuleReferencesFromExplorer",
+        "title": "Verilog: Find Module References From Explorer"
+      },
+      {
         "command": "verilog.openInstanceFromExplorer",
         "title": "Verilog: Open Instance From Explorer"
+      },
+      {
+        "command": "verilog.openInstanceModuleFromExplorer",
+        "title": "Verilog: Open Instance Module From Explorer"
+      },
+      {
+        "command": "verilog.findInstanceModuleReferencesFromExplorer",
+        "title": "Verilog: Find Instance Module References From Explorer"
+      },
+      {
+        "command": "verilog.searchUnresolvedModule",
+        "title": "Verilog: Search Unresolved Module"
+      },
+      {
+        "command": "verilog.copyModuleNameFromExplorer",
+        "title": "Verilog: Copy Module Name From Explorer"
+      },
+      {
+        "command": "verilog.openFileFromExplorer",
+        "title": "Verilog: Open File From Explorer"
+      },
+      {
+        "command": "verilog.revealFileInOs",
+        "title": "Verilog: Reveal File in OS"
+      },
+      {
+        "command": "verilog.revealIncludeDirInOs",
+        "title": "Verilog: Reveal Include Directory in OS"
+      },
+      {
+        "command": "verilog.copyPathFromExplorer",
+        "title": "Verilog: Copy Path From Explorer"
+      },
+      {
+        "command": "verilog.copyRelativePathFromExplorer",
+        "title": "Verilog: Copy Relative Path From Explorer"
+      },
+      {
+        "command": "verilog.openCompileUnitSource",
+        "title": "Verilog: Open Compile Unit Source"
+      },
+      {
+        "command": "verilog.copyDefineNameFromExplorer",
+        "title": "Verilog: Copy Define Name From Explorer"
+      },
+      {
+        "command": "verilog.copyDefineArgumentFromExplorer",
+        "title": "Verilog: Copy Define Argument From Explorer"
+      },
+      {
+        "command": "verilog.openDefineLocationFromExplorer",
+        "title": "Verilog: Open Define Location From Explorer"
       },
       {
         "command": "verilog.openFliplot",
@@ -1061,6 +1137,168 @@
           "command": "verilog.refreshHdlExplorer",
           "when": "view == verilog.hdlExplorer",
           "group": "navigation"
+        },
+        {
+          "command": "verilog.refreshHierarchy",
+          "when": "view == verilog.hdlExplorer",
+          "group": "navigation"
+        },
+        {
+          "command": "verilog.selectActiveTarget",
+          "when": "view == verilog.hdlExplorer",
+          "group": "navigation"
+        },
+        {
+          "command": "verilog.showProjectStatus",
+          "when": "view == verilog.hdlExplorer",
+          "group": "navigation"
+        },
+        {
+          "command": "verilog.clearHierarchyRootFilter",
+          "when": "view == verilog.hdlExplorer",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "verilog.selectActiveTarget",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.projectRoot",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.showProjectStatus",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.projectRoot",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.refreshHdlExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.projectRoot",
+          "group": "navigation@3"
+        },
+        {
+          "command": "verilog.setActiveTargetFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.compileUnit",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.openCompileUnitSource",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.compileUnit",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.openFileFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.sourceFile",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.revealFileInOs",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.sourceFile",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.copyPathFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.sourceFile",
+          "group": "clipboard@1"
+        },
+        {
+          "command": "verilog.copyRelativePathFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.sourceFile",
+          "group": "clipboard@2"
+        },
+        {
+          "command": "verilog.revealIncludeDirInOs",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.includeDir",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.copyPathFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.includeDir",
+          "group": "clipboard@1"
+        },
+        {
+          "command": "verilog.openModuleFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.module",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.instantiateModuleFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.module",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.showHierarchyFromModule",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.module",
+          "group": "navigation@3"
+        },
+        {
+          "command": "verilog.findModuleReferencesFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.module",
+          "group": "navigation@4"
+        },
+        {
+          "command": "verilog.openModuleFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyModule",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.instantiateModuleFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyModule",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.showHierarchyFromModule",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyModule",
+          "group": "navigation@3"
+        },
+        {
+          "command": "verilog.findModuleReferencesFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyModule",
+          "group": "navigation@4"
+        },
+        {
+          "command": "verilog.openInstanceFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyInstance",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.openInstanceModuleFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyInstance",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.findInstanceModuleReferencesFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.hierarchyInstance",
+          "group": "navigation@3"
+        },
+        {
+          "command": "verilog.openInstanceFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.unresolvedInstance",
+          "group": "navigation@1"
+        },
+        {
+          "command": "verilog.searchUnresolvedModule",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.unresolvedInstance",
+          "group": "navigation@2"
+        },
+        {
+          "command": "verilog.copyModuleNameFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.unresolvedInstance",
+          "group": "clipboard@1"
+        },
+        {
+          "command": "verilog.copyDefineNameFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.define",
+          "group": "clipboard@1"
+        },
+        {
+          "command": "verilog.copyDefineArgumentFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.define",
+          "group": "clipboard@2"
+        },
+        {
+          "command": "verilog.openDefineLocationFromExplorer",
+          "when": "view == verilog.hdlExplorer && viewItem == hdlExplorer.define",
+          "group": "navigation@1"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,15 @@ export async function activate(context: vscode.ExtensionContext) {
     new ProjectWatcher(projectService)
   );
   context.subscriptions.push(...registerProjectCommands(projectService, indexService));
-  context.subscriptions.push(...registerHdlExplorerCommands(hierarchyService, hdlExplorerProvider));
+  context.subscriptions.push(
+    ...registerHdlExplorerCommands(
+      projectService,
+      hierarchyService,
+      instantiationService,
+      referenceService,
+      hdlExplorerProvider
+    )
+  );
   context.subscriptions.push(
     vscode.window.createTreeView('verilog.hdlExplorer', {
       treeDataProvider: hdlExplorerProvider,

--- a/src/hdl/InstantiationService.ts
+++ b/src/hdl/InstantiationService.ts
@@ -12,6 +12,16 @@ interface ModuleQuickPickItem extends vscode.QuickPickItem {
 export class InstantiationService {
   constructor(private readonly indexService: IndexService) {}
 
+  async instantiateModule(moduleRecord: ModuleRecord): Promise<boolean> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || !isHdlDocument(editor.document)) {
+      vscode.window.showWarningMessage('Open a Verilog/SystemVerilog editor before instantiating a module.');
+      return false;
+    }
+    await editor.insertSnippet(buildModuleInstantiationSnippet(moduleRecord));
+    return true;
+  }
+
   async instantiateModuleInteract(fallback: InstantiationFallback): Promise<void> {
     if (!useProjectIndex()) {
       await fallback();
@@ -91,6 +101,10 @@ function useProjectIndex(): boolean {
   return vscode.workspace
     .getConfiguration('verilog.instantiate')
     .get<boolean>('useProjectIndex', true);
+}
+
+function isHdlDocument(document: vscode.TextDocument): boolean {
+  return document.languageId === 'verilog' || document.languageId === 'systemverilog';
 }
 
 function getIndentationString(): string {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -146,8 +146,23 @@ suite('Extension Test Suite', () => {
     assert.ok(commands.includes('verilog.showProjectModules'));
     assert.ok(commands.includes('verilog.refreshHierarchy'));
     assert.ok(commands.includes('verilog.refreshHdlExplorer'));
+    assert.ok(commands.includes('verilog.setActiveTargetFromExplorer'));
+    assert.ok(commands.includes('verilog.selectActiveTarget'));
     assert.ok(commands.includes('verilog.openModuleFromExplorer'));
+    assert.ok(commands.includes('verilog.instantiateModuleFromExplorer'));
+    assert.ok(commands.includes('verilog.showHierarchyFromModule'));
+    assert.ok(commands.includes('verilog.clearHierarchyRootFilter'));
+    assert.ok(commands.includes('verilog.findModuleReferencesFromExplorer'));
     assert.ok(commands.includes('verilog.openInstanceFromExplorer'));
+    assert.ok(commands.includes('verilog.openInstanceModuleFromExplorer'));
+    assert.ok(commands.includes('verilog.findInstanceModuleReferencesFromExplorer'));
+    assert.ok(commands.includes('verilog.searchUnresolvedModule'));
+    assert.ok(commands.includes('verilog.copyModuleNameFromExplorer'));
+    assert.ok(commands.includes('verilog.openFileFromExplorer'));
+    assert.ok(commands.includes('verilog.copyPathFromExplorer'));
+    assert.ok(commands.includes('verilog.copyRelativePathFromExplorer'));
+    assert.ok(commands.includes('verilog.copyDefineNameFromExplorer'));
+    assert.ok(commands.includes('verilog.copyDefineArgumentFromExplorer'));
   });
 
   test('package should contribute project settings', () => {
@@ -203,5 +218,41 @@ suite('Extension Test Suite', () => {
     };
 
     assert.ok(packageJson.contributes.views.explorer.some((view) => view.id === 'verilog.hdlExplorer'));
+  });
+
+  test('package should contribute HDL Explorer context menus', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(getRepositoryRoot(), 'package.json'), 'utf8')
+    ) as {
+      contributes: {
+        menus: {
+          'view/item/context': Array<{ command: string; when: string }>;
+          'view/title': Array<{ command: string; when: string }>;
+        };
+      };
+    };
+
+    const itemMenus = packageJson.contributes.menus['view/item/context'];
+    const titleMenus = packageJson.contributes.menus['view/title'];
+    assert.ok(itemMenus.some((menu) =>
+      menu.command === 'verilog.setActiveTargetFromExplorer' &&
+      menu.when.includes('viewItem == hdlExplorer.compileUnit')
+    ));
+    assert.ok(itemMenus.some((menu) =>
+      menu.command === 'verilog.instantiateModuleFromExplorer' &&
+      menu.when.includes('viewItem == hdlExplorer.module')
+    ));
+    assert.ok(itemMenus.some((menu) =>
+      menu.command === 'verilog.searchUnresolvedModule' &&
+      menu.when.includes('viewItem == hdlExplorer.unresolvedInstance')
+    ));
+    assert.ok(itemMenus.some((menu) =>
+      menu.command === 'verilog.copyDefineArgumentFromExplorer' &&
+      menu.when.includes('viewItem == hdlExplorer.define')
+    ));
+    assert.ok(titleMenus.some((menu) =>
+      menu.command === 'verilog.selectActiveTarget' &&
+      menu.when === 'view == verilog.hdlExplorer'
+    ));
   });
 });

--- a/src/test/hdlExplorerProvider.test.ts
+++ b/src/test/hdlExplorerProvider.test.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { HdlExplorerProvider } from '../views/HdlExplorerProvider';
+import {
+  buildActiveTargetQuickPickItems,
+  filterHierarchyRoots,
+  formatDefineArgument,
+  getRelativePath,
+  HdlExplorerProvider,
+} from '../views/HdlExplorerProvider';
 import type { HierarchyService } from '../hierarchy/HierarchyService';
 import type { HierarchySnapshot } from '../hierarchy/HierarchyTypes';
 import type { ProjectService } from '../project/ProjectService';
@@ -49,6 +55,62 @@ suite('HdlExplorerProvider', () => {
     assert.ok((await sectionChildren(provider, root, 'Packages')).some((item) => item.label === 'pkg'));
     assert.ok((await sectionChildren(provider, root, 'Hierarchy (best-effort)')).some((item) => item.label === 'top'));
     assert.ok((await sectionChildren(provider, root, 'Unresolved Instances')).some((item) => item.label === 'u_missing : missing'));
+  });
+
+  test('assigns stable context values to explorer items', async () => {
+    const moduleRecord = createModuleRecord('top');
+    const packageRecord = createSymbolRecord('pkg', 'package');
+    const provider = createProvider({
+      symbols: [moduleRecord, packageRecord],
+      hierarchy: {
+        version: 1,
+        roots: [{
+          moduleName: 'top',
+          module: moduleRecord,
+          instances: [{
+            instanceName: 'u_child',
+            moduleName: 'child',
+            resolvedModule: createModuleRecord('child'),
+            location: new vscode.Location(moduleRecord.uri, moduleRecord.selectionRange),
+          }, {
+            instanceName: 'u_missing',
+            moduleName: 'missing',
+            location: new vscode.Location(moduleRecord.uri, moduleRecord.selectionRange),
+          }],
+          unresolvedInstances: [],
+        }],
+        unresolvedInstances: [],
+        allInstances: [],
+      },
+    });
+
+    const root = await children(provider);
+    const projectItems = await sectionChildren(provider, root, 'HDL Project');
+    const compileUnits = projectItems.find((item) => item.label === 'Compile Units');
+    assert.ok(compileUnits);
+    const compileUnit = (await children(provider, compileUnits))[0];
+    assert.ok(compileUnit);
+    const compileUnitChildren = await children(provider, compileUnit);
+    const filesGroup = compileUnitChildren.find((item) => item.label === 'Files');
+    const includeDirsGroup = compileUnitChildren.find((item) => item.label === 'Include Dirs');
+    const definesGroup = compileUnitChildren.find((item) => item.label === 'Defines');
+    assert.ok(filesGroup);
+    assert.ok(includeDirsGroup);
+    assert.ok(definesGroup);
+    const hierarchyRoot = (await sectionChildren(provider, root, 'Hierarchy (best-effort)'))[0];
+    assert.ok(hierarchyRoot);
+    const hierarchyChildren = await children(provider, hierarchyRoot);
+
+    assert.strictEqual(root.find((item) => item.label === 'HDL Project')?.contextValue, 'hdlExplorer.projectRoot');
+    assert.strictEqual(compileUnit.contextValue, 'hdlExplorer.compileUnit');
+    assert.strictEqual((await children(provider, filesGroup))[0]?.contextValue, 'hdlExplorer.sourceFile');
+    assert.strictEqual((await children(provider, includeDirsGroup))[0]?.contextValue, 'hdlExplorer.includeDir');
+    assert.strictEqual((await children(provider, definesGroup))[0]?.contextValue, 'hdlExplorer.define');
+    assert.strictEqual((await sectionChildren(provider, root, 'Modules'))[0]?.contextValue, 'hdlExplorer.module');
+    assert.strictEqual((await sectionChildren(provider, root, 'Packages'))[0]?.contextValue, 'hdlExplorer.package');
+    assert.strictEqual(hierarchyRoot.contextValue, 'hdlExplorer.hierarchyModule');
+    assert.strictEqual(hierarchyChildren[0]?.contextValue, 'hdlExplorer.hierarchyInstance');
+    assert.strictEqual(hierarchyChildren[1]?.contextValue, 'hdlExplorer.unresolvedInstance');
   });
 
   test('maps module and instance items to source locations', async () => {
@@ -112,6 +174,92 @@ suite('HdlExplorerProvider', () => {
     } finally {
       await config.update('verilog.hdlExplorer.enabled', previous, vscode.ConfigurationTarget.Global);
     }
+  });
+
+  test('filters hierarchy roots and clears the filter', async () => {
+    const top = createModuleRecord('top');
+    const child = createModuleRecord('child');
+    const provider = createProvider({
+      symbols: [top, child],
+      hierarchy: {
+        version: 1,
+        roots: [{
+          moduleName: 'top',
+          module: top,
+          instances: [{
+            instanceName: 'u_child',
+            moduleName: 'child',
+            resolvedModule: child,
+            location: new vscode.Location(top.uri, top.selectionRange),
+            children: {
+              moduleName: 'child',
+              module: child,
+              instances: [],
+              unresolvedInstances: [],
+            },
+          }],
+          unresolvedInstances: [],
+        }],
+        unresolvedInstances: [],
+        allInstances: [],
+      },
+    });
+
+    provider.setHierarchyRootFilter('child', 'unit');
+    const filtered = await sectionChildren(provider, await children(provider), 'Hierarchy (best-effort)');
+    assert.strictEqual(filtered[0]?.label, 'Filtered root');
+    assert.strictEqual(filtered[1]?.label, 'child');
+
+    provider.clearHierarchyRootFilter();
+    const unfiltered = await sectionChildren(provider, await children(provider), 'Hierarchy (best-effort)');
+    assert.strictEqual(unfiltered[0]?.label, 'top');
+  });
+
+  test('helper functions build active target, path, define, and hierarchy values', () => {
+    const snapshot = createProjectSnapshot();
+    const compileUnit = snapshot.compileUnits[0];
+    assert.ok(compileUnit);
+    const picks = buildActiveTargetQuickPickItems(snapshot.compileUnits);
+    assert.strictEqual(picks[0]?.targetId, '');
+    assert.strictEqual(picks[1]?.label, compileUnit.name);
+    assert.strictEqual(picks[1]?.targetId, compileUnit.id);
+
+    assert.strictEqual(
+      getRelativePath(vscode.Uri.file('/workspace/rtl/top.sv'), vscode.Uri.file('/workspace')),
+      'rtl/top.sv'
+    );
+    const outsideWorkspaceUri = vscode.Uri.file('/other/top.sv');
+    assert.strictEqual(
+      getRelativePath(outsideWorkspaceUri, vscode.Uri.file('/workspace')),
+      outsideWorkspaceUri.fsPath
+    );
+    assert.strictEqual(formatDefineArgument('SIM', { name: 'SIM', value: true, source: 'settings' }), '+define+SIM');
+    assert.strictEqual(
+      formatDefineArgument('WIDTH', { name: 'WIDTH', value: '32', source: 'settings' }),
+      '+define+WIDTH=32'
+    );
+
+    const top = createModuleRecord('top');
+    const child = createModuleRecord('child');
+    const roots = [{
+      moduleName: 'top',
+      module: top,
+      instances: [{
+        instanceName: 'u_child',
+        moduleName: 'child',
+        resolvedModule: child,
+        location: new vscode.Location(top.uri, top.selectionRange),
+        children: {
+          moduleName: 'child',
+          module: child,
+          instances: [],
+          unresolvedInstances: [],
+        },
+      }],
+      unresolvedInstances: [],
+    }];
+    assert.deepStrictEqual(filterHierarchyRoots(roots).map((node) => node.moduleName), ['top']);
+    assert.deepStrictEqual(filterHierarchyRoots(roots, { moduleName: 'child', compileUnitId: 'unit' }).map((node) => node.moduleName), ['child']);
   });
 });
 

--- a/src/test/moduleInstantiation.test.ts
+++ b/src/test/moduleInstantiation.test.ts
@@ -61,6 +61,29 @@ suite('Module Instantiation', () => {
     }
   });
 
+  test('direct project-index instantiation handles no active editor gracefully', async () => {
+    const service = new InstantiationService({
+      getIndex: () => new SemanticIndex(1, []),
+    } as unknown as IndexService);
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    let warning: string | undefined;
+
+    try {
+      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+      (vscode.window as any).showWarningMessage = async (message: string) => {
+        warning = message;
+        return undefined;
+      };
+
+      const inserted = await service.instantiateModule(createModuleRecord('idx_mod', [], []));
+
+      assert.strictEqual(inserted, false);
+      assert.ok(warning?.includes('Verilog/SystemVerilog'));
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
   test('falls back when project index instantiation is disabled', async () => {
     const config = vscode.workspace.getConfiguration('verilog.instantiate');
     const previous = config.get('useProjectIndex');

--- a/src/views/HdlExplorerItems.ts
+++ b/src/views/HdlExplorerItems.ts
@@ -5,34 +5,88 @@ import type { CompileUnit, MacroDefine, SourceFileRef } from '../project/Project
 import type { HierarchyInstanceNode, HierarchyNode } from '../hierarchy/HierarchyTypes';
 import type { ModuleRecord, SymbolRecord } from '../semantic/SymbolRecords';
 
+export type RootSection = 'project' | 'modules' | 'packages' | 'hierarchy' | 'unresolved';
+export type CompileUnitGroup = 'files' | 'includeDirs' | 'defines';
+
+export type HdlExplorerPayload =
+  | { kind: 'section'; section: RootSection }
+  | { kind: 'compileUnits'; compileUnits: CompileUnit[] }
+  | { kind: 'compileUnit'; compileUnit: CompileUnit }
+  | { kind: 'compileUnitGroup'; group: CompileUnitGroup; compileUnit: CompileUnit }
+  | { kind: 'sourceFile'; file: SourceFileRef }
+  | { kind: 'includeDir'; uri: vscode.Uri }
+  | { kind: 'define'; name: string; define: MacroDefine }
+  | { kind: 'symbol'; symbol: ModuleRecord | SymbolRecord }
+  | { kind: 'hierarchyModule'; node: HierarchyNode }
+  | { kind: 'hierarchyInstance'; instance: HierarchyInstanceNode }
+  | { kind: 'info' };
+
 export type HdlExplorerItemKind =
-  | 'section'
-  | 'info'
-  | 'compileUnit'
-  | 'group'
-  | 'file'
-  | 'symbol'
-  | 'hierarchyModule'
-  | 'hierarchyInstance';
+  | 'hdlExplorer.projectRoot'
+  | 'hdlExplorer.section'
+  | 'hdlExplorer.info'
+  | 'hdlExplorer.compileUnits'
+  | 'hdlExplorer.compileUnit'
+  | 'hdlExplorer.compileUnitGroup'
+  | 'hdlExplorer.sourceFile'
+  | 'hdlExplorer.includeDir'
+  | 'hdlExplorer.define'
+  | 'hdlExplorer.module'
+  | 'hdlExplorer.package'
+  | 'hdlExplorer.symbol'
+  | 'hdlExplorer.hierarchyModule'
+  | 'hdlExplorer.hierarchyInstance'
+  | 'hdlExplorer.unresolvedInstance';
 
 export class HdlExplorerItem extends vscode.TreeItem {
   constructor(
     label: string,
     readonly kind: HdlExplorerItemKind,
     collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None,
-    readonly payload?: unknown
+    readonly payload: HdlExplorerPayload = { kind: 'info' }
   ) {
     super(label, collapsibleState);
-    this.contextValue = kind;
+    this.contextValue = getContextValueForPayload(payload, kind);
   }
 }
 
-export function createSectionItem(label: string): HdlExplorerItem {
-  return new HdlExplorerItem(label, 'section', vscode.TreeItemCollapsibleState.Expanded);
+export function getContextValueForPayload(
+  payload: HdlExplorerPayload,
+  fallback: HdlExplorerItemKind = 'hdlExplorer.info'
+): HdlExplorerItemKind {
+  switch (payload.kind) {
+    case 'section':
+      return payload.section === 'project' ? 'hdlExplorer.projectRoot' : 'hdlExplorer.section';
+    case 'compileUnits':
+      return 'hdlExplorer.compileUnits';
+    case 'compileUnit':
+      return 'hdlExplorer.compileUnit';
+    case 'compileUnitGroup':
+      return 'hdlExplorer.compileUnitGroup';
+    case 'sourceFile':
+      return 'hdlExplorer.sourceFile';
+    case 'includeDir':
+      return 'hdlExplorer.includeDir';
+    case 'define':
+      return 'hdlExplorer.define';
+    case 'symbol':
+      if (payload.symbol.kind === 'module') {
+        return 'hdlExplorer.module';
+      }
+      return payload.symbol.kind === 'package' ? 'hdlExplorer.package' : 'hdlExplorer.symbol';
+    case 'hierarchyModule':
+      return 'hdlExplorer.hierarchyModule';
+    case 'hierarchyInstance':
+      return payload.instance.resolvedModule ? 'hdlExplorer.hierarchyInstance' : 'hdlExplorer.unresolvedInstance';
+    case 'info':
+      return 'hdlExplorer.info';
+    default:
+      return fallback;
+  }
 }
 
 export function createInfoItem(label: string, description?: string): HdlExplorerItem {
-  const item = new HdlExplorerItem(label, 'info');
+  const item = new HdlExplorerItem(label, 'hdlExplorer.info');
   item.description = description;
   return item;
 }
@@ -40,38 +94,80 @@ export function createInfoItem(label: string, description?: string): HdlExplorer
 export function createCompileUnitItem(compileUnit: CompileUnit): HdlExplorerItem {
   const item = new HdlExplorerItem(
     compileUnit.name,
-    'compileUnit',
+    'hdlExplorer.compileUnit',
     vscode.TreeItemCollapsibleState.Collapsed,
-    compileUnit
+    { kind: 'compileUnit', compileUnit }
   );
   item.description = compileUnit.id;
   return item;
 }
 
-export function createGroupItem(label: string, payload: unknown): HdlExplorerItem {
-  return new HdlExplorerItem(label, 'group', vscode.TreeItemCollapsibleState.Collapsed, payload);
+export function createCompileUnitsItem(compileUnits: CompileUnit[]): HdlExplorerItem {
+  return new HdlExplorerItem(
+    'Compile Units',
+    'hdlExplorer.compileUnits',
+    vscode.TreeItemCollapsibleState.Collapsed,
+    { kind: 'compileUnits', compileUnits }
+  );
+}
+
+export function createGroupItem(label: string, group: CompileUnitGroup, compileUnit: CompileUnit): HdlExplorerItem {
+  return new HdlExplorerItem(
+    label,
+    'hdlExplorer.compileUnitGroup',
+    vscode.TreeItemCollapsibleState.Collapsed,
+    { kind: 'compileUnitGroup', group, compileUnit }
+  );
 }
 
 export function createFileItem(file: SourceFileRef): HdlExplorerItem {
-  const item = new HdlExplorerItem(path.basename(file.uri.fsPath), 'file', vscode.TreeItemCollapsibleState.None, file);
+  const item = new HdlExplorerItem(
+    path.basename(file.uri.fsPath),
+    'hdlExplorer.sourceFile',
+    vscode.TreeItemCollapsibleState.None,
+    { kind: 'sourceFile', file }
+  );
   item.description = file.kind;
   item.resourceUri = file.uri;
   item.command = {
-    command: 'vscode.open',
+    command: 'verilog.openFileFromExplorer',
     title: 'Open File',
     arguments: [file.uri],
   };
   return item;
 }
 
+export function createIncludeDirItem(uri: vscode.Uri): HdlExplorerItem {
+  const item = new HdlExplorerItem(
+    path.basename(uri.fsPath),
+    'hdlExplorer.includeDir',
+    vscode.TreeItemCollapsibleState.None,
+    { kind: 'includeDir', uri }
+  );
+  item.description = uri.fsPath;
+  item.resourceUri = uri;
+  return item;
+}
+
 export function createDefineItem(name: string, define: MacroDefine): HdlExplorerItem {
-  const item = createInfoItem(name, String(define.value));
+  const item = new HdlExplorerItem(
+    name,
+    'hdlExplorer.define',
+    vscode.TreeItemCollapsibleState.None,
+    { kind: 'define', name, define }
+  );
+  item.description = String(define.value);
   item.tooltip = `${name} = ${String(define.value)} (${define.source})`;
   return item;
 }
 
 export function createSymbolItem(symbol: ModuleRecord | SymbolRecord): HdlExplorerItem {
-  const item = new HdlExplorerItem(symbol.name, 'symbol', vscode.TreeItemCollapsibleState.None, symbol);
+  const item = new HdlExplorerItem(
+    symbol.name,
+    symbol.kind === 'module' ? 'hdlExplorer.module' : 'hdlExplorer.symbol',
+    vscode.TreeItemCollapsibleState.None,
+    { kind: 'symbol', symbol }
+  );
   item.description = symbol.compileUnitId;
   item.resourceUri = symbol.uri;
   item.command = {
@@ -86,9 +182,9 @@ export function createHierarchyModuleItem(node: HierarchyNode): HdlExplorerItem 
   const childCount = node.instances.length + node.unresolvedInstances.length;
   const item = new HdlExplorerItem(
     node.moduleName,
-    'hierarchyModule',
+    'hdlExplorer.hierarchyModule',
     childCount > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
-    node
+    { kind: 'hierarchyModule', node }
   );
   if (node.module) {
     item.description = node.module.compileUnitId;
@@ -108,9 +204,9 @@ export function createHierarchyInstanceItem(instance: HierarchyInstanceNode): Hd
     : 0;
   const item = new HdlExplorerItem(
     `${instance.instanceName} : ${instance.moduleName}`,
-    'hierarchyInstance',
+    instance.resolvedModule ? 'hdlExplorer.hierarchyInstance' : 'hdlExplorer.unresolvedInstance',
     childCount > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
-    instance
+    { kind: 'hierarchyInstance', instance }
   );
   item.description = instance.resolvedModule ? undefined : 'unresolved';
   item.resourceUri = instance.location.uri;

--- a/src/views/HdlExplorerProvider.ts
+++ b/src/views/HdlExplorerProvider.ts
@@ -2,43 +2,43 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { HierarchyService } from '../hierarchy/HierarchyService';
-import type { HierarchyInstanceNode, HierarchyNode } from '../hierarchy/HierarchyTypes';
+import type { HierarchyNode } from '../hierarchy/HierarchyTypes';
+import type { InstantiationService } from '../hdl/InstantiationService';
+import type { ReferenceService } from '../hdl/ReferenceService';
 import type { ProjectService } from '../project/ProjectService';
-import type { CompileUnit } from '../project/ProjectTypes';
+import type { CompileUnit, MacroDefine } from '../project/ProjectTypes';
 import { getActiveCompileUnit } from '../project/ProjectTargetResolver';
 import type { IndexService } from '../semantic/IndexService';
+import type { ModuleRecord } from '../semantic/SymbolRecords';
 import {
   createCompileUnitItem,
+  createCompileUnitsItem,
   createDefineItem,
   createFileItem,
   createGroupItem,
   createHierarchyInstanceItem,
   createHierarchyModuleItem,
+  createIncludeDirItem,
   createInfoItem,
   createSymbolItem,
+  HdlExplorerPayload,
   HdlExplorerItem,
+  RootSection,
 } from './HdlExplorerItems';
 
-type RootSection = 'project' | 'modules' | 'packages' | 'hierarchy' | 'unresolved';
-type CompileUnitGroup = 'files' | 'includeDirs' | 'defines';
-
-interface SectionPayload {
-  section: RootSection;
+interface HierarchyRootFilter {
+  moduleName: string;
+  compileUnitId?: string;
 }
 
-interface CompileUnitGroupPayload {
-  group: CompileUnitGroup;
-  compileUnit: CompileUnit;
-}
-
-interface CompileUnitsPayload {
-  group: 'compileUnits';
-  compileUnits: CompileUnit[];
+interface ActiveTargetQuickPickItem extends vscode.QuickPickItem {
+  targetId: string;
 }
 
 export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerItem>, vscode.Disposable {
   private readonly emitter = new vscode.EventEmitter<HdlExplorerItem | undefined>();
   private readonly disposables: vscode.Disposable[] = [];
+  private hierarchyRootFilter?: HierarchyRootFilter;
 
   readonly onDidChangeTreeData = this.emitter.event;
 
@@ -77,25 +77,35 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
     if (!element) {
       return this.getRootItems();
     }
-    if (isSectionPayload(element.payload)) {
+    if (element.payload.kind === 'section') {
       return this.getSectionChildren(element.payload.section);
     }
-    if (isCompileUnit(element.payload)) {
-      return this.getCompileUnitChildren(element.payload);
+    if (element.payload.kind === 'compileUnit') {
+      return this.getCompileUnitChildren(element.payload.compileUnit);
     }
-    if (isCompileUnitsPayload(element.payload)) {
+    if (element.payload.kind === 'compileUnits') {
       return element.payload.compileUnits.map(createCompileUnitItem);
     }
-    if (isCompileUnitGroupPayload(element.payload)) {
+    if (element.payload.kind === 'compileUnitGroup') {
       return this.getCompileUnitGroupChildren(element.payload);
     }
-    if (isHierarchyNode(element.payload)) {
-      return this.getHierarchyNodeChildren(element.payload);
+    if (element.payload.kind === 'hierarchyModule') {
+      return this.getHierarchyNodeChildren(element.payload.node);
     }
-    if (isHierarchyInstance(element.payload) && element.payload.children) {
-      return this.getHierarchyNodeChildren(element.payload.children);
+    if (element.payload.kind === 'hierarchyInstance' && element.payload.instance.children) {
+      return this.getHierarchyNodeChildren(element.payload.instance.children);
     }
     return [];
+  }
+
+  setHierarchyRootFilter(moduleName: string, compileUnitId?: string): void {
+    this.hierarchyRootFilter = { moduleName, compileUnitId };
+    this.refresh();
+  }
+
+  clearHierarchyRootFilter(): void {
+    this.hierarchyRootFilter = undefined;
+    this.refresh();
   }
 
   dispose(): void {
@@ -131,10 +141,22 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
           .filter((symbol) => symbol.kind === 'package')
           .map(createSymbolItem);
       case 'hierarchy':
-        return this.hierarchyService.getHierarchy().roots.map(createHierarchyModuleItem);
+        return this.getHierarchySectionChildren();
       case 'unresolved':
         return this.hierarchyService.getHierarchy().unresolvedInstances.map(createHierarchyInstanceItem);
     }
+  }
+
+  private getHierarchySectionChildren(): HdlExplorerItem[] {
+    const roots = filterHierarchyRoots(this.hierarchyService.getHierarchy().roots, this.hierarchyRootFilter);
+    const items = roots.map(createHierarchyModuleItem);
+    if (this.hierarchyRootFilter) {
+      return [
+        createInfoItem('Filtered root', this.hierarchyRootFilter.moduleName),
+        ...items,
+      ];
+    }
+    return items;
   }
 
   private getProjectChildren(): HdlExplorerItem[] {
@@ -145,7 +167,7 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
       createInfoItem('Active Compile Unit', activeCompileUnit ? `${activeCompileUnit.name} (${activeCompileUnit.id})` : '(none)'),
       createInfoItem('Diagnostics', String(snapshot.diagnostics.length)),
       createInfoItem('Workspace Root', snapshot.workspaceRoot.fsPath),
-      createGroupItem('Compile Units', { group: 'compileUnits', compileUnits: snapshot.compileUnits }),
+      createCompileUnitsItem(snapshot.compileUnits),
     ];
   }
 
@@ -153,22 +175,18 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
     return [
       createInfoItem('Id', compileUnit.id),
       createInfoItem('Source', formatCompileUnitSource(compileUnit)),
-      createGroupItem('Files', { group: 'files', compileUnit }),
-      createGroupItem('Include Dirs', { group: 'includeDirs', compileUnit }),
-      createGroupItem('Defines', { group: 'defines', compileUnit }),
+      createGroupItem('Files', 'files', compileUnit),
+      createGroupItem('Include Dirs', 'includeDirs', compileUnit),
+      createGroupItem('Defines', 'defines', compileUnit),
     ];
   }
 
-  private getCompileUnitGroupChildren(payload: CompileUnitGroupPayload): HdlExplorerItem[] {
+  private getCompileUnitGroupChildren(payload: Extract<HdlExplorerPayload, { kind: 'compileUnitGroup' }>): HdlExplorerItem[] {
     switch (payload.group) {
       case 'files':
         return payload.compileUnit.files.map(createFileItem);
       case 'includeDirs':
-        return payload.compileUnit.includeDirs.map((uri) => {
-          const item = createInfoItem(path.basename(uri.fsPath), uri.fsPath);
-          item.resourceUri = uri;
-          return item;
-        });
+        return payload.compileUnit.includeDirs.map(createIncludeDirItem);
       case 'defines':
         return Object.entries(payload.compileUnit.defines).map(([name, define]) => createDefineItem(name, define));
     }
@@ -183,7 +201,10 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
 }
 
 export function registerHdlExplorerCommands(
+  projectService: ProjectService,
   hierarchyService: HierarchyService,
+  instantiationService: InstantiationService,
+  referenceService: ReferenceService,
   provider: HdlExplorerProvider
 ): vscode.Disposable[] {
   return [
@@ -195,13 +216,120 @@ export function registerHdlExplorerCommands(
       await hierarchyService.rebuild('explorer-command');
       provider.refresh();
     }),
-    vscode.commands.registerCommand('verilog.openModuleFromExplorer', (location: vscode.Location) => openLocation(location)),
-    vscode.commands.registerCommand('verilog.openInstanceFromExplorer', (location: vscode.Location) => openLocation(location)),
+    vscode.commands.registerCommand('verilog.setActiveTargetFromExplorer', async (arg: unknown) => {
+      const compileUnit = getCompileUnitFromArg(arg);
+      if (!compileUnit) {
+        vscode.window.showWarningMessage('No HDL compile unit selected.');
+        return;
+      }
+      await setActiveTarget(projectService, hierarchyService, provider, compileUnit.id);
+      vscode.window.showInformationMessage(`Active HDL target set to ${compileUnit.id}`);
+    }),
+    vscode.commands.registerCommand('verilog.selectActiveTarget', async () => {
+      const snapshot = projectService.getSnapshot();
+      if (snapshot.compileUnits.length === 0) {
+        vscode.window.showWarningMessage('No HDL compile units are available.');
+        return;
+      }
+      const selected = await vscode.window.showQuickPick(buildActiveTargetQuickPickItems(snapshot.compileUnits), {
+        placeHolder: 'Select active HDL target',
+        matchOnDescription: true,
+        matchOnDetail: true,
+      });
+      if (!selected) {
+        return;
+      }
+      await setActiveTarget(projectService, hierarchyService, provider, selected.targetId);
+      vscode.window.showInformationMessage(
+        selected.targetId ? `Active HDL target set to ${selected.targetId}` : 'Active HDL target cleared.'
+      );
+    }),
+    vscode.commands.registerCommand('verilog.openModuleFromExplorer', (arg: unknown) => {
+      void openOptionalLocation(getModuleLocationFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.instantiateModuleFromExplorer', async (arg: unknown) => {
+      const moduleRecord = getModuleRecordFromArg(arg);
+      if (!moduleRecord) {
+        vscode.window.showWarningMessage('No resolved HDL module selected.');
+        return;
+      }
+      await instantiationService.instantiateModule(moduleRecord);
+    }),
+    vscode.commands.registerCommand('verilog.showHierarchyFromModule', (arg: unknown) => {
+      const moduleRecord = getModuleRecordFromArg(arg);
+      const moduleName = moduleRecord?.name ?? getHierarchyModuleNameFromArg(arg);
+      if (!moduleName) {
+        vscode.window.showWarningMessage('No HDL module selected.');
+        return;
+      }
+      provider.setHierarchyRootFilter(moduleName, moduleRecord?.compileUnitId);
+    }),
+    vscode.commands.registerCommand('verilog.clearHierarchyRootFilter', () => {
+      provider.clearHierarchyRootFilter();
+    }),
+    vscode.commands.registerCommand('verilog.findModuleReferencesFromExplorer', (arg: unknown) => {
+      void showModuleReferences(referenceService, getModuleRecordFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.openInstanceFromExplorer', (arg: unknown) => {
+      void openOptionalLocation(getInstanceLocationFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.openInstanceModuleFromExplorer', (arg: unknown) => {
+      void openOptionalLocation(getModuleLocationFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.findInstanceModuleReferencesFromExplorer', (arg: unknown) => {
+      void showModuleReferences(referenceService, getModuleRecordFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.searchUnresolvedModule', async (arg: unknown) => {
+      const moduleName = getModuleNameFromArg(arg);
+      if (!moduleName) {
+        vscode.window.showWarningMessage('No unresolved HDL module selected.');
+        return;
+      }
+      await vscode.commands.executeCommand('workbench.action.findInFiles', { query: moduleName });
+    }),
+    vscode.commands.registerCommand('verilog.copyModuleNameFromExplorer', async (arg: unknown) => {
+      await copyText(getModuleNameFromArg(arg), 'No HDL module name selected.', 'HDL module name copied.');
+    }),
+    vscode.commands.registerCommand('verilog.openFileFromExplorer', (arg: unknown) => {
+      void openOptionalUri(getUriFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.revealFileInOs', (arg: unknown) => {
+      void revealOptionalUri(getUriFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.revealIncludeDirInOs', (arg: unknown) => {
+      void revealOptionalUri(getUriFromArg(arg));
+    }),
+    vscode.commands.registerCommand('verilog.copyPathFromExplorer', async (arg: unknown) => {
+      await copyText(getUriFromArg(arg)?.fsPath, 'No HDL path selected.', 'HDL path copied.');
+    }),
+    vscode.commands.registerCommand('verilog.copyRelativePathFromExplorer', async (arg: unknown) => {
+      const uri = getUriFromArg(arg);
+      await copyText(uri ? getRelativePath(uri) : undefined, 'No HDL path selected.', 'HDL relative path copied.');
+    }),
+    vscode.commands.registerCommand('verilog.openCompileUnitSource', (arg: unknown) => {
+      void openOptionalUri(getCompileUnitFromArg(arg)?.source.uri);
+    }),
+    vscode.commands.registerCommand('verilog.copyDefineNameFromExplorer', async (arg: unknown) => {
+      await copyText(getDefineFromArg(arg)?.name, 'No HDL define selected.', 'HDL define name copied.');
+    }),
+    vscode.commands.registerCommand('verilog.copyDefineArgumentFromExplorer', async (arg: unknown) => {
+      const entry = getDefineFromArg(arg);
+      await copyText(entry ? formatDefineArgument(entry.name, entry.define) : undefined, 'No HDL define selected.', 'HDL define argument copied.');
+    }),
+    vscode.commands.registerCommand('verilog.openDefineLocationFromExplorer', (arg: unknown) => {
+      const location = getDefineFromArg(arg)?.define.location;
+      void openOptionalLocation(location, 'Selected HDL define does not have a source location.');
+    }),
   ];
 }
 
 function createRootSectionItem(label: string, section: RootSection): HdlExplorerItem {
-  return new HdlExplorerItem(label, 'section', vscode.TreeItemCollapsibleState.Expanded, { section });
+  return new HdlExplorerItem(
+    label,
+    section === 'project' ? 'hdlExplorer.projectRoot' : 'hdlExplorer.section',
+    vscode.TreeItemCollapsibleState.Expanded,
+    { kind: 'section', section }
+  );
 }
 
 async function openLocation(location: vscode.Location): Promise<void> {
@@ -209,6 +337,99 @@ async function openLocation(location: vscode.Location): Promise<void> {
   const editor = await vscode.window.showTextDocument(document);
   editor.revealRange(location.range, vscode.TextEditorRevealType.InCenter);
   editor.selection = new vscode.Selection(location.range.start, location.range.end);
+}
+
+async function openOptionalLocation(
+  location: vscode.Location | undefined,
+  missingMessage = 'Selected HDL item does not have a source location.'
+): Promise<void> {
+  if (!location) {
+    vscode.window.showWarningMessage(missingMessage);
+    return;
+  }
+  await openLocation(location);
+}
+
+async function openOptionalUri(uri: vscode.Uri | undefined): Promise<void> {
+  if (!uri) {
+    vscode.window.showWarningMessage('Selected HDL item does not have a file path.');
+    return;
+  }
+  try {
+    await vscode.workspace.fs.stat(uri);
+    await vscode.commands.executeCommand('vscode.open', uri);
+  } catch {
+    vscode.window.showWarningMessage(`HDL path does not exist: ${uri.fsPath}`);
+  }
+}
+
+async function revealOptionalUri(uri: vscode.Uri | undefined): Promise<void> {
+  if (!uri) {
+    vscode.window.showWarningMessage('Selected HDL item does not have a file path.');
+    return;
+  }
+  try {
+    await vscode.workspace.fs.stat(uri);
+    await vscode.commands.executeCommand('revealFileInOS', uri);
+  } catch {
+    vscode.window.showWarningMessage(`HDL path does not exist: ${uri.fsPath}`);
+  }
+}
+
+async function copyText(text: string | undefined, missingMessage: string, successMessage: string): Promise<void> {
+  if (!text) {
+    vscode.window.showWarningMessage(missingMessage);
+    return;
+  }
+  await vscode.env.clipboard.writeText(text);
+  vscode.window.showInformationMessage(successMessage);
+}
+
+async function setActiveTarget(
+  projectService: ProjectService,
+  hierarchyService: HierarchyService,
+  provider: HdlExplorerProvider,
+  targetId: string
+): Promise<void> {
+  const configTarget = vscode.workspace.workspaceFolders?.length
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
+  await vscode.workspace.getConfiguration('verilog.project').update('activeTarget', targetId, configTarget);
+  await projectService.reload('active-target-command');
+  await hierarchyService.rebuild('active-target-command');
+  provider.refresh();
+}
+
+async function showModuleReferences(
+  referenceService: ReferenceService,
+  moduleRecord: ModuleRecord | undefined
+): Promise<void> {
+  if (!moduleRecord) {
+    vscode.window.showWarningMessage('No resolved HDL module selected.');
+    return;
+  }
+  const document = await vscode.workspace.openTextDocument(moduleRecord.uri);
+  const tokenSource = new vscode.CancellationTokenSource();
+  try {
+    const locations = await referenceService.provideReferences(
+      document,
+      moduleRecord.selectionRange.start,
+      { includeDeclaration: true },
+      tokenSource.token
+    );
+    if (locations.length === 0) {
+      vscode.window.showInformationMessage(`No references found for ${moduleRecord.name}.`);
+      return;
+    }
+    await vscode.commands.executeCommand(
+      'editor.action.showReferences',
+      moduleRecord.uri,
+      moduleRecord.selectionRange.start,
+      locations
+    );
+  } finally {
+    tokenSource.dispose();
+  }
 }
 
 function isHdlExplorerEnabled(): boolean {
@@ -225,48 +446,187 @@ function formatCompileUnitSource(compileUnit: CompileUnit): string {
     : compileUnit.source.type;
 }
 
-function isSectionPayload(payload: unknown): payload is SectionPayload {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'section' in payload
-    && typeof (payload as SectionPayload).section === 'string';
+export function buildActiveTargetQuickPickItems(compileUnits: readonly CompileUnit[]): ActiveTargetQuickPickItem[] {
+  return [
+    {
+      label: '(auto / none)',
+      description: 'Use automatic target selection',
+      targetId: '',
+    },
+    ...compileUnits.map((compileUnit) => ({
+      label: compileUnit.name,
+      description: compileUnit.id,
+      detail: formatCompileUnitSource(compileUnit),
+      targetId: compileUnit.id,
+    })),
+  ];
 }
 
-function isCompileUnit(payload: unknown): payload is CompileUnit {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'files' in payload
-    && 'includeDirs' in payload
-    && 'defines' in payload;
+export function filterHierarchyRoots(
+  roots: readonly HierarchyNode[],
+  filter?: HierarchyRootFilter
+): HierarchyNode[] {
+  if (!filter) {
+    return roots.slice();
+  }
+  const matches: HierarchyNode[] = [];
+  for (const root of roots) {
+    collectMatchingHierarchyNodes(root, filter, matches);
+  }
+  return matches;
 }
 
-function isCompileUnitGroupPayload(payload: unknown): payload is CompileUnitGroupPayload {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'group' in payload
-    && 'compileUnit' in payload;
+function collectMatchingHierarchyNodes(
+  node: HierarchyNode,
+  filter: HierarchyRootFilter,
+  matches: HierarchyNode[]
+): void {
+  if (
+    node.moduleName === filter.moduleName
+    && (!filter.compileUnitId || node.module?.compileUnitId === filter.compileUnitId)
+  ) {
+    matches.push(node);
+  }
+  for (const instance of [...node.instances, ...node.unresolvedInstances]) {
+    if (instance.children) {
+      collectMatchingHierarchyNodes(instance.children, filter, matches);
+    }
+  }
 }
 
-function isCompileUnitsPayload(payload: unknown): payload is CompileUnitsPayload {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'group' in payload
-    && (payload as CompileUnitsPayload).group === 'compileUnits'
-    && 'compileUnits' in payload;
+export function getRelativePath(uri: vscode.Uri, workspaceRoot?: vscode.Uri): string {
+  const root = workspaceRoot ?? vscode.workspace.getWorkspaceFolder(uri)?.uri ?? vscode.workspace.workspaceFolders?.[0]?.uri;
+  if (!root) {
+    return uri.fsPath;
+  }
+  const relative = path.relative(root.fsPath, uri.fsPath);
+  return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
+    ? relative.split(path.sep).join('/')
+    : uri.fsPath;
 }
 
-function isHierarchyNode(payload: unknown): payload is HierarchyNode {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'moduleName' in payload
-    && 'instances' in payload
-    && 'unresolvedInstances' in payload;
+export function formatDefineArgument(name: string, define: MacroDefine): string {
+  return define.value === true ? `+define+${name}` : `+define+${name}=${define.value}`;
 }
 
-function isHierarchyInstance(payload: unknown): payload is HierarchyInstanceNode {
-  return typeof payload === 'object'
-    && payload !== null
-    && 'instanceName' in payload
-    && 'moduleName' in payload
-    && 'location' in payload;
+function getPayload(arg: unknown): HdlExplorerPayload | undefined {
+  if (arg instanceof HdlExplorerItem) {
+    return arg.payload;
+  }
+  if (typeof arg === 'object' && arg !== null && 'payload' in arg) {
+    return (arg as { payload?: HdlExplorerPayload }).payload;
+  }
+  return undefined;
+}
+
+function getCompileUnitFromArg(arg: unknown): CompileUnit | undefined {
+  const payload = getPayload(arg);
+  if (payload?.kind === 'compileUnit') {
+    return payload.compileUnit;
+  }
+  if (isCompileUnitLike(arg)) {
+    return arg;
+  }
+  return undefined;
+}
+
+function getUriFromArg(arg: unknown): vscode.Uri | undefined {
+  if (arg instanceof vscode.Uri) {
+    return arg;
+  }
+  if (arg instanceof vscode.Location) {
+    return arg.uri;
+  }
+  const payload = getPayload(arg);
+  switch (payload?.kind) {
+    case 'sourceFile':
+      return payload.file.uri;
+    case 'includeDir':
+      return payload.uri;
+    case 'compileUnit':
+      return payload.compileUnit.source.uri;
+    case 'symbol':
+      return payload.symbol.uri;
+    case 'hierarchyModule':
+      return payload.node.module?.uri;
+    case 'hierarchyInstance':
+      return payload.instance.location.uri;
+    default:
+      return undefined;
+  }
+}
+
+function getDefineFromArg(arg: unknown): { name: string; define: MacroDefine } | undefined {
+  const payload = getPayload(arg);
+  return payload?.kind === 'define' ? { name: payload.name, define: payload.define } : undefined;
+}
+
+function getModuleRecordFromArg(arg: unknown): ModuleRecord | undefined {
+  const payload = getPayload(arg);
+  if (payload?.kind === 'symbol' && isModuleRecordLike(payload.symbol)) {
+    return payload.symbol;
+  }
+  if (payload?.kind === 'hierarchyModule') {
+    return payload.node.module;
+  }
+  if (payload?.kind === 'hierarchyInstance') {
+    return payload.instance.resolvedModule;
+  }
+  return isModuleRecordLike(arg) ? arg : undefined;
+}
+
+function getHierarchyModuleNameFromArg(arg: unknown): string | undefined {
+  const payload = getPayload(arg);
+  if (payload?.kind === 'hierarchyModule') {
+    return payload.node.moduleName;
+  }
+  return undefined;
+}
+
+function getModuleNameFromArg(arg: unknown): string | undefined {
+  const payload = getPayload(arg);
+  switch (payload?.kind) {
+    case 'symbol':
+      return payload.symbol.name;
+    case 'hierarchyModule':
+      return payload.node.moduleName;
+    case 'hierarchyInstance':
+      return payload.instance.moduleName;
+    default:
+      return isModuleRecordLike(arg) ? arg.name : undefined;
+  }
+}
+
+function getModuleLocationFromArg(arg: unknown): vscode.Location | undefined {
+  if (arg instanceof vscode.Location) {
+    return arg;
+  }
+  const moduleRecord = getModuleRecordFromArg(arg);
+  return moduleRecord ? new vscode.Location(moduleRecord.uri, moduleRecord.selectionRange) : undefined;
+}
+
+function getInstanceLocationFromArg(arg: unknown): vscode.Location | undefined {
+  if (arg instanceof vscode.Location) {
+    return arg;
+  }
+  const payload = getPayload(arg);
+  return payload?.kind === 'hierarchyInstance' ? payload.instance.location : undefined;
+}
+
+function isCompileUnitLike(value: unknown): value is CompileUnit {
+  return typeof value === 'object'
+    && value !== null
+    && 'id' in value
+    && 'files' in value
+    && 'includeDirs' in value
+    && 'defines' in value;
+}
+
+function isModuleRecordLike(value: unknown): value is ModuleRecord {
+  return typeof value === 'object'
+    && value !== null
+    && 'kind' in value
+    && (value as { kind?: unknown }).kind === 'module'
+    && 'uri' in value
+    && 'selectionRange' in value;
 }


### PR DESCRIPTION
## Summary
- Add stable HDL Explorer context values and discriminated item payloads for targeted context menus.
- Add active target, module, hierarchy, instance, unresolved-module, file/path, include-dir, and define actions from HDL Explorer.
- Wire new commands and view menus in `package.json`, update README, and extend coverage for explorer helpers and command registration.

## Validation
- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile`
- `npm test` with VS Code test access: 340 passing, 6 pending