### PR TITLE
Fix slang-server initialization compatibility

### DIFF
--- a/.github/actions/setup-slang-server/action.yml
+++ b/.github/actions/setup-slang-server/action.yml
@@ -1,0 +1,91 @@
+name: Setup slang-server
+description: Install a pinned slang-server release and expose it on PATH.
+
+inputs:
+  version:
+    description: slang-server release tag to install.
+    default: v0.2.7
+    required: false
+  asset:
+    description: slang-server release asset to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache slang-server
+      id: cache-slang-server
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}
+        key: ${{ runner.os }}-slang-server-${{ inputs.version }}-${{ inputs.asset }}
+
+    - name: Install slang-server (Unix)
+      if: runner.os != 'Windows' && steps.cache-slang-server.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euxo pipefail
+        install_dir="$HOME/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        archive="$RUNNER_TEMP/${{ inputs.asset }}"
+        curl -fsSL --retry 3 --retry-delay 5 \
+          -o "$archive" \
+          "https://github.com/hudson-trading/slang-server/releases/download/${{ inputs.version }}/${{ inputs.asset }}"
+        rm -rf "$install_dir"
+        mkdir -p "$install_dir"
+        tar -xzf "$archive" -C "$install_dir"
+
+    - name: Install slang-server (Windows)
+      if: runner.os == 'Windows' && steps.cache-slang-server.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        $archive = Join-Path $env:RUNNER_TEMP "${{ inputs.asset }}"
+        curl.exe -fsSL --retry 3 --retry-delay 5 `
+          -o $archive `
+          "https://github.com/hudson-trading/slang-server/releases/download/${{ inputs.version }}/${{ inputs.asset }}"
+        if (Test-Path $installDir) {
+          Remove-Item -Recurse -Force $installDir
+        }
+        New-Item -ItemType Directory -Force $installDir | Out-Null
+        Expand-Archive -LiteralPath $archive -DestinationPath $installDir
+
+    - name: Export slang-server path (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euxo pipefail
+        install_dir="$HOME/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        server_path="$(find "$install_dir" -type f -name slang-server -perm -u+x | head -n 1)"
+        if [ -z "$server_path" ]; then
+          server_path="$(find "$install_dir" -type f -name slang-server | head -n 1)"
+        fi
+        if [ -z "$server_path" ]; then
+          echo "Could not find slang-server in $install_dir" >&2
+          exit 1
+        fi
+        chmod +x "$server_path"
+        dirname "$server_path" >> "$GITHUB_PATH"
+        echo "SLANG_SERVER_PATH=$server_path" >> "$GITHUB_ENV"
+
+    - name: Export slang-server path (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        $serverPath = Get-ChildItem -LiteralPath $installDir -Recurse -File -Filter "slang-server.exe" |
+          Select-Object -First 1 -ExpandProperty FullName
+        if (-not $serverPath) {
+          throw "Could not find slang-server.exe in $installDir"
+        }
+        Split-Path -Parent $serverPath | Out-File -FilePath $env:GITHUB_PATH -Append
+        "SLANG_SERVER_PATH=$serverPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Verify slang-server (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: '"$SLANG_SERVER_PATH" --version'
+
+    - name: Verify slang-server (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: '& $env:SLANG_SERVER_PATH --version'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,20 @@ jobs:
           - os: macos-latest
             slang_asset: slang-macos-arm64.tar.gz
             slang_sha256: 6d2f86ffedfefe663c6f55fd77348806faafccd69e71f7359986b0c9604f9187
+            slang_server_asset: slang-server-macos.tar.gz
           - os: ubuntu-latest
             slang_asset: slang-linux-x86_64.tar.gz
             slang_sha256: 951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4
+            slang_server_asset: slang-server-linux-x64.tar.gz
           - os: windows-latest
             slang_asset: slang-windows-x86_64.zip
             slang_sha256: 23d0a3d052cf88da13acc8b73161d77e3242ffbc630bb0577a3ccda0e4e39d81
+            slang_server_asset: slang-server-windows-x64.zip
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       SLANG_VERSION: v11.0
+      SLANG_SERVER_VERSION: v0.2.7
       VERIBLE_VERSION: v0.0-4071-g8d9f2c97
       VERIBLE_SHA256: bfa43258d9132797ec9dca2a624395bb83967e18b888803c022d1c9a889203b6
     steps:
@@ -33,6 +37,11 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Setup slang-server
+        uses: ./.github/actions/setup-slang-server
+        with:
+          version: ${{ env.SLANG_SERVER_VERSION }}
+          asset: ${{ matrix.slang_server_asset }}
       - name: Cache slang
         id: cache-slang
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Setup slang-server
+        uses: ./.github/actions/setup-slang-server
+        with:
+          version: v0.2.7
+          asset: slang-server-linux-x64.tar.gz
       - name: Cache Cargo installs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/src/languageServer/definitions.ts
+++ b/src/languageServer/definitions.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { LanguageClientOptions, Message } from 'vscode-languageclient/node';
+import { Message, type InitializeParams, type LanguageClientOptions } from 'vscode-languageclient/node';
 
+import { sanitizeSlangServerInitializeParams } from './slangServerCompatibility';
 import { buildTclspInitializationOptions } from './tclspOptions';
 
 export type LanguageServerDefinition = {
@@ -11,6 +12,7 @@ export type LanguageServerDefinition = {
   serverDebugArgs: string[];
   buildClientOptions: () => LanguageClientOptions;
   applyProcessEnv?: () => void;
+  sanitizeInitializeParams?: (params: InitializeParams) => void;
 };
 
 export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
@@ -50,6 +52,7 @@ export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
       buildClientOptions: () => ({
         documentSelector: [{ scheme: 'file', language: 'systemverilog' }],
       }),
+      sanitizeInitializeParams: sanitizeSlangServerInitializeParams,
     },
     {
       name: 'hdlChecker',

--- a/src/languageServer/manager.ts
+++ b/src/languageServer/manager.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import {
+  LanguageClient,
+  type InitializeParams,
+  type LanguageClientOptions,
+  type ServerOptions,
+} from 'vscode-languageclient/node';
 import { getExtensionLogger } from '../logging';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import { LanguageServerDefinition } from './definitions';
@@ -22,6 +27,23 @@ export function buildServerOptions(input: BuildServerOptionsInput): BuiltServerO
     run: { command: input.command, args: input.definition.serverArgs.concat(customArgs) },
     debug: { command: input.command, args: input.definition.serverDebugArgs.concat(customArgs) },
   };
+}
+
+class SanitizingLanguageClient extends LanguageClient {
+  constructor(
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+    private readonly sanitizeInitializeParams: (params: InitializeParams) => void
+  ) {
+    super(id, name, serverOptions, clientOptions);
+  }
+
+  protected fillInitializeParams(params: InitializeParams): void {
+    super.fillInitializeParams(params);
+    this.sanitizeInitializeParams(params);
+  }
 }
 
 export class LanguageServerManager {
@@ -58,12 +80,7 @@ export class LanguageServerManager {
 
     const serverOptions = buildServerOptions({ definition, command: binPath, customArgs });
 
-    const client = new LanguageClient(
-      definition.name,
-      `${definition.name  } language server`,
-      serverOptions,
-      definition.buildClientOptions()
-    );
+    const client = createLanguageClient(definition, serverOptions);
     this.languageClients.set(definition.name, client);
 
     if (!enabled) {
@@ -77,4 +94,22 @@ export class LanguageServerManager {
     client.start();
     this.logger.info`"${definition.name}" language server started.`;
   }
+}
+
+function createLanguageClient(
+  definition: LanguageServerDefinition,
+  serverOptions: ServerOptions
+): LanguageClient {
+  const name = `${definition.name  } language server`;
+  const clientOptions = definition.buildClientOptions();
+  if (definition.sanitizeInitializeParams) {
+    return new SanitizingLanguageClient(
+      definition.name,
+      name,
+      serverOptions,
+      clientOptions,
+      definition.sanitizeInitializeParams
+    );
+  }
+  return new LanguageClient(definition.name, name, serverOptions, clientOptions);
 }

--- a/src/languageServer/slangServerCompatibility.ts
+++ b/src/languageServer/slangServerCompatibility.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+import type { InitializeParams } from 'vscode-languageclient/node';
+
+const UNSUPPORTED_SLANG_SERVER_CODE_ACTION_KIND = 'refactor.move';
+
+export function sanitizeSlangServerInitializeParams(params: InitializeParams): void {
+  const capabilities = asRecord(params.capabilities);
+  const textDocument = asRecord(capabilities?.textDocument);
+  const codeAction = asRecord(textDocument?.codeAction);
+  const literalSupport = asRecord(codeAction?.codeActionLiteralSupport);
+  const codeActionKind = asRecord(literalSupport?.codeActionKind);
+  if (!codeActionKind || !Array.isArray(codeActionKind.valueSet)) {
+    return;
+  }
+
+  codeActionKind.valueSet = codeActionKind.valueSet.filter(
+    (value) => value !== UNSUPPORTED_SLANG_SERVER_CODE_ACTION_KIND
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
+import type { InitializeParams } from 'vscode-languageclient/node';
 
 import { createLanguageServerDefinitions } from '../languageServer/definitions';
 import { initAllLanguageClients, stopAllLanguageClients } from '../languageServer';
 import { buildServerOptions } from '../languageServer/manager';
+import { sanitizeSlangServerInitializeParams } from '../languageServer/slangServerCompatibility';
 
 suite('Language Server smoke', () => {
   test('defines expected servers', () => {
@@ -41,6 +43,62 @@ suite('Language Server smoke', () => {
     const selector = definition.buildClientOptions().documentSelector;
 
     assert.deepStrictEqual(selector, [{ scheme: 'file', language: 'systemverilog' }]);
+  });
+
+  test('only slang-server has an initialize params sanitizer', () => {
+    const definitions = createLanguageServerDefinitions();
+    const slangServer = definitions.find((server) => server.name === 'slangServer');
+
+    assert.strictEqual(typeof slangServer?.sanitizeInitializeParams, 'function');
+    assert.ok(
+      definitions
+        .filter((server) => server.name !== 'slangServer')
+        .every((server) => server.sanitizeInitializeParams === undefined)
+    );
+  });
+
+  test('slang-server sanitizer removes unsupported refactor.move code action kind', () => {
+    const params = initializeParamsWithCodeActionKinds([
+      '',
+      'quickfix',
+      'refactor.move',
+      'refactor.extract',
+      'source',
+    ]);
+
+    sanitizeSlangServerInitializeParams(params);
+
+    assert.deepStrictEqual(getCodeActionKindValueSet(params), [
+      '',
+      'quickfix',
+      'refactor.extract',
+      'source',
+    ]);
+  });
+
+  test('slang-server sanitizer tolerates missing or malformed code action capabilities', () => {
+    const malformedParams = [
+      { capabilities: {} },
+      { capabilities: { textDocument: {} } },
+      { capabilities: { textDocument: { codeAction: 'unsupported-shape' } } },
+      {
+        capabilities: {
+          textDocument: {
+            codeAction: {
+              codeActionLiteralSupport: {
+                codeActionKind: {
+                  valueSet: 'unsupported-shape',
+                },
+              },
+            },
+          },
+        },
+      },
+    ] as unknown as InitializeParams[];
+
+    for (const params of malformedParams) {
+      assert.doesNotThrow(() => sanitizeSlangServerInitializeParams(params));
+    }
   });
 
   test('initializes and stops without enabled servers', async () => {
@@ -92,3 +150,34 @@ suite('Language Server smoke', () => {
     assert.deepStrictEqual(options.debug.args, ['--lsp', '--define', 'A=B C']);
   });
 });
+
+function initializeParamsWithCodeActionKinds(valueSet: string[]): InitializeParams {
+  return {
+    capabilities: {
+      textDocument: {
+        codeAction: {
+          codeActionLiteralSupport: {
+            codeActionKind: {
+              valueSet,
+            },
+          },
+        },
+      },
+    },
+  } as unknown as InitializeParams;
+}
+
+function getCodeActionKindValueSet(params: InitializeParams): unknown {
+  const capabilities = params.capabilities as unknown as {
+    textDocument?: {
+      codeAction?: {
+        codeActionLiteralSupport?: {
+          codeActionKind?: {
+            valueSet?: unknown;
+          };
+        };
+      };
+    };
+  };
+  return capabilities.textDocument?.codeAction?.codeActionLiteralSupport?.codeActionKind?.valueSet;
+}


### PR DESCRIPTION
## Summary
- filter unsupported `refactor.move` from slang-server initialize capabilities
- add unit coverage for the slang-server initialize sanitizer
- install pinned `slang-server` in CI and publish workflows so the existing version-probe test runs

## Tests
- `npm run check-types`
- `npm run lint`
- `npm run compile`
- `SLANG_SERVER_PATH=/Users/mshr/.local/bin/slang-server npm test`
- `actionlint .github/workflows/ci.yml .github/workflows/publish-marketplace.yml`
- `git diff --check`