### PR TITLE
Make project indexing opt-in by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ Install it from [VS Code Marketplace](https://marketplace.visualstudio.com/items
 
 ### Project-Aware HDL Features
 
-The extension can build a lightweight project model for Verilog/SystemVerilog workspaces. Configure filelists with `verilog.project.filelists`, or leave that setting empty to let the extension discover `*.v`, `*.vh`, `*.sv`, and `*.svh` files in the workspace. Project-level include directories and defines can be configured with `verilog.project.includeDirs` and `verilog.project.defines`.
+The extension can build a lightweight project model for Verilog/SystemVerilog workspaces when `verilog.project.enabled` is enabled. Users who only need formatting or syntax highlighting do not need project indexing. Configure filelists with `verilog.project.filelists`, or leave that setting empty to let the extension discover `*.v`, `*.vh`, `*.sv`, and `*.svh` files in the workspace. Project-level include directories and defines can be configured with `verilog.project.includeDirs` and `verilog.project.defines`.
 
 The project model powers cross-file module lookup, include resolution, workspace symbols, hover, completion, module instantiation, HDL Explorer, and compile-unit linting. Existing Ctags behavior remains available as a fallback when the project index has no answer or the project model is disabled with `verilog.project.enabled`.
+
+Large workspaces should either keep `"verilog.project.enabled": false`, configure explicit `verilog.project.filelists`, narrow indexing with `verilog.project.exclude`, or raise `verilog.project.maxAutoDiscoveredFiles` after confirming automatic discovery is acceptable.
 
 Use **Verilog: Reload Project**, **Verilog: Show Project Status**, and **Verilog: Show Project Modules** to inspect or refresh the current project model.
 

--- a/package.json
+++ b/package.json
@@ -739,8 +739,8 @@
           "verilog.project.enabled": {
             "scope": "window",
             "type": "boolean",
-            "default": true,
-            "markdownDescription": "Enable project-aware Verilog/SystemVerilog model."
+            "default": false,
+            "markdownDescription": "Opt in to the project-aware Verilog/SystemVerilog model and semantic index. This can be expensive in large workspaces; users who only need formatting or syntax highlighting can leave it disabled."
           },
           "verilog.project.filelists": {
             "scope": "window",
@@ -794,6 +794,13 @@
               "**/sim/**"
             ],
             "markdownDescription": "Glob patterns excluded from project indexing."
+          },
+          "verilog.project.maxAutoDiscoveredFiles": {
+            "scope": "window",
+            "type": "number",
+            "default": 5000,
+            "minimum": 1,
+            "markdownDescription": "Maximum number of HDL files discovered automatically when `verilog.project.filelists` is empty. If the limit is exceeded, project indexing is skipped. Configure `verilog.project.filelists` or `verilog.project.exclude` for large workspaces."
           }
         }
       },

