### PR TITLE
Add Slang-backed analysis engine

### DIFF
--- a/.github/actions/setup-slang-server/action.yml
+++ b/.github/actions/setup-slang-server/action.yml
@@ -1,0 +1,91 @@
+name: Setup slang-server
+description: Install a pinned slang-server release and expose it on PATH.
+
+inputs:
+  version:
+    description: slang-server release tag to install.
+    default: v0.2.7
+    required: false
+  asset:
+    description: slang-server release asset to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache slang-server
+      id: cache-slang-server
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}
+        key: ${{ runner.os }}-slang-server-${{ inputs.version }}-${{ inputs.asset }}
+
+    - name: Install slang-server (Unix)
+      if: runner.os != 'Windows' && steps.cache-slang-server.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euxo pipefail
+        install_dir="$HOME/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        archive="$RUNNER_TEMP/${{ inputs.asset }}"
+        curl -fsSL --retry 3 --retry-delay 5 \
+          -o "$archive" \
+          "https://github.com/hudson-trading/slang-server/releases/download/${{ inputs.version }}/${{ inputs.asset }}"
+        rm -rf "$install_dir"
+        mkdir -p "$install_dir"
+        tar -xzf "$archive" -C "$install_dir"
+
+    - name: Install slang-server (Windows)
+      if: runner.os == 'Windows' && steps.cache-slang-server.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        $archive = Join-Path $env:RUNNER_TEMP "${{ inputs.asset }}"
+        curl.exe -fsSL --retry 3 --retry-delay 5 `
+          -o $archive `
+          "https://github.com/hudson-trading/slang-server/releases/download/${{ inputs.version }}/${{ inputs.asset }}"
+        if (Test-Path $installDir) {
+          Remove-Item -Recurse -Force $installDir
+        }
+        New-Item -ItemType Directory -Force $installDir | Out-Null
+        Expand-Archive -LiteralPath $archive -DestinationPath $installDir
+
+    - name: Export slang-server path (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euxo pipefail
+        install_dir="$HOME/.cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        server_path="$(find "$install_dir" -type f -name slang-server -perm -u+x | head -n 1)"
+        if [ -z "$server_path" ]; then
+          server_path="$(find "$install_dir" -type f -name slang-server | head -n 1)"
+        fi
+        if [ -z "$server_path" ]; then
+          echo "Could not find slang-server in $install_dir" >&2
+          exit 1
+        fi
+        chmod +x "$server_path"
+        dirname "$server_path" >> "$GITHUB_PATH"
+        echo "SLANG_SERVER_PATH=$server_path" >> "$GITHUB_ENV"
+
+    - name: Export slang-server path (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $installDir = Join-Path $env:USERPROFILE ".cache/veriloghdl-tools/slang-server/${{ inputs.version }}/${{ inputs.asset }}"
+        $serverPath = Get-ChildItem -LiteralPath $installDir -Recurse -File -Filter "slang-server.exe" |
+          Select-Object -First 1 -ExpandProperty FullName
+        if (-not $serverPath) {
+          throw "Could not find slang-server.exe in $installDir"
+        }
+        Split-Path -Parent $serverPath | Out-File -FilePath $env:GITHUB_PATH -Append
+        "SLANG_SERVER_PATH=$serverPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Verify slang-server (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: '"$SLANG_SERVER_PATH" --version'
+
+    - name: Verify slang-server (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: '& $env:SLANG_SERVER_PATH --version'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,20 @@ jobs:
           - os: macos-latest
             slang_asset: slang-macos-arm64.tar.gz
             slang_sha256: 6d2f86ffedfefe663c6f55fd77348806faafccd69e71f7359986b0c9604f9187
+            slang_server_asset: slang-server-macos.tar.gz
           - os: ubuntu-latest
             slang_asset: slang-linux-x86_64.tar.gz
             slang_sha256: 951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4
+            slang_server_asset: slang-server-linux-x64.tar.gz
           - os: windows-latest
             slang_asset: slang-windows-x86_64.zip
             slang_sha256: 23d0a3d052cf88da13acc8b73161d77e3242ffbc630bb0577a3ccda0e4e39d81
+            slang_server_asset: slang-server-windows-x64.zip
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       SLANG_VERSION: v11.0
+      SLANG_SERVER_VERSION: v0.2.7
       VERIBLE_VERSION: v0.0-4071-g8d9f2c97
       VERIBLE_SHA256: bfa43258d9132797ec9dca2a624395bb83967e18b888803c022d1c9a889203b6
     steps:
@@ -33,6 +37,11 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Setup slang-server
+        uses: ./.github/actions/setup-slang-server
+        with:
+          version: ${{ env.SLANG_SERVER_VERSION }}
+          asset: ${{ matrix.slang_server_asset }}
       - name: Cache slang
         id: cache-slang
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Setup slang-server
+        uses: ./.github/actions/setup-slang-server
+        with:
+          version: v0.2.7
+          asset: slang-server-linux-x64.tar.gz
       - name: Cache Cargo installs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ We currently support the following language servers. You can enable multiple lan
 | -------------------------------------------------------------- | ------------------ |
 | [svls](https://github.com/dalance/svls)                        | SystemVerilog |
 | [veridian](https://github.com/vivekmalneedi/veridian)          | SystemVerilog |
+| [slang-server](https://github.com/hudson-trading/slang-server) | SystemVerilog |
 | [HDL Checker](https://github.com/suoto/hdl_checker)            | Verilog-HDL, SystemVerilog, VHDL |
 | [verible-verilog-ls](https://github.com/chipsalliance/verible) | Verilog-HDL, SystemVerilog |
 | [vhdl_ls](https://github.com/VHDL-LS/rust_hdl)                 | VHDL |
@@ -268,10 +269,13 @@ Enable only the language servers you need. For example:
 
 ```json
 {
+    "verilog.languageServer.slangServer.enabled": true,
     "verilog.languageServer.veribleVerilogLs.enabled": true,
     "verilog.languageServer.tclsp.enabled": true
 }
 ```
+
+Install [slang-server](https://github.com/hudson-trading/slang-server) and enable `verilog.languageServer.slangServer.enabled` when you want Slang-backed SystemVerilog language intelligence.
 
 Install [svls](https://github.com/dalance/svls) via `cargo`:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Project-aware Verilog/SystemVerilog features are also disabled by default. Enabl
 }
 ```
 
+The project index uses `verilog.analysis.engine: "auto"` by default. When the [Slang](https://github.com/MikePopoloski/slang) binary is available, the extension uses Slang-backed analysis to enrich the built-in fast scanner; otherwise it falls back to the fast scanner without disabling existing features.
+
 Use **Verilog: Doctor** from the command palette to inspect external tool paths, enabled language servers, formatter setup, linter configuration, WSL setup, include paths, and project configuration.
+
+Use **Verilog: Configure HDL Project** to enable project indexing and set basic filelist, include directory, and Slang path settings from VS Code.
 
 To try the project-aware features together, open the [HDL Feature Showcase](examples/hdl-feature-showcase/README.md). It walks through project-aware navigation, HDL Explorer hierarchy, semantic diagnostics, compile-unit linting, and inactive preprocessor regions with a small multi-target SystemVerilog project.
 
@@ -54,6 +58,7 @@ To try the project-aware features together, open the [HDL Feature Showcase](exam
 - Optional compile-unit linting for Slang, Verilator, and Icarus Verilog.
 - Formatting support from `verilog-format`, `iStyle`, and `verible-verilog-format`.
 - Project-aware HDL editing: go-to-definition, Find References, Rename Symbol, hover, workspace symbols, completion, module instantiation, and code actions.
+- Slang-backed analysis engine selection with automatic fallback to the built-in fast scanner.
 - Ctags-backed fallback features for autocomplete, document symbols, hover, go-to-definition, peek definition, and module instantiation.
 - Optional language-server integration for Verilog/SystemVerilog, VHDL, Tcl, SDC, XDC, and UPF.
 
@@ -93,6 +98,10 @@ To try the project-aware features together, open the [HDL Feature Showcase](exam
 - **Verilog: Reload Project**
 
     Reload the project-aware HDL model from configured filelists, project settings, or workspace discovery.
+
+- **Verilog: Configure HDL Project**
+
+    Enable project-aware indexing and configure basic filelist, include directory, and Slang path settings for the current workspace.
 
 - **Verilog: Select Active HDL Target**
 
@@ -158,6 +167,23 @@ Configure filelists with `verilog.project.filelists`, or leave that setting empt
 ```
 
 The project model powers cross-file module lookup, include resolution, workspace symbols, hover, completion, module instantiation, HDL Explorer, semantic diagnostics, and compile-unit linting. Existing Ctags behavior remains available as a fallback when the project index has no answer or the project model is disabled.
+
+### Analysis Engine
+
+The extension can build its project index with the built-in fast scanner or with Slang-backed analysis:
+
+```json
+{
+    "verilog.analysis.engine": "auto",
+    "verilog.analysis.slang.path": "slang",
+    "verilog.analysis.slang.arguments": "",
+    "verilog.analysis.cache.enabled": true
+}
+```
+
+`auto` is the default. It tries Slang first and falls back to the fast scanner if Slang is not installed or the Slang run fails. `fast` forces the built-in scanner. `slang` requests Slang-backed analysis, but still falls back to the fast scanner instead of emptying the index when the external tool is unavailable.
+
+Slang-backed analysis currently enriches the existing project index while preserving fast scanner locations and existing editor behavior. Use **Verilog: Doctor** to see the requested analysis engine, the actual engine used for the current index, and any fallback reason.
 
 For a guided multi-target filelist example, see the [HDL Feature Showcase](examples/hdl-feature-showcase/README.md).
 
@@ -312,6 +338,7 @@ The `verilog.formatting.verilogFormat.settings` path supports `${env:VAR}` and `
 ### Limitations
 
 - Project-aware features are lightweight and do not perform full SystemVerilog elaboration or full lexical scope resolution.
+- Slang-backed analysis is optional and falls back to the fast scanner when the `slang` binary is unavailable or returns unusable AST JSON.
 - Project indexing is opt-in and may be skipped when automatic discovery exceeds `verilog.project.maxAutoDiscoveredFiles`.
 - Compile-unit linting is supported by Slang, Verilator, and Icarus Verilog. Other linters use file-mode linting.
 - Ctags integration indexes the currently opened file and is used as a fallback for several editor features.

--- a/package.json
+++ b/package.json
@@ -753,6 +753,40 @@
         }
       },
       {
+        "title": "Verilog: Analysis",
+        "properties": {
+          "verilog.analysis.engine": {
+            "scope": "window",
+            "type": "string",
+            "enum": [
+              "auto",
+              "fast",
+              "slang"
+            ],
+            "default": "auto",
+            "markdownDescription": "Choose the Verilog/SystemVerilog analysis engine. `auto` uses Slang when available and falls back to the built-in fast scanner."
+          },
+          "verilog.analysis.slang.path": {
+            "scope": "window",
+            "type": "string",
+            "default": "slang",
+            "markdownDescription": "A path to the Slang binary used by the Slang-backed analysis engine."
+          },
+          "verilog.analysis.slang.arguments": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Additional arguments passed to Slang before project include directories, defines, and source files."
+          },
+          "verilog.analysis.cache.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable analysis cache support for engines that can reuse project analysis data. The initial Slang integration records this preference but falls back to full analysis when no cache is available."
+          }
+        }
+      },
+      {
         "title": "Verilog: Project",
         "properties": {
           "verilog.project.enabled": {
@@ -1039,6 +1073,10 @@
       {
         "command": "verilog.reloadProject",
         "title": "Verilog: Reload Project"
+      },
+      {
+        "command": "verilog.configureProject",
+        "title": "Verilog: Configure HDL Project"
       },
       {
         "command": "verilog.showProjectStatus",

--- a/package.json
+++ b/package.json
@@ -624,6 +624,24 @@
             "default": "",
             "markdownDescription": "Add custom arguments for the HDL Checker Veridian Language Server."
           },
+          "verilog.languageServer.slangServer.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable slang-server Language Server for SystemVerilog."
+          },
+          "verilog.languageServer.slangServer.path": {
+            "scope": "window",
+            "type": "string",
+            "default": "slang-server",
+            "markdownDescription": "A path to the slang-server Language Server binary."
+          },
+          "verilog.languageServer.slangServer.arguments": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Add custom arguments for the slang-server Language Server."
+          },
           "verilog.languageServer.hdlChecker.enabled": {
             "scope": "window",
             "type": "boolean",

--- a/src/commands/Doctor.ts
+++ b/src/commands/Doctor.ts
@@ -110,6 +110,7 @@ const linterVersionArgs = new Map<string, string[]>([
 const languageServerLabels: Record<string, string> = {
   svls: 'svls',
   veridian: 'veridian',
+  slangServer: 'slang-server',
   hdlChecker: 'hdlChecker',
   veribleVerilogLs: 'verible-verilog-ls',
   tclsp: 'tclsp',

--- a/src/commands/Doctor.ts
+++ b/src/commands/Doctor.ts
@@ -12,6 +12,8 @@ import {
   createLanguageServerDefinitions,
   type LanguageServerDefinition,
 } from '../languageServer/definitions';
+import type { IndexService } from '../semantic/IndexService';
+import { getAnalysisSettings } from '../semantic/backends/AnalysisSettings';
 import type { ProjectService } from '../project/ProjectService';
 import { activeEditorContextDiagnostic, summarizeContext } from '../project/ProjectCommands';
 import { getCompileUnitLintContext } from '../linter/ProjectLintContext';
@@ -119,15 +121,19 @@ const languageServerLabels: Record<string, string> = {
 
 export function registerDoctorCommand(
   context: vscode.ExtensionContext,
-  projectService?: ProjectService
+  projectService?: ProjectService,
+  indexService?: IndexService
 ): vscode.Disposable {
-  return vscode.commands.registerCommand('verilog.doctor', () => runDoctor(context, createDefaultDoctorDependencies(), projectService));
+  return vscode.commands.registerCommand('verilog.doctor', () =>
+    runDoctor(context, createDefaultDoctorDependencies(), projectService, indexService)
+  );
 }
 
 export async function runDoctor(
   context: vscode.ExtensionContext,
   deps: DoctorDependencies = createDefaultDoctorDependencies(),
-  projectService?: ProjectService
+  projectService?: ProjectService,
+  indexService?: IndexService
 ): Promise<void> {
   let report: DoctorReport;
   try {
@@ -137,7 +143,7 @@ export async function runDoctor(
         title: 'Running Verilog Doctor',
         cancellable: true,
       },
-      async (_progress, token) => buildDoctorReport(context, deps, token, projectService)
+      async (_progress, token) => buildDoctorReport(context, deps, token, projectService, indexService)
     );
   } catch (err) {
     if (err instanceof ToolRunError && err.reason === 'cancelled') {
@@ -166,7 +172,8 @@ export async function buildDoctorReport(
   context: vscode.ExtensionContext,
   deps: DoctorDependencies,
   token?: vscode.CancellationToken,
-  projectService?: ProjectService
+  projectService?: ProjectService,
+  indexService?: IndexService
 ): Promise<DoctorReport> {
   const activeDocument = vscode.window.activeTextEditor?.document;
   const activeWorkspaceFolder = activeDocument
@@ -184,6 +191,7 @@ export async function buildDoctorReport(
     await buildLintingSectionFromConfiguration(deps, workspaceFolderPath, token, projectService),
     await buildFormattingSection(deps, workspaceFolderPath, token),
     await buildLanguageServersSection(deps, workspaceFolderPaths, token),
+    await buildAnalysisSection(deps, token, indexService),
     buildProjectSection(projectService),
   ];
   sections.push(buildSummarySection(sections));
@@ -245,6 +253,45 @@ function buildProjectSection(projectService?: ProjectService): DoctorSection {
   }
 
   return { title: 'Project', checks };
+}
+
+async function buildAnalysisSection(
+  deps: DoctorDependencies,
+  token?: vscode.CancellationToken,
+  indexService?: IndexService
+): Promise<DoctorSection> {
+  const settings = getAnalysisSettings();
+  const metadata = indexService?.getIndex().metadata;
+  const checks: DoctorCheck[] = [
+    { status: 'info', message: `verilog.analysis.engine = ${settings.engine}` },
+    { status: 'info', message: `verilog.analysis.cache.enabled = ${String(settings.cacheEnabled)}` },
+    { status: 'info', message: `verilog.analysis.slang.arguments = ${settings.slangArguments.join(' ')}` },
+  ];
+
+  if (settings.engine !== 'fast') {
+    const resolved = await appendBinaryChecks(
+      checks,
+      'slang binary',
+      settings.slangPath,
+      deps,
+      token
+    );
+    if (resolved) {
+      await appendVersionCheck(checks, 'slang version', resolved, ['--version'], deps, token);
+    }
+  }
+
+  if (metadata) {
+    checks.push({ status: 'info', message: `requested analysis engine = ${metadata.requestedEngine}` });
+    checks.push({ status: 'info', message: `actual analysis engine = ${metadata.actualEngine}` });
+    if (metadata.fallbackReason) {
+      checks.push({ status: 'warn', message: `analysis fallback reason = ${metadata.fallbackReason}` });
+    }
+  } else {
+    checks.push({ status: 'info', message: 'semantic index unavailable in this Doctor context.' });
+  }
+
+  return { title: 'Analysis', checks };
 }
 
 export function renderDoctorReport(report: DoctorReport): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,7 +274,7 @@ export async function activate(context: vscode.ExtensionContext) {
       openWaveform(context, arg)
     )
   );
-  context.subscriptions.push(registerDoctorCommand(context, projectService));
+  context.subscriptions.push(registerDoctorCommand(context, projectService, indexService));
 
   context.subscriptions.push(
     vscode.window.registerCustomEditorProvider(

--- a/src/languageServer/definitions.ts
+++ b/src/languageServer/definitions.ts
@@ -43,6 +43,15 @@ export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
       }),
     },
     {
+      name: 'slangServer',
+      defaultPath: 'slang-server',
+      serverArgs: [],
+      serverDebugArgs: [],
+      buildClientOptions: () => ({
+        documentSelector: [{ scheme: 'file', language: 'systemverilog' }],
+      }),
+    },
+    {
       name: 'hdlChecker',
       defaultPath: 'hdl_checker',
       serverArgs: ['--lsp'],

--- a/src/languageServer/definitions.ts
+++ b/src/languageServer/definitions.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { LanguageClientOptions, Message } from 'vscode-languageclient/node';
+import { Message, type InitializeParams, type LanguageClientOptions } from 'vscode-languageclient/node';
 
+import { sanitizeSlangServerInitializeParams } from './slangServerCompatibility';
 import { buildTclspInitializationOptions } from './tclspOptions';
 
 export type LanguageServerDefinition = {
@@ -11,6 +12,7 @@ export type LanguageServerDefinition = {
   serverDebugArgs: string[];
   buildClientOptions: () => LanguageClientOptions;
   applyProcessEnv?: () => void;
+  sanitizeInitializeParams?: (params: InitializeParams) => void;
 };
 
 export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
@@ -50,6 +52,7 @@ export function createLanguageServerDefinitions(): LanguageServerDefinition[] {
       buildClientOptions: () => ({
         documentSelector: [{ scheme: 'file', language: 'systemverilog' }],
       }),
+      sanitizeInitializeParams: sanitizeSlangServerInitializeParams,
     },
     {
       name: 'hdlChecker',

--- a/src/languageServer/manager.ts
+++ b/src/languageServer/manager.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import {
+  LanguageClient,
+  type InitializeParams,
+  type LanguageClientOptions,
+  type ServerOptions,
+} from 'vscode-languageclient/node';
 import { getExtensionLogger } from '../logging';
 import { splitCommandLineArgs } from '../utils/commandLine';
 import { LanguageServerDefinition } from './definitions';
@@ -22,6 +27,23 @@ export function buildServerOptions(input: BuildServerOptionsInput): BuiltServerO
     run: { command: input.command, args: input.definition.serverArgs.concat(customArgs) },
     debug: { command: input.command, args: input.definition.serverDebugArgs.concat(customArgs) },
   };
+}
+
+class SanitizingLanguageClient extends LanguageClient {
+  constructor(
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+    private readonly sanitizeInitializeParams: (params: InitializeParams) => void
+  ) {
+    super(id, name, serverOptions, clientOptions);
+  }
+
+  protected fillInitializeParams(params: InitializeParams): void {
+    super.fillInitializeParams(params);
+    this.sanitizeInitializeParams(params);
+  }
 }
 
 export class LanguageServerManager {
@@ -58,12 +80,7 @@ export class LanguageServerManager {
 
     const serverOptions = buildServerOptions({ definition, command: binPath, customArgs });
 
-    const client = new LanguageClient(
-      definition.name,
-      `${definition.name  } language server`,
-      serverOptions,
-      definition.buildClientOptions()
-    );
+    const client = createLanguageClient(definition, serverOptions);
     this.languageClients.set(definition.name, client);
 
     if (!enabled) {
@@ -77,4 +94,22 @@ export class LanguageServerManager {
     client.start();
     this.logger.info`"${definition.name}" language server started.`;
   }
+}
+
+function createLanguageClient(
+  definition: LanguageServerDefinition,
+  serverOptions: ServerOptions
+): LanguageClient {
+  const name = `${definition.name  } language server`;
+  const clientOptions = definition.buildClientOptions();
+  if (definition.sanitizeInitializeParams) {
+    return new SanitizingLanguageClient(
+      definition.name,
+      name,
+      serverOptions,
+      clientOptions,
+      definition.sanitizeInitializeParams
+    );
+  }
+  return new LanguageClient(definition.name, name, serverOptions, clientOptions);
 }

--- a/src/languageServer/slangServerCompatibility.ts
+++ b/src/languageServer/slangServerCompatibility.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+import type { InitializeParams } from 'vscode-languageclient/node';
+
+const UNSUPPORTED_SLANG_SERVER_CODE_ACTION_KIND = 'refactor.move';
+
+export function sanitizeSlangServerInitializeParams(params: InitializeParams): void {
+  const capabilities = asRecord(params.capabilities);
+  const textDocument = asRecord(capabilities?.textDocument);
+  const codeAction = asRecord(textDocument?.codeAction);
+  const literalSupport = asRecord(codeAction?.codeActionLiteralSupport);
+  const codeActionKind = asRecord(literalSupport?.codeActionKind);
+  if (!codeActionKind || !Array.isArray(codeActionKind.valueSet)) {
+    return;
+  }
+
+  codeActionKind.valueSet = codeActionKind.valueSet.filter(
+    (value) => value !== UNSUPPORTED_SLANG_SERVER_CODE_ACTION_KIND
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/project/ProjectCommands.ts
+++ b/src/project/ProjectCommands.ts
@@ -39,6 +39,53 @@ export function registerProjectCommands(
         { placeHolder: 'Project modules' }
       );
     }),
+    vscode.commands.registerCommand('verilog.configureProject', async () => {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.at(0);
+      if (!workspaceFolder) {
+        vscode.window.showErrorMessage('Verilog: Open a workspace folder before configuring an HDL project.');
+        return;
+      }
+
+      const configTarget = vscode.ConfigurationTarget.Workspace;
+      const projectConfig = vscode.workspace.getConfiguration('verilog.project', workspaceFolder.uri);
+      const analysisConfig = vscode.workspace.getConfiguration('verilog.analysis', workspaceFolder.uri);
+
+      await projectConfig.update('enabled', true, configTarget);
+
+      const filelists = await vscode.window.showInputBox({
+        title: 'Configure HDL Project',
+        prompt: 'Filelists, comma-separated. Leave empty to keep automatic workspace discovery.',
+        value: projectConfig.get<string[]>('filelists', []).join(', '),
+      });
+      if (filelists !== undefined) {
+        await projectConfig.update('filelists', splitCommaList(filelists), configTarget);
+      }
+
+      const includeDirs = await vscode.window.showInputBox({
+        title: 'Configure HDL Project',
+        prompt: 'Include directories, comma-separated. Leave empty for none.',
+        value: projectConfig.get<string[]>('includeDirs', []).join(', '),
+      });
+      if (includeDirs !== undefined) {
+        await projectConfig.update('includeDirs', splitCommaList(includeDirs), configTarget);
+      }
+
+      const slangPath = await vscode.window.showInputBox({
+        title: 'Configure HDL Project',
+        prompt: 'Slang binary path. Leave empty to use "slang" from PATH.',
+        value: vscode.workspace.getConfiguration('verilog.analysis.slang', workspaceFolder.uri).get<string>('path', 'slang'),
+      });
+      if (slangPath !== undefined) {
+        await analysisConfig.update('engine', 'auto', configTarget);
+        await vscode
+          .workspace
+          .getConfiguration('verilog.analysis.slang', workspaceFolder.uri)
+          .update('path', slangPath.trim() || 'slang', configTarget);
+      }
+
+      await projectService.reload('configure project command');
+      vscode.window.showInformationMessage('Verilog HDL project configuration updated.');
+    }),
   ];
 }
 
@@ -142,4 +189,11 @@ function formatDiagnostic(diagnostic: ProjectDiagnostic): string {
     ? ` (${diagnostic.location.uri.fsPath}:${diagnostic.location.range.start.line + 1})`
     : '';
   return `[${diagnostic.severity.toUpperCase()}] ${diagnostic.message}${location}`;
+}
+
+function splitCommaList(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }

--- a/src/project/ProjectWatcher.ts
+++ b/src/project/ProjectWatcher.ts
@@ -14,8 +14,10 @@ export interface ProjectWatcherOptions {
 export class ProjectWatcher implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
   private readonly filelistWatcherDisposables: vscode.Disposable[] = [];
+  private readonly sourceWatcherDisposables: vscode.Disposable[] = [];
   private reloadTimer: NodeJS.Timeout | undefined;
   private filelistWatcher: vscode.FileSystemWatcher | undefined;
+  private sourceWatcher: vscode.FileSystemWatcher | undefined;
   private readonly debounceMs: number;
   private readonly createFileSystemWatcher: typeof vscode.workspace.createFileSystemWatcher;
   private readonly onDidChangeConfiguration: typeof vscode.workspace.onDidChangeConfiguration;
@@ -41,9 +43,11 @@ export class ProjectWatcher implements vscode.Disposable {
         }
         this.scheduleReload('configuration changed');
         this.refreshFilelistWatcher();
+        this.refreshSourceWatcher();
       })
     );
     this.refreshFilelistWatcher();
+    this.refreshSourceWatcher();
   }
 
   scheduleReload(reason: string): void {
@@ -62,6 +66,7 @@ export class ProjectWatcher implements vscode.Disposable {
       this.reloadTimer = undefined;
     }
     this.disposeFilelistWatcher();
+    this.disposeSourceWatcher();
     for (const disposable of this.disposables) {
       disposable.dispose();
     }
@@ -87,6 +92,28 @@ export class ProjectWatcher implements vscode.Disposable {
       this.filelistWatcherDisposables.pop()?.dispose();
     }
     this.filelistWatcher = undefined;
+  }
+
+  private refreshSourceWatcher(): void {
+    this.disposeSourceWatcher();
+    if (!this.isProjectEnabled()) {
+      return;
+    }
+
+    this.sourceWatcher = this.createFileSystemWatcher('**/*.{v,V,vh,VH,vl,sv,SV,svh,SVH}');
+    this.sourceWatcherDisposables.push(this.sourceWatcher);
+    this.sourceWatcherDisposables.push(
+      this.sourceWatcher.onDidCreate(() => this.scheduleReload('HDL source created')),
+      this.sourceWatcher.onDidChange(() => this.scheduleReload('HDL source changed')),
+      this.sourceWatcher.onDidDelete(() => this.scheduleReload('HDL source deleted'))
+    );
+  }
+
+  private disposeSourceWatcher(): void {
+    while (this.sourceWatcherDisposables.length > 0) {
+      this.sourceWatcherDisposables.pop()?.dispose();
+    }
+    this.sourceWatcher = undefined;
   }
 
   private isProjectEnabled(): boolean {

--- a/src/semantic/IndexService.ts
+++ b/src/semantic/IndexService.ts
@@ -3,8 +3,10 @@ import * as vscode from 'vscode';
 import { getExtensionLogger } from '../logging';
 import type { ProjectService } from '../project/ProjectService';
 import type { ProjectSnapshot } from '../project/ProjectTypes';
-import { FastIndexerBackend } from './backends/FastIndexerBackend';
+import type { AnalysisResult } from './backends/AnalysisBackend';
+import { ConfiguredAnalysisBackend } from './backends/ConfiguredAnalysisBackend';
 import { SemanticIndex } from './SemanticIndex';
+import type { SymbolRecord } from './SymbolRecords';
 
 const logger = getExtensionLogger('Semantic', 'IndexService');
 
@@ -17,12 +19,18 @@ export class IndexService implements vscode.Disposable {
   readonly onDidChangeIndex = this.emitter.event;
 
   constructor(
-    projectService: ProjectService,
-    private readonly backend = new FastIndexerBackend()
+    private readonly projectService: ProjectService,
+    private readonly backend: { build(snapshot: ProjectSnapshot): Promise<AnalysisResult | SymbolRecord[]> } =
+      new ConfiguredAnalysisBackend()
   ) {
     this.disposables.push(
       projectService.onDidChangeSnapshot((snapshot) => {
         void this.rebuild(snapshot);
+      }),
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration('verilog.analysis')) {
+          void this.rebuild(this.projectService.getSnapshot());
+        }
       })
     );
   }
@@ -40,13 +48,16 @@ export class IndexService implements vscode.Disposable {
       files: snapshot.compileUnits.reduce((sum, compileUnit) => sum + compileUnit.files.length, 0),
     });
     try {
-      const symbols = await this.backend.build(snapshot);
+      const result = toAnalysisResult(await this.backend.build(snapshot));
       if (serial === this.rebuildSerial) {
-        this.index = new SemanticIndex(snapshot.version, symbols);
+        this.index = new SemanticIndex(snapshot.version, result.symbols, result.metadata);
         this.emitter.fire(this.index);
         logger.info('Rebuilt Verilog semantic index', {
           version: snapshot.version,
-          symbols: symbols.length,
+          symbols: result.symbols.length,
+          engine: result.metadata.actualEngine,
+          requestedEngine: result.metadata.requestedEngine,
+          fallbackReason: result.metadata.fallbackReason,
         });
       }
     } catch (error) {
@@ -69,4 +80,17 @@ export class IndexService implements vscode.Disposable {
     }
     this.emitter.dispose();
   }
+}
+
+function toAnalysisResult(result: AnalysisResult | SymbolRecord[]): AnalysisResult {
+  if (Array.isArray(result)) {
+    return {
+      symbols: result,
+      metadata: {
+        requestedEngine: 'fast',
+        actualEngine: 'fast',
+      },
+    };
+  }
+  return result;
 }

--- a/src/semantic/SemanticIndex.ts
+++ b/src/semantic/SemanticIndex.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { FileContext } from '../project/FileContext';
+import type { AnalysisMetadata } from './backends/AnalysisBackend';
 import type { ModuleRecord, SymbolRecord, SymbolRecordKind } from './SymbolRecords';
 
 export class SemanticIndex {
@@ -13,7 +14,11 @@ export class SemanticIndex {
 
   constructor(
     readonly version: number,
-    private readonly symbols: SymbolRecord[]
+    private readonly symbols: SymbolRecord[],
+    readonly metadata: AnalysisMetadata = {
+      requestedEngine: 'fast',
+      actualEngine: 'fast',
+    }
   ) {
     for (const symbol of symbols) {
       addToMap(this.symbolsByFile, symbol.uri.fsPath, symbol);

--- a/src/semantic/backends/AnalysisBackend.ts
+++ b/src/semantic/backends/AnalysisBackend.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+import type { ProjectSnapshot } from '../../project/ProjectTypes';
+import type { SymbolRecord } from '../SymbolRecords';
+
+export type AnalysisEngine = 'fast' | 'slang';
+
+export interface AnalysisMetadata {
+  requestedEngine: 'auto' | AnalysisEngine;
+  actualEngine: AnalysisEngine;
+  fallbackReason?: string;
+  cacheEnabled?: boolean;
+}
+
+export interface AnalysisResult {
+  symbols: SymbolRecord[];
+  metadata: AnalysisMetadata;
+}
+
+export interface AnalysisBackend {
+  build(snapshot: ProjectSnapshot): Promise<AnalysisResult>;
+}

--- a/src/semantic/backends/AnalysisSettings.ts
+++ b/src/semantic/backends/AnalysisSettings.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import { splitCommandLineArgs } from '../../utils/commandLine';
+
+export type AnalysisEngineSetting = 'auto' | 'fast' | 'slang';
+
+export interface AnalysisSettings {
+  engine: AnalysisEngineSetting;
+  slangPath: string;
+  slangArguments: string[];
+  cacheEnabled: boolean;
+}
+
+export function getAnalysisSettings(): AnalysisSettings {
+  const analysisConfig = vscode.workspace.getConfiguration('verilog.analysis');
+  const slangConfig = vscode.workspace.getConfiguration('verilog.analysis.slang');
+  return {
+    engine: normalizeEngine(analysisConfig.get<string>('engine', 'auto')),
+    slangPath: slangConfig.get<string>('path', 'slang'),
+    slangArguments: splitCommandLineArgs(slangConfig.get<string>('arguments', '')),
+    cacheEnabled: analysisConfig.get<boolean>('cache.enabled', true),
+  };
+}
+
+function normalizeEngine(value: string): AnalysisEngineSetting {
+  if (value === 'fast' || value === 'slang') {
+    return value;
+  }
+  return 'auto';
+}

--- a/src/semantic/backends/ConfiguredAnalysisBackend.ts
+++ b/src/semantic/backends/ConfiguredAnalysisBackend.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+import type { ProjectSnapshot } from '../../project/ProjectTypes';
+import type { AnalysisResult } from './AnalysisBackend';
+import { getAnalysisSettings } from './AnalysisSettings';
+import { FastIndexerBackend } from './FastIndexerBackend';
+import { SlangIndexerBackend } from './SlangIndexerBackend';
+
+export class ConfiguredAnalysisBackend {
+  constructor(private readonly fastBackend = new FastIndexerBackend()) {}
+
+  async build(snapshot: ProjectSnapshot): Promise<AnalysisResult> {
+    const settings = getAnalysisSettings();
+    if (settings.engine === 'fast') {
+      return {
+        symbols: await this.fastBackend.build(snapshot),
+        metadata: {
+          requestedEngine: 'fast',
+          actualEngine: 'fast',
+          cacheEnabled: settings.cacheEnabled,
+        },
+      };
+    }
+
+    const result = await new SlangIndexerBackend(settings, this.fastBackend).build(snapshot);
+    return {
+      ...result,
+      metadata: {
+        ...result.metadata,
+        requestedEngine: settings.engine,
+      },
+    };
+  }
+}

--- a/src/semantic/backends/SlangAstParser.ts
+++ b/src/semantic/backends/SlangAstParser.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+import type { ModuleRecord, ParameterRecord, PortRecord, SymbolRecord } from '../SymbolRecords';
+
+interface SlangNamedNode {
+  name?: unknown;
+  kind?: unknown;
+  type?: unknown;
+  direction?: unknown;
+  value?: unknown;
+  body?: unknown;
+  members?: unknown;
+}
+
+export function enrichSymbolsWithSlangAst(
+  symbols: SymbolRecord[],
+  ast: unknown
+): SymbolRecord[] {
+  const modules = new Map<string, ModuleRecord[]>();
+  const nextSymbols = symbols.slice();
+  for (const symbol of nextSymbols) {
+    if (symbol.kind === 'module') {
+      const moduleRecord = symbol as ModuleRecord;
+      const existing = modules.get(symbol.name) ?? [];
+      existing.push(moduleRecord);
+      modules.set(symbol.name, existing);
+    }
+  }
+
+  for (const node of walkObjects(ast)) {
+    const name = getString(node.name);
+    if (!name) {
+      continue;
+    }
+    const moduleRecords = modules.get(name);
+    if (!moduleRecords) {
+      continue;
+    }
+    for (const moduleRecord of moduleRecords) {
+      const added = enrichModuleFromNode(moduleRecord, node);
+      nextSymbols.push(...added);
+    }
+  }
+
+  return nextSymbols;
+}
+
+function enrichModuleFromNode(moduleRecord: ModuleRecord, node: SlangNamedNode): SymbolRecord[] {
+  const added: SymbolRecord[] = [];
+  const existingPorts = new Set(moduleRecord.ports.map((port) => port.name));
+  const existingParameters = new Set(moduleRecord.parameters.map((parameter) => parameter.name));
+  for (const child of getMemberObjects(node)) {
+    const kind = getString(child.kind)?.toLowerCase() ?? '';
+    const name = getString(child.name);
+    if (!name) {
+      continue;
+    }
+    if (isPortNode(child, kind) && !existingPorts.has(name)) {
+      const port = createPortRecord(moduleRecord, child, name);
+      moduleRecord.ports.push(port);
+      added.push(port);
+      existingPorts.add(name);
+    } else if (isParameterNode(kind) && !existingParameters.has(name)) {
+      const parameter = createParameterRecord(moduleRecord, child, name);
+      moduleRecord.parameters.push(parameter);
+      added.push(parameter);
+      existingParameters.add(name);
+    }
+  }
+  return added;
+}
+
+function isPortNode(node: SlangNamedNode, kind: string): boolean {
+  return kind.includes('port') || getString(node.direction) !== undefined;
+}
+
+function isParameterNode(kind: string): boolean {
+  return kind.includes('parameter') || kind === 'param';
+}
+
+function createPortRecord(moduleRecord: ModuleRecord, node: SlangNamedNode, name: string): PortRecord {
+  return {
+    ...createChildRecord(moduleRecord, 'port', name),
+    kind: 'port',
+    direction: normalizeDirection(getString(node.direction)),
+    dataType: getString(node.type),
+  };
+}
+
+function createParameterRecord(moduleRecord: ModuleRecord, node: SlangNamedNode, name: string): ParameterRecord {
+  return {
+    ...createChildRecord(moduleRecord, 'parameter', name),
+    kind: 'parameter',
+    dataType: getString(node.type),
+    defaultValue: stringifyValue(node.value),
+  };
+}
+
+function createChildRecord(
+  moduleRecord: ModuleRecord,
+  kind: 'port' | 'parameter',
+  name: string
+): SymbolRecord {
+  return {
+    id: `${moduleRecord.compileUnitId}:${moduleRecord.uri.fsPath}:${moduleRecord.name}:${kind}:${name}:slang`,
+    name,
+    kind,
+    uri: moduleRecord.uri,
+    range: moduleRecord.range,
+    selectionRange: moduleRecord.selectionRange,
+    containerName: moduleRecord.name,
+    compileUnitId: moduleRecord.compileUnitId,
+  };
+}
+
+function normalizeDirection(direction: string | undefined): PortRecord['direction'] {
+  const value = direction?.toLowerCase();
+  if (value === 'input' || value === 'in' || value === 'inout' || value === 'output' || value === 'out' || value === 'ref') {
+    return value === 'in' ? 'input' : value === 'out' ? 'output' : value;
+  }
+  if (value === 'interface') {
+    return 'interface';
+  }
+  return undefined;
+}
+
+function stringifyValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+function getMemberObjects(node: SlangNamedNode): SlangNamedNode[] {
+  const members: SlangNamedNode[] = [];
+  const directMembers = toObjectArray(node.members);
+  members.push(...directMembers);
+  const body = isObject(node.body) ? node.body : undefined;
+  if (body) {
+    members.push(...toObjectArray(body.members));
+  }
+  return members;
+}
+
+function* walkObjects(value: unknown): Generator<SlangNamedNode> {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      yield* walkObjects(item);
+    }
+    return;
+  }
+  if (!isObject(value)) {
+    return;
+  }
+  yield value;
+  for (const child of Object.values(value)) {
+    yield* walkObjects(child);
+  }
+}
+
+function toObjectArray(value: unknown): SlangNamedNode[] {
+  return Array.isArray(value) ? value.filter(isObject) : [];
+}
+
+function isObject(value: unknown): value is SlangNamedNode {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/src/semantic/backends/SlangIndexerBackend.ts
+++ b/src/semantic/backends/SlangIndexerBackend.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+import * as path from 'path';
+import which = require('which');
+import type { CompileUnit, ProjectSnapshot } from '../../project/ProjectTypes';
+import { runTool, ToolRunError, type ToolRunOptions, type ToolRunResult } from '../../tools/ToolRunner';
+import type { AnalysisResult } from './AnalysisBackend';
+import type { AnalysisSettings } from './AnalysisSettings';
+import { enrichSymbolsWithSlangAst } from './SlangAstParser';
+import { FastIndexerBackend } from './FastIndexerBackend';
+
+export interface SlangBackendDependencies {
+  runTool: (options: ToolRunOptions) => Promise<ToolRunResult>;
+  resolveExecutable: (command: string) => Promise<string | undefined>;
+}
+
+export class SlangIndexerBackend {
+  constructor(
+    private readonly settings: AnalysisSettings,
+    private readonly fastBackend = new FastIndexerBackend(),
+    private readonly deps: SlangBackendDependencies = {
+      runTool,
+      resolveExecutable: resolveExecutableOnPath,
+    }
+  ) {}
+
+  async build(snapshot: ProjectSnapshot): Promise<AnalysisResult> {
+    const fastSymbols = await this.fastBackend.build(snapshot);
+    const resolvedSlang = await this.deps.resolveExecutable(this.settings.slangPath);
+    if (!resolvedSlang) {
+      return {
+        symbols: fastSymbols,
+        metadata: {
+          requestedEngine: 'slang',
+          actualEngine: 'fast',
+          cacheEnabled: this.settings.cacheEnabled,
+          fallbackReason: `slang binary not found: ${this.settings.slangPath}`,
+        },
+      };
+    }
+
+    try {
+      let symbols = fastSymbols;
+      for (const compileUnit of snapshot.compileUnits) {
+        if (compileUnit.files.length === 0) {
+          continue;
+        }
+        const ast = await this.loadAst(resolvedSlang, snapshot, compileUnit);
+        symbols = enrichSymbolsWithSlangAst(symbols, ast);
+      }
+      return {
+        symbols,
+        metadata: {
+          requestedEngine: 'slang',
+          actualEngine: 'slang',
+          cacheEnabled: this.settings.cacheEnabled,
+        },
+      };
+    } catch (error) {
+      return {
+        symbols: fastSymbols,
+        metadata: {
+          requestedEngine: 'slang',
+          actualEngine: 'fast',
+          cacheEnabled: this.settings.cacheEnabled,
+          fallbackReason: fallbackMessage(error),
+        },
+      };
+    }
+  }
+
+  private async loadAst(
+    slangPath: string,
+    snapshot: ProjectSnapshot,
+    compileUnit: CompileUnit
+  ): Promise<unknown> {
+    const result = await this.deps.runTool({
+      command: slangPath,
+      args: buildSlangAstArgs(compileUnit, this.settings.slangArguments),
+      cwd: snapshot.workspaceRoot.fsPath,
+      timeoutMs: 15000,
+      collectStdout: true,
+      collectStderr: true,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`slang exited with code ${result.exitCode ?? 'unknown'}`);
+    }
+    const stdout = result.stdout.trim();
+    if (stdout.length === 0) {
+      throw new Error('slang did not emit AST JSON');
+    }
+    return JSON.parse(stdout) as unknown;
+  }
+}
+
+export function buildSlangAstArgs(
+  compileUnit: CompileUnit,
+  extraArgs: string[]
+): string[] {
+  return [
+    ...extraArgs,
+    '--ast-json',
+    ...compileUnit.includeDirs.map((dir) => `-I${dir.fsPath}`),
+    ...Object.values(compileUnit.defines).map((define) =>
+      define.value === true ? `-D${define.name}` : `-D${define.name}=${define.value}`
+    ),
+    ...compileUnit.files
+      .filter((file) => file.kind !== 'include')
+      .map((file) => path.relative(compileUnit.root.fsPath, file.uri.fsPath)),
+  ];
+}
+
+async function resolveExecutableOnPath(command: string): Promise<string | undefined> {
+  try {
+    return await which(command);
+  } catch {
+    return undefined;
+  }
+}
+
+function fallbackMessage(error: unknown): string {
+  if (error instanceof ToolRunError) {
+    return `${error.reason}: ${error.message}`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -3,8 +3,10 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import which = require('which');
 import {
   buildFormatterChecks,
+  createDefaultDoctorDependencies,
   buildLanguageServerConflictChecks,
   buildLanguageServerChecks,
   buildLinterChecks,
@@ -200,6 +202,34 @@ suite('Doctor', () => {
     assert.ok(
       checks.some(
         (check) => check.status === 'ok' && check.message.includes('verible-verilog-ls 1.0')
+      )
+    );
+  });
+
+  test('installed slang-server version probe works when available', async function () {
+    const slangServerPath = process.env.SLANG_SERVER_PATH || which.sync('slang-server', { nothrow: true });
+    if (!slangServerPath) {
+      this.skip();
+    }
+
+    const checks = await buildLanguageServerChecks(
+      {
+        name: 'slang-server',
+        enabled: true,
+        path: slangServerPath,
+        arguments: '',
+      },
+      createDefaultDoctorDependencies()
+    );
+
+    assert.ok(
+      checks.some(
+        (check) => check.status === 'ok' && check.message.includes('slang-server binary')
+      )
+    );
+    assert.ok(
+      checks.some(
+        (check) => check.status === 'ok' && check.message.includes('slang-server version')
       )
     );
   });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -141,6 +141,7 @@ suite('Extension Test Suite', () => {
     }
 
     const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes('verilog.configureProject'));
     assert.ok(commands.includes('verilog.reloadProject'));
     assert.ok(commands.includes('verilog.showProjectStatus'));
     assert.ok(commands.includes('verilog.showProjectModules'));
@@ -186,6 +187,10 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.project.defines']);
     assert.ok(properties['verilog.project.exclude']);
     assert.ok(properties['verilog.project.maxAutoDiscoveredFiles']);
+    assert.ok(properties['verilog.analysis.engine']);
+    assert.ok(properties['verilog.analysis.slang.path']);
+    assert.ok(properties['verilog.analysis.slang.arguments']);
+    assert.ok(properties['verilog.analysis.cache.enabled']);
     assert.ok(properties['verilog.hierarchy.enabled']);
     assert.ok(properties['verilog.hierarchy.maxDepth']);
     assert.ok(properties['verilog.hierarchy.showUnresolved']);

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -11,6 +11,7 @@ suite('Language Server smoke', () => {
     const expected = [
       'hdlChecker',
       'rustHdl',
+      'slangServer',
       'svls',
       'tclsp',
       'veribleVerilogLs',
@@ -29,6 +30,17 @@ suite('Language Server smoke', () => {
         `Expected documentSelector for ${definition.name}`
       );
     }
+  });
+
+  test('slang-server handles SystemVerilog documents', () => {
+    const definition = createLanguageServerDefinitions().find(
+      (server) => server.name === 'slangServer'
+    );
+    assert.ok(definition);
+
+    const selector = definition.buildClientOptions().documentSelector;
+
+    assert.deepStrictEqual(selector, [{ scheme: 'file', language: 'systemverilog' }]);
   });
 
   test('initializes and stops without enabled servers', async () => {

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 import * as assert from 'assert';
+import type { InitializeParams } from 'vscode-languageclient/node';
 
 import { createLanguageServerDefinitions } from '../languageServer/definitions';
 import { initAllLanguageClients, stopAllLanguageClients } from '../languageServer';
 import { buildServerOptions } from '../languageServer/manager';
+import { sanitizeSlangServerInitializeParams } from '../languageServer/slangServerCompatibility';
 
 suite('Language Server smoke', () => {
   test('defines expected servers', () => {
@@ -41,6 +43,62 @@ suite('Language Server smoke', () => {
     const selector = definition.buildClientOptions().documentSelector;
 
     assert.deepStrictEqual(selector, [{ scheme: 'file', language: 'systemverilog' }]);
+  });
+
+  test('only slang-server has an initialize params sanitizer', () => {
+    const definitions = createLanguageServerDefinitions();
+    const slangServer = definitions.find((server) => server.name === 'slangServer');
+
+    assert.strictEqual(typeof slangServer?.sanitizeInitializeParams, 'function');
+    assert.ok(
+      definitions
+        .filter((server) => server.name !== 'slangServer')
+        .every((server) => server.sanitizeInitializeParams === undefined)
+    );
+  });
+
+  test('slang-server sanitizer removes unsupported refactor.move code action kind', () => {
+    const params = initializeParamsWithCodeActionKinds([
+      '',
+      'quickfix',
+      'refactor.move',
+      'refactor.extract',
+      'source',
+    ]);
+
+    sanitizeSlangServerInitializeParams(params);
+
+    assert.deepStrictEqual(getCodeActionKindValueSet(params), [
+      '',
+      'quickfix',
+      'refactor.extract',
+      'source',
+    ]);
+  });
+
+  test('slang-server sanitizer tolerates missing or malformed code action capabilities', () => {
+    const malformedParams = [
+      { capabilities: {} },
+      { capabilities: { textDocument: {} } },
+      { capabilities: { textDocument: { codeAction: 'unsupported-shape' } } },
+      {
+        capabilities: {
+          textDocument: {
+            codeAction: {
+              codeActionLiteralSupport: {
+                codeActionKind: {
+                  valueSet: 'unsupported-shape',
+                },
+              },
+            },
+          },
+        },
+      },
+    ] as unknown as InitializeParams[];
+
+    for (const params of malformedParams) {
+      assert.doesNotThrow(() => sanitizeSlangServerInitializeParams(params));
+    }
   });
 
   test('initializes and stops without enabled servers', async () => {
@@ -92,3 +150,34 @@ suite('Language Server smoke', () => {
     assert.deepStrictEqual(options.debug.args, ['--lsp', '--define', 'A=B C']);
   });
 });
+
+function initializeParamsWithCodeActionKinds(valueSet: string[]): InitializeParams {
+  return {
+    capabilities: {
+      textDocument: {
+        codeAction: {
+          codeActionLiteralSupport: {
+            codeActionKind: {
+              valueSet,
+            },
+          },
+        },
+      },
+    },
+  } as unknown as InitializeParams;
+}
+
+function getCodeActionKindValueSet(params: InitializeParams): unknown {
+  const capabilities = params.capabilities as unknown as {
+    textDocument?: {
+      codeAction?: {
+        codeActionLiteralSupport?: {
+          codeActionKind?: {
+            valueSet?: unknown;
+          };
+        };
+      };
+    };
+  };
+  return capabilities.textDocument?.codeAction?.codeActionLiteralSupport?.codeActionKind?.valueSet;
+}

--- a/src/test/projectStabilization.test.ts
+++ b/src/test/projectStabilization.test.ts
@@ -321,7 +321,7 @@ suite('Minimal IDE Model Stabilization', () => {
       watcher.dispose();
     });
 
-    test('ProjectWatcher creates filelist watcher only while project indexing is enabled', () => {
+    test('ProjectWatcher creates filelist and source watchers only while project indexing is enabled', () => {
       let enabled = false;
       let watchersCreated = 0;
       let watchersDisposed = 0;
@@ -362,17 +362,17 @@ suite('Minimal IDE Model Stabilization', () => {
 
       enabled = true;
       configListener?.(projectConfigurationChangeEvent());
-      assert.strictEqual(watchersCreated, 1);
+      assert.strictEqual(watchersCreated, 2);
       assert.strictEqual(watchersDisposed, 0);
 
       enabled = false;
       configListener?.(projectConfigurationChangeEvent());
-      assert.strictEqual(watchersCreated, 1);
-      assert.strictEqual(watchersDisposed, 1);
-      assert.strictEqual(watcherEventDisposablesDisposed, 3);
+      assert.strictEqual(watchersCreated, 2);
+      assert.strictEqual(watchersDisposed, 2);
+      assert.strictEqual(watcherEventDisposablesDisposed, 6);
 
       watcher.dispose();
-      assert.strictEqual(watchersDisposed, 1);
+      assert.strictEqual(watchersDisposed, 2);
     });
 
     test('auto-discovery excludes large ignored directories before indexing', async function () {

--- a/src/test/semanticProject.test.ts
+++ b/src/test/semanticProject.test.ts
@@ -8,8 +8,10 @@ import { buildCompileUnit } from '../project/ProjectModelMerger';
 import type { ProjectSnapshot } from '../project/ProjectTypes';
 import { FastIndexerBackend } from '../semantic/backends/FastIndexerBackend';
 import { FastScanner } from '../semantic/backends/FastScanner';
+import { buildSlangAstArgs, SlangIndexerBackend } from '../semantic/backends/SlangIndexerBackend';
 import { SemanticIndex } from '../semantic/SemanticIndex';
 import type { ModuleRecord } from '../semantic/SymbolRecords';
+import type { ToolRunOptions, ToolRunResult } from '../tools/ToolRunner';
 import { assertSameFsPath } from './pathTestUtils';
 
 suite('FastScanner', () => {
@@ -154,6 +156,104 @@ suite('FastIndexerBackend', () => {
   });
 });
 
+suite('SlangIndexerBackend', () => {
+  test('falls back to fast index when slang is not available', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-slang-index-'));
+    const filePath = path.join(root, 'top.sv');
+    fs.writeFileSync(filePath, 'module top; endmodule\n');
+    const snapshot = createSnapshot(root, [filePath]);
+
+    const result = await new SlangIndexerBackend(
+      { engine: 'slang', slangPath: 'missing-slang', slangArguments: [], cacheEnabled: true },
+      new FastIndexerBackend(),
+      {
+        resolveExecutable: async () => undefined,
+        runTool: async () => {
+          throw new Error('should not run');
+        },
+      }
+    ).build(snapshot);
+
+    assert.strictEqual(result.metadata.actualEngine, 'fast');
+    assert.ok(result.metadata.fallbackReason?.includes('missing-slang'));
+    assert.ok(result.symbols.some((symbol) => symbol.kind === 'module' && symbol.name === 'top'));
+  });
+
+  test('uses slang AST JSON to enrich missing module port and parameter metadata', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-slang-index-'));
+    const filePath = path.join(root, 'top.sv');
+    fs.writeFileSync(filePath, 'module top; endmodule\n');
+    const snapshot = createSnapshot(root, [filePath]);
+    const ast = {
+      members: [
+        {
+          kind: 'Instance',
+          name: 'top',
+          body: {
+            members: [
+              { kind: 'Port', name: 'clk', direction: 'In', type: 'logic' },
+              { kind: 'Parameter', name: 'WIDTH', type: 'int', value: 32 },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await new SlangIndexerBackend(
+      { engine: 'slang', slangPath: 'slang', slangArguments: ['--single-unit'], cacheEnabled: true },
+      new FastIndexerBackend(),
+      {
+        resolveExecutable: async () => '/usr/bin/slang',
+        runTool: async (options: ToolRunOptions): Promise<ToolRunResult> => ({
+          exitCode: 0,
+          signal: null,
+          stdout: JSON.stringify(ast),
+          stderr: '',
+          command: options.command,
+          args: options.args,
+        }),
+      }
+    ).build(snapshot);
+    const index = new SemanticIndex(snapshot.version, result.symbols, result.metadata);
+    const moduleRecord = index.findBestModule('top');
+
+    assert.strictEqual(result.metadata.actualEngine, 'slang');
+    assert.ok(moduleRecord?.ports.some((port) => port.name === 'clk' && port.direction === 'input'));
+    assert.ok(moduleRecord?.parameters.some((parameter) => parameter.name === 'WIDTH'));
+  });
+
+  test('builds slang AST arguments from compile unit context', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verilog-slang-args-'));
+    const includeDir = path.join(root, 'include');
+    const filePath = path.join(root, 'rtl', 'top.sv');
+    fs.mkdirSync(includeDir);
+    fs.mkdirSync(path.dirname(filePath));
+    fs.writeFileSync(filePath, 'module top; endmodule\n');
+    const compileUnit = buildCompileUnit({
+      id: 'unit',
+      name: 'unit',
+      root: vscode.Uri.file(root),
+      files: [{ resolvedPath: filePath, kind: 'source' }],
+      includeDirs: [{ resolvedPath: includeDir }],
+      defines: [{ name: 'SIM', value: true, line: 0, character: 0 }],
+      settingsIncludeDirs: [],
+      settingsDefines: { WIDTH: 32 },
+      source: { type: 'settings' },
+    });
+
+    const args = buildSlangAstArgs(compileUnit, ['--single-unit']);
+
+    assert.deepStrictEqual(args, [
+      '--single-unit',
+      '--ast-json',
+      `-I${includeDir}`,
+      '-DSIM',
+      '-DWIDTH=32',
+      path.join('rtl', 'top.sv'),
+    ]);
+  });
+});
+
 suite('SemanticIndex query helpers', () => {
   test('findBestModule prefers the requested compile unit for duplicate modules', () => {
     const first = createModuleRecord('dupe', 'unitA');
@@ -208,5 +308,27 @@ function createSymbolRecord(
     range: selectionRange,
     selectionRange,
     compileUnitId,
+  };
+}
+
+function createSnapshot(root: string, files: string[]): ProjectSnapshot {
+  return {
+    version: 1,
+    workspaceRoot: vscode.Uri.file(root),
+    activeTargetId: 'unit',
+    compileUnits: [
+      buildCompileUnit({
+        id: 'unit',
+        name: 'unit',
+        root: vscode.Uri.file(root),
+        files: files.map((file) => ({ resolvedPath: file, kind: 'source' })),
+        includeDirs: [],
+        defines: [],
+        settingsIncludeDirs: [],
+        settingsDefines: {},
+        source: { type: 'settings' },
+      }),
+    ],
+    diagnostics: [],
   };
 }


### PR DESCRIPTION
## Summary

- Add `verilog.analysis.*` settings and an analysis backend abstraction for fast vs. Slang-backed indexing.
- Add Slang discovery, AST enrichment, and safe fallback to the existing fast scanner when Slang is unavailable or unusable.
- Surface analysis engine state in Doctor and add a Configure HDL Project command for project setup.
- Reload project state on HDL source/header changes and document the new analysis behavior.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile`
- `npm test` (`343 passing`, `3 pending`)