### PR TITLE
[codex] Add slang-server language server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ We currently support the following language servers. You can enable multiple lan
 | -------------------------------------------------------------- | ------------------ |
 | [svls](https://github.com/dalance/svls)                        | SystemVerilog |
 | [veridian](https://github.com/vivekmalneedi/veridian)          | SystemVerilog |
+| [slang-server](https://github.com/hudson-trading/slang-server) | SystemVerilog |
 | [HDL Checker](https://github.com/suoto/hdl_checker)            | Verilog-HDL, SystemVerilog, VHDL |
 | [verible-verilog-ls](https://github.com/chipsalliance/verible) | Verilog-HDL, SystemVerilog |
 | [vhdl_ls](https://github.com/VHDL-LS/rust_hdl)                 | VHDL |
@@ -268,10 +269,13 @@ Enable only the language servers you need. For example:
 
 ```json
 {
+    "verilog.languageServer.slangServer.enabled": true,
     "verilog.languageServer.veribleVerilogLs.enabled": true,
     "verilog.languageServer.tclsp.enabled": true
 }
 ```
+
+Install [slang-server](https://github.com/hudson-trading/slang-server) and enable `verilog.languageServer.slangServer.enabled` when you want Slang-backed SystemVerilog language intelligence.
 
 Install [svls](https://github.com/dalance/svls) via `cargo`:
 

--- a/package.json
+++ b/package.json
@@ -624,6 +624,24 @@
             "default": "",
             "markdownDescription": "Add custom arguments for the HDL Checker Veridian Language Server."
           },
+          "verilog.languageServer.slangServer.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable slang-server Language Server for SystemVerilog."
+          },
+          "verilog.languageServer.slangServer.path": {
+            "scope": "window",
+            "type": "string",
+            "default": "slang-server",
+            "markdownDescription": "A path to the slang-server Language Server binary."
+          },
+          "verilog.languageServer.slangServer.arguments": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Add custom arguments for the slang-server Language Server."
+          },
           "verilog.languageServer.hdlChecker.enabled": {
             "scope": "window",
             "type": "boolean",

--- a/src/commands/Doctor.ts
+++ b/src/commands/Doctor.ts
@@ -110,6 +110,7 @@ const linterVersionArgs = new Map<string, string[]>([
 const languageServerLabels: Record<string, string> = {
   svls: 'svls',
   veridian: 'veridian',
+  slangServer: 'slang-server',
   hdlChecker: 'hdlChecker',
   veribleVerilogLs: 'verible-verilog-ls',
   tclsp: 'tclsp',

--- a/src/languageServer/definitions.ts
+++ b/src/languageServer/definitions.ts
@@ -43,6 +43,15 @@ export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
       }),
     },
     {
+      name: 'slangServer',
+      defaultPath: 'slang-server',
+      serverArgs: [],
+      serverDebugArgs: [],
+      buildClientOptions: () => ({
+        documentSelector: [{ scheme: 'file', language: 'systemverilog' }],
+      }),
+    },
+    {
       name: 'hdlChecker',
       defaultPath: 'hdl_checker',
       serverArgs: ['--lsp'],

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -3,8 +3,10 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import which = require('which');
 import {
   buildFormatterChecks,
+  createDefaultDoctorDependencies,
   buildLanguageServerConflictChecks,
   buildLanguageServerChecks,
   buildLinterChecks,
@@ -200,6 +202,34 @@ suite('Doctor', () => {
     assert.ok(
       checks.some(
         (check) => check.status === 'ok' && check.message.includes('verible-verilog-ls 1.0')
+      )
+    );
+  });
+
+  test('installed slang-server version probe works when available', async function () {
+    const slangServerPath = process.env.SLANG_SERVER_PATH || which.sync('slang-server', { nothrow: true });
+    if (!slangServerPath) {
+      this.skip();
+    }
+
+    const checks = await buildLanguageServerChecks(
+      {
+        name: 'slang-server',
+        enabled: true,
+        path: slangServerPath,
+        arguments: '',
+      },
+      createDefaultDoctorDependencies()
+    );
+
+    assert.ok(
+      checks.some(
+        (check) => check.status === 'ok' && check.message.includes('slang-server binary')
+      )
+    );
+    assert.ok(
+      checks.some(
+        (check) => check.status === 'ok' && check.message.includes('slang-server version')
       )
     );
   });

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -11,6 +11,7 @@ suite('Language Server smoke', () => {
     const expected = [
       'hdlChecker',
       'rustHdl',
+      'slangServer',
       'svls',
       'tclsp',
       'veribleVerilogLs',
@@ -29,6 +30,17 @@ suite('Language Server smoke', () => {
         `Expected documentSelector for ${definition.name}`
       );
     }
+  });
+
+  test('slang-server handles SystemVerilog documents', () => {
+    const definition = createLanguageServerDefinitions().find(
+      (server) => server.name === 'slangServer'
+    );
+    assert.ok(definition);
+
+    const selector = definition.buildClientOptions().documentSelector;
+
+    assert.deepStrictEqual(selector, [{ scheme: 'file', language: 'systemverilog' }]);
   });
 
   test('initializes and stops without enabled servers', async () => {


### PR DESCRIPTION
## Summary

- Add `slang-server` as an optional SystemVerilog language server.
- Expose `verilog.languageServer.slangServer.*` settings in the extension manifest.
- Include slang-server in Doctor checks and README language-server documentation.
- Add smoke coverage plus an optional real-binary Doctor probe via `SLANG_SERVER_PATH` or PATH.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `SLANG_SERVER_PATH=/Users/mshr/.local/bin/slang-server npm test` (`337 passing`, `3 pending`)

## Notes

The integration is scoped to SystemVerilog to match slang-server's upstream positioning.