--- a/src/project/ProjectLoader.ts
+++ b/src/project/ProjectLoader.ts
@@ -112,10 +112,24 @@ export class ProjectLoader {
     diagnostics: ProjectDiagnostic[]
   ): Promise<CompileUnit[]> {
     const exclude = settings.exclude.length > 0 ? `{${settings.exclude.join(',')}}` : undefined;
+    const maxFiles = settings.maxAutoDiscoveredFiles;
     const files = await vscode.workspace.findFiles(
       new vscode.RelativePattern(workspaceRoot, '**/*.{v,vh,sv,svh}'),
-      exclude
+      exclude,
+      maxFiles + 1
     );
+    if (files.length > maxFiles) {
+      diagnostics.push({
+        severity: 'warning',
+        message:
+          `Project auto-discovery found more than ${maxFiles} HDL files. `
+          + 'Project indexing was skipped. Configure verilog.project.filelists, '
+          + 'increase verilog.project.maxAutoDiscoveredFiles, or adjust verilog.project.exclude.',
+        source: PROJECT_DIAGNOSTIC_SOURCE,
+        code: 'auto-discovery-file-limit-exceeded',
+      });
+      return [];
+    }
     diagnostics.push({
       severity: 'info',
       message: `No project filelists configured; discovered ${files.length} HDL files.`,

--- a/src/project/ProjectWatcher.ts
+++ b/src/project/ProjectWatcher.ts
@@ -1,28 +1,41 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
 import type { ProjectService } from './ProjectService';
+import { SettingsProjectSourceProvider } from './providers/SettingsProjectSourceProvider';
 
 export interface ProjectWatcherOptions {
   debounceMs?: number;
   watch?: boolean;
+  createFileSystemWatcher?: typeof vscode.workspace.createFileSystemWatcher;
+  onDidChangeConfiguration?: typeof vscode.workspace.onDidChangeConfiguration;
+  settingsProvider?: Pick<SettingsProjectSourceProvider, 'getSettings'>;
 }
 
 export class ProjectWatcher implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
+  private readonly filelistWatcherDisposables: vscode.Disposable[] = [];
   private reloadTimer: NodeJS.Timeout | undefined;
   private filelistWatcher: vscode.FileSystemWatcher | undefined;
   private readonly debounceMs: number;
+  private readonly createFileSystemWatcher: typeof vscode.workspace.createFileSystemWatcher;
+  private readonly onDidChangeConfiguration: typeof vscode.workspace.onDidChangeConfiguration;
+  private readonly settingsProvider: Pick<SettingsProjectSourceProvider, 'getSettings'>;
 
   constructor(
     private readonly projectService: ProjectService,
     options: ProjectWatcherOptions = {}
   ) {
     this.debounceMs = options.debounceMs ?? 300;
+    this.createFileSystemWatcher = options.createFileSystemWatcher
+      ?? vscode.workspace.createFileSystemWatcher.bind(vscode.workspace);
+    this.onDidChangeConfiguration = options.onDidChangeConfiguration
+      ?? vscode.workspace.onDidChangeConfiguration.bind(vscode.workspace);
+    this.settingsProvider = options.settingsProvider ?? new SettingsProjectSourceProvider();
     if (options.watch === false) {
       return;
     }
     this.disposables.push(
-      vscode.workspace.onDidChangeConfiguration((event) => {
+      this.onDidChangeConfiguration((event) => {
         if (!event.affectsConfiguration('verilog.project')) {
           return;
         }
@@ -48,18 +61,35 @@ export class ProjectWatcher implements vscode.Disposable {
       clearTimeout(this.reloadTimer);
       this.reloadTimer = undefined;
     }
-    this.filelistWatcher?.dispose();
+    this.disposeFilelistWatcher();
     for (const disposable of this.disposables) {
       disposable.dispose();
     }
   }
 
   private refreshFilelistWatcher(): void {
-    this.filelistWatcher?.dispose();
-    this.filelistWatcher = vscode.workspace.createFileSystemWatcher('**/*.{f,F}');
-    this.disposables.push(this.filelistWatcher);
-    this.filelistWatcher.onDidCreate(() => this.scheduleReload('filelist created'), undefined, this.disposables);
-    this.filelistWatcher.onDidChange(() => this.scheduleReload('filelist changed'), undefined, this.disposables);
-    this.filelistWatcher.onDidDelete(() => this.scheduleReload('filelist deleted'), undefined, this.disposables);
+    this.disposeFilelistWatcher();
+    if (!this.isProjectEnabled()) {
+      return;
+    }
+
+    this.filelistWatcher = this.createFileSystemWatcher('**/*.{f,F}');
+    this.filelistWatcherDisposables.push(this.filelistWatcher);
+    this.filelistWatcherDisposables.push(
+      this.filelistWatcher.onDidCreate(() => this.scheduleReload('filelist created')),
+      this.filelistWatcher.onDidChange(() => this.scheduleReload('filelist changed')),
+      this.filelistWatcher.onDidDelete(() => this.scheduleReload('filelist deleted'))
+    );
+  }
+
+  private disposeFilelistWatcher(): void {
+    while (this.filelistWatcherDisposables.length > 0) {
+      this.filelistWatcherDisposables.pop()?.dispose();
+    }
+    this.filelistWatcher = undefined;
+  }
+
+  private isProjectEnabled(): boolean {
+    return this.settingsProvider.getSettings().enabled;
   }
 }

--- a/src/project/providers/SettingsProjectSourceProvider.ts
+++ b/src/project/providers/SettingsProjectSourceProvider.ts
@@ -9,24 +9,30 @@ export interface ProjectSettings {
   includeDirs: string[];
   defines: Record<string, string | boolean | number>;
   exclude: string[];
+  maxAutoDiscoveredFiles: number;
 }
 
 export class SettingsProjectSourceProvider {
   getSettings(): ProjectSettings {
     const config = vscode.workspace.getConfiguration('verilog.project');
-    return {
-      enabled: config.get<boolean>('enabled', true),
-      filelists: config.get<string[]>('filelists', []),
-      activeTarget: config.get<string>('activeTarget', ''),
-      topModules: config.get<string[]>('topModules', []),
-      includeDirs: config.get<string[]>('includeDirs', []),
-      defines: config.get<Record<string, string | boolean | number>>('defines', {}),
-      exclude: config.get<string[]>('exclude', [
-        '**/.git/**',
-        '**/node_modules/**',
-        '**/build/**',
-        '**/sim/**',
-      ]),
-    };
+    return readProjectSettings(config);
   }
+}
+
+export function readProjectSettings(config: Pick<vscode.WorkspaceConfiguration, 'get'>): ProjectSettings {
+  return {
+    enabled: config.get<boolean>('enabled', false),
+    filelists: config.get<string[]>('filelists', []),
+    activeTarget: config.get<string>('activeTarget', ''),
+    topModules: config.get<string[]>('topModules', []),
+    includeDirs: config.get<string[]>('includeDirs', []),
+    defines: config.get<Record<string, string | boolean | number>>('defines', {}),
+    exclude: config.get<string[]>('exclude', [
+      '**/.git/**',
+      '**/node_modules/**',
+      '**/build/**',
+      '**/sim/**',
+    ]),
+    maxAutoDiscoveredFiles: Math.max(1, config.get<number>('maxAutoDiscoveredFiles', 5000)),
+  };
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -160,13 +160,16 @@ suite('Extension Test Suite', () => {
       ...packageJson.contributes.configuration.map((configuration) => configuration.properties)
     ) as Record<string, unknown>;
 
-    assert.ok(properties['verilog.project.enabled']);
+    const projectEnabled = properties['verilog.project.enabled'] as { default?: unknown };
+    assert.ok(projectEnabled);
+    assert.strictEqual(projectEnabled.default, false);
     assert.ok(properties['verilog.project.filelists']);
     assert.ok(properties['verilog.project.activeTarget']);
     assert.ok(properties['verilog.project.topModules']);
     assert.ok(properties['verilog.project.includeDirs']);
     assert.ok(properties['verilog.project.defines']);
     assert.ok(properties['verilog.project.exclude']);
+    assert.ok(properties['verilog.project.maxAutoDiscoveredFiles']);
     assert.ok(properties['verilog.hierarchy.enabled']);
     assert.ok(properties['verilog.hierarchy.maxDepth']);
     assert.ok(properties['verilog.hierarchy.showUnresolved']);

--- a/src/test/filelistProject.test.ts
+++ b/src/test/filelistProject.test.ts
@@ -194,6 +194,7 @@ suite('ProjectLoader', () => {
       includeDirs: [],
       defines: {},
       exclude: ['**/.git/**', '**/node_modules/**', '**/build/**'],
+      maxAutoDiscoveredFiles: 5000,
     };
     const loader = new ProjectLoader(
       { getSettings: () => settings },

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -14,7 +14,7 @@ import { ProjectWatcher } from '../project/ProjectWatcher';
 import { buildCompileUnit } from '../project/ProjectModelMerger';
 import { renderProjectStatus } from '../project/ProjectCommands';
 import type { ProjectSnapshot } from '../project/ProjectTypes';
-import type { ProjectSettings } from '../project/providers/SettingsProjectSourceProvider';
+import { readProjectSettings, type ProjectSettings } from '../project/providers/SettingsProjectSourceProvider';
 import { FastIndexerBackend } from '../semantic/backends/FastIndexerBackend';
 import { IndexService } from '../semantic/IndexService';
 import { SemanticIndex } from '../semantic/SemanticIndex';
@@ -73,6 +73,42 @@ suite('Minimal IDE Model Stabilization', () => {
 
       assert.strictEqual(snapshot.compileUnits.length, 0);
       assert.ok(snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'project-disabled'));
+    });
+
+    test('SettingsProjectSourceProvider defaults project indexing to disabled', () => {
+      const projectSettings = readProjectSettings({
+        get: <T>(_section: string, defaultValue: T): T => defaultValue,
+      } as Pick<vscode.WorkspaceConfiguration, 'get'>);
+
+      assert.strictEqual(projectSettings.enabled, false);
+      assert.strictEqual(projectSettings.maxAutoDiscoveredFiles, 5000);
+    });
+
+    test('auto-discovery skips indexing when file count exceeds the configured limit', async function () {
+      this.timeout(10000);
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-autodiscovery-limit-'));
+      fs.writeFileSync(path.join(root, 'top.sv'), 'module top; endmodule\n');
+      fs.writeFileSync(path.join(root, 'child.sv'), 'module child; endmodule\n');
+
+      const snapshot = await loadFixture(root, settings({ maxAutoDiscoveredFiles: 1 }));
+
+      assert.strictEqual(snapshot.compileUnits.length, 0);
+      assert.ok(
+        snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'auto-discovery-file-limit-exceeded')
+      );
+    });
+
+    test('auto-discovery still creates fallback compile unit under the configured limit', async function () {
+      this.timeout(10000);
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-autodiscovery-small-'));
+      fs.writeFileSync(path.join(root, 'top.sv'), 'module top; endmodule\n');
+      fs.writeFileSync(path.join(root, 'child.sv'), 'module child; endmodule\n');
+
+      const snapshot = await loadFixture(root, settings({ maxAutoDiscoveredFiles: 2 }));
+
+      assert.strictEqual(snapshot.compileUnits[0]?.id, 'auto:workspace');
+      assert.strictEqual(snapshot.compileUnits[0]?.files.length, 2);
+      assert.ok(snapshot.diagnostics.some((diagnostic) => diagnostic.code === 'fallback-discovery'));
     });
 
     test('returns preferred file context by active target and no context for unrelated files', async () => {
@@ -268,6 +304,60 @@ suite('Minimal IDE Model Stabilization', () => {
       watcher.dispose();
     });
 
+    test('ProjectWatcher creates filelist watcher only while project indexing is enabled', () => {
+      let enabled = false;
+      let watchersCreated = 0;
+      let watchersDisposed = 0;
+      let watcherEventDisposablesDisposed = 0;
+      let configListener: ((event: vscode.ConfigurationChangeEvent) => void) | undefined;
+      const watcher = new ProjectWatcher({
+        reload: async () => createSnapshot('/workspace', []),
+      } as unknown as ProjectService, {
+        createFileSystemWatcher: (() => {
+          watchersCreated += 1;
+          const event: vscode.Event<vscode.Uri> = (_listener, _thisArgs, _disposables) => ({
+            dispose: () => {
+              watcherEventDisposablesDisposed += 1;
+            },
+          });
+          return {
+            ignoreCreateEvents: false,
+            ignoreChangeEvents: false,
+            ignoreDeleteEvents: false,
+            onDidCreate: event,
+            onDidChange: event,
+            onDidDelete: event,
+            dispose: () => {
+              watchersDisposed += 1;
+            },
+          };
+        }) as typeof vscode.workspace.createFileSystemWatcher,
+        onDidChangeConfiguration: ((listener) => {
+          configListener = listener;
+          return { dispose: () => undefined };
+        }) as typeof vscode.workspace.onDidChangeConfiguration,
+        settingsProvider: {
+          getSettings: () => settings({ enabled }),
+        },
+      });
+
+      assert.strictEqual(watchersCreated, 0);
+
+      enabled = true;
+      configListener?.(projectConfigurationChangeEvent());
+      assert.strictEqual(watchersCreated, 1);
+      assert.strictEqual(watchersDisposed, 0);
+
+      enabled = false;
+      configListener?.(projectConfigurationChangeEvent());
+      assert.strictEqual(watchersCreated, 1);
+      assert.strictEqual(watchersDisposed, 1);
+      assert.strictEqual(watcherEventDisposablesDisposed, 3);
+
+      watcher.dispose();
+      assert.strictEqual(watchersDisposed, 1);
+    });
+
     test('auto-discovery excludes large ignored directories before indexing', async function () {
       this.timeout(10000);
       const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-large-workspace-'));
@@ -300,6 +390,7 @@ function settings(overrides: Partial<ProjectSettings> = {}): ProjectSettings {
     includeDirs: [],
     defines: {},
     exclude: ['**/.git/**', '**/node_modules/**', '**/build/**', '**/sim/**'],
+    maxAutoDiscoveredFiles: 5000,
     ...overrides,
   };
 }
@@ -372,4 +463,10 @@ function createSnapshot(workspaceRoot: string, symbols: SymbolRecord[]): Project
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function projectConfigurationChangeEvent(): vscode.ConfigurationChangeEvent {
+  return {
+    affectsConfiguration: (section: string) => section === 'verilog.project',
+  };
 }


### PR DESCRIPTION
## Summary

- Make project indexing opt-in by default so formatter and syntax users do not trigger workspace indexing on activation.
- Add `verilog.project.maxAutoDiscoveredFiles` to cap fallback auto-discovery when no filelists are configured.
- Avoid creating or accumulating filelist watchers while project indexing is disabled.
- Update README and focused tests for the hotfix behavior.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile`
- `npm test` after cleaning stale untracked generated `out/` test files: 280 passing, 3 pending

## Notes

The package version bumps in `package.json` and `package-lock.json`, plus the local `CHANGELOG.md` edit, were intentionally left out of this commit per request.