### PR TITLE
Add lint trigger settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Added
+
+- Added `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` settings to control automatic lint triggers independently.
+
 ## [1.27.1] - 2026-06-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ All linters expect the executable binary (`iverilog`, `verilator`, and so on) to
 
 On Windows, Vivado `xvlog` can be discovered when it is provided as `xvlog.bat` or `xvlog.cmd` on `PATH` or under `verilog.linting.path`.
 
-Set `verilog.linting.linter` to `none` to disable automatic linting without warnings. Automatic linting runs for Verilog/SystemVerilog files when they are opened or saved and a linter other than `none` is configured.
+Set `verilog.linting.linter` to `none` to disable automatic linting without warnings. Automatic linting runs for Verilog/SystemVerilog files when they are opened or saved and a linter other than `none` is configured. Use `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` to control these triggers independently. For example, users of `xvlog` can disable lint-on-open to avoid Vivado-generated workspace artifacts while keeping lint-on-save or manual linting enabled.
 
 While using `` `include`` directives, the path to the files should be relative to the workspace directory, unless `runAtFileLocation` is enabled (not supported by all linters).
 

--- a/package.json
+++ b/package.json
@@ -394,6 +394,18 @@
             "default": "none",
             "markdownDescription": "Select the verilog linter."
           },
+          "verilog.linting.runOnOpen": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Run the configured linter automatically when Verilog/SystemVerilog files are opened. Disable this to avoid linter side effects such as generated tool files on file open."
+          },
+          "verilog.linting.runOnSave": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Run the configured linter automatically when Verilog/SystemVerilog files are saved."
+          },
           "verilog.linting.useProjectContext": {
             "scope": "window",
             "type": "boolean",

--- a/src/linter/LintManager.ts
+++ b/src/linter/LintManager.ts
@@ -29,16 +29,18 @@ export default class LintManager {
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection('verilog-lint');
     this.diagnosticManager = new LinterDiagnosticManager(this.diagnosticCollection);
     this.runManager = new LintRunManager();
-    vscode.workspace.onDidOpenTextDocument(this.lint, this, this.subscriptions);
-    vscode.workspace.onDidSaveTextDocument(this.lint, this, this.subscriptions);
+    vscode.workspace.onDidOpenTextDocument(this.lintOnOpen, this, this.subscriptions);
+    vscode.workspace.onDidSaveTextDocument(this.lintOnSave, this, this.subscriptions);
     vscode.workspace.onDidCloseTextDocument(this.removeFileDiagnostics, this, this.subscriptions);
     vscode.workspace.onDidChangeConfiguration(this.configLinter, this, this.subscriptions);
     this.configLinter();
 
     // Run linting for open documents on launch
-    vscode.window.visibleTextEditors.forEach((editor) => {
-      this.lint(editor.document);
-    });
+    if (this.shouldRunOnOpen()) {
+      vscode.window.visibleTextEditors.forEach((editor) => {
+        this.lint(editor.document);
+      });
+    }
   }
 
   getLinterFromString(name: string): BaseLinter | null {
@@ -116,6 +118,28 @@ export default class LintManager {
       default:
         break;
     }
+  }
+
+  private shouldRunOnOpen(): boolean {
+    return vscode.workspace.getConfiguration('verilog.linting').get<boolean>('runOnOpen', true);
+  }
+
+  private shouldRunOnSave(): boolean {
+    return vscode.workspace.getConfiguration('verilog.linting').get<boolean>('runOnSave', true);
+  }
+
+  private lintOnOpen(doc: vscode.TextDocument): void {
+    if (!this.shouldRunOnOpen()) {
+      return;
+    }
+    this.lint(doc);
+  }
+
+  private lintOnSave(doc: vscode.TextDocument): void {
+    if (!this.shouldRunOnSave()) {
+      return;
+    }
+    this.lint(doc);
   }
 
   removeFileDiagnostics(doc: vscode.TextDocument) {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -199,6 +199,12 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.semanticDiagnostics.maxFiles']);
     assert.ok(properties['verilog.instantiate.useProjectIndex']);
     assert.ok(properties['verilog.preprocessor.useProjectDefines']);
+    const runOnOpen = properties['verilog.linting.runOnOpen'] as { default?: unknown };
+    const runOnSave = properties['verilog.linting.runOnSave'] as { default?: unknown };
+    assert.ok(runOnOpen);
+    assert.strictEqual(runOnOpen.default, true);
+    assert.ok(runOnSave);
+    assert.strictEqual(runOnSave.default, true);
     assert.ok(properties['verilog.linting.useProjectContext']);
     assert.ok(properties['verilog.linting.mode']);
     assert.ok(properties['verilog.linting.compileUnit.maxFiles']);

--- a/src/test/lintManager.test.ts
+++ b/src/test/lintManager.test.ts
@@ -14,16 +14,58 @@ interface LintManagerInternals {
   };
 }
 
-async function setConfiguredLinter(linter: string): Promise<unknown> {
+interface LintManagerTriggerInternals {
+  lintOnOpen: (doc: vscode.TextDocument) => void;
+  lintOnSave: (doc: vscode.TextDocument) => void;
+}
+
+interface FakeLinter {
+  name: string;
+  startLint: (doc: vscode.TextDocument, options?: unknown) => Promise<void>;
+  removeFileDiagnostics: (doc: vscode.TextDocument) => void;
+  dispose: () => void;
+}
+
+async function setLintConfigValue(key: string, value: unknown): Promise<unknown> {
   const config = vscode.workspace.getConfiguration('verilog.linting');
-  const previous = config.get('linter');
-  await config.update('linter', linter, vscode.ConfigurationTarget.Global);
+  const previous = config.inspect(key)?.globalValue;
+  await config.update(key, value, vscode.ConfigurationTarget.Global);
   return previous;
 }
 
-async function restoreConfiguredLinter(previous: unknown): Promise<void> {
+async function restoreLintConfigValue(key: string, previous: unknown): Promise<void> {
   const config = vscode.workspace.getConfiguration('verilog.linting');
-  await config.update('linter', previous, vscode.ConfigurationTarget.Global);
+  await config.update(key, previous, vscode.ConfigurationTarget.Global);
+}
+
+async function setConfiguredLinter(linter: string): Promise<unknown> {
+  return setLintConfigValue('linter', linter);
+}
+
+async function restoreConfiguredLinter(previous: unknown): Promise<void> {
+  await restoreLintConfigValue('linter', previous);
+}
+
+function createVerilogDocument(): Thenable<vscode.TextDocument> {
+  return vscode.workspace.openTextDocument({
+    language: 'verilog',
+    content: 'module test; endmodule',
+  });
+}
+
+async function createVisibleVerilogDocument(): Promise<vscode.TextDocument> {
+  const document = await createVerilogDocument();
+  await vscode.window.showTextDocument(document);
+  return document;
+}
+
+function stubConfiguredLinter(fakeLinter: FakeLinter): () => void {
+  const original = LintManager.prototype.getLinterFromString;
+  LintManager.prototype.getLinterFromString = () =>
+    fakeLinter as unknown as ReturnType<LintManager['getLinterFromString']>;
+  return () => {
+    LintManager.prototype.getLinterFromString = original;
+  };
 }
 
 suite('LintManager', () => {
@@ -39,6 +81,10 @@ suite('LintManager', () => {
 
   setup(() => {
     logCapture.clear();
+  });
+
+  teardown(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
   });
 
   test('treats none as a no-op linter without invalid warning', async () => {
@@ -110,6 +156,176 @@ suite('LintManager', () => {
     } finally {
       manager.dispose();
       await restoreConfiguredLinter(previous);
+    }
+  });
+
+  test('skips startup linting of visible editors when runOnOpen is false', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnOpen = await setLintConfigValue('runOnOpen', false);
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    await createVisibleVerilogDocument();
+    const manager = new LintManager();
+
+    try {
+      assert.strictEqual(lintedDocuments.length, 0);
+    } finally {
+      manager.dispose();
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnOpen', previousRunOnOpen);
+      await restoreConfiguredLinter(previousLinter);
+    }
+  });
+
+  test('startup linting of visible editors runs when runOnOpen is true', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnOpen = await setLintConfigValue('runOnOpen', true);
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    const document = await createVisibleVerilogDocument();
+    const manager = new LintManager();
+
+    try {
+      assert.ok(lintedDocuments.includes(document));
+    } finally {
+      manager.dispose();
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnOpen', previousRunOnOpen);
+      await restoreConfiguredLinter(previousLinter);
+    }
+  });
+
+  test('startup linting of visible editors runs when runOnOpen is unset', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnOpen = await setLintConfigValue('runOnOpen', undefined);
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    const document = await createVisibleVerilogDocument();
+    const manager = new LintManager();
+
+    try {
+      assert.ok(lintedDocuments.includes(document));
+    } finally {
+      manager.dispose();
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnOpen', previousRunOnOpen);
+      await restoreConfiguredLinter(previousLinter);
+    }
+  });
+
+  test('lint-on-open follows runOnOpen setting', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnOpen = await setLintConfigValue('runOnOpen', false);
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    const document = await createVerilogDocument();
+    const manager = new LintManager();
+
+    try {
+      (manager as unknown as LintManagerTriggerInternals).lintOnOpen(document);
+      assert.strictEqual(lintedDocuments.length, 0);
+
+      await setLintConfigValue('runOnOpen', true);
+      (manager as unknown as LintManagerTriggerInternals).lintOnOpen(document);
+      assert.deepStrictEqual(lintedDocuments, [document]);
+    } finally {
+      manager.dispose();
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnOpen', previousRunOnOpen);
+      await restoreConfiguredLinter(previousLinter);
+    }
+  });
+
+  test('lint-on-save follows runOnSave setting', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnSave = await setLintConfigValue('runOnSave', false);
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    const document = await createVerilogDocument();
+    const manager = new LintManager();
+
+    try {
+      (manager as unknown as LintManagerTriggerInternals).lintOnSave(document);
+      assert.strictEqual(lintedDocuments.length, 0);
+
+      await setLintConfigValue('runOnSave', true);
+      (manager as unknown as LintManagerTriggerInternals).lintOnSave(document);
+      assert.deepStrictEqual(lintedDocuments, [document]);
+    } finally {
+      manager.dispose();
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnSave', previousRunOnSave);
+      await restoreConfiguredLinter(previousLinter);
+    }
+  });
+
+  test('manual lint ignores automatic trigger settings', async () => {
+    const previousLinter = await setConfiguredLinter('iverilog');
+    const previousRunOnOpen = await setLintConfigValue('runOnOpen', false);
+    const previousRunOnSave = await setLintConfigValue('runOnSave', false);
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    const lintedDocuments: vscode.TextDocument[] = [];
+    const restoreGetLinter = stubConfiguredLinter({
+      name: 'iverilog',
+      startLint: async (doc) => {
+        lintedDocuments.push(doc);
+      },
+      removeFileDiagnostics: () => undefined,
+      dispose: () => undefined,
+    });
+    const document = await createVisibleVerilogDocument();
+    const manager = new LintManager();
+    (vscode.window as unknown as { showQuickPick: unknown }).showQuickPick = async () => ({
+      label: 'iverilog',
+      description: 'Icarus Verilog',
+    });
+
+    try {
+      await manager.runLintTool();
+
+      assert.deepStrictEqual(lintedDocuments, [document]);
+    } finally {
+      manager.dispose();
+      (vscode.window as unknown as { showQuickPick: unknown }).showQuickPick = originalShowQuickPick;
+      restoreGetLinter();
+      await restoreLintConfigValue('runOnSave', previousRunOnSave);
+      await restoreLintConfigValue('runOnOpen', previousRunOnOpen);
+      await restoreConfiguredLinter(previousLinter);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Add `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` settings with default-on behavior.
- Route automatic open, save, and startup lint triggers through those settings while leaving manual lint unchanged.
- Document the `xvlog` workaround for avoiding Vivado-generated artifacts on file open.

## Why

Issue #624 reports that opening a `.v` file can create `xsim.dir` and `xvlog.pb` when `xvlog` is configured as the linter. The root cause is automatic lint-on-open. These settings let users disable that trigger without disabling lint-on-save or manual linting.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run check-types`
- `npm run compile-tests`
- `npm test` (`341 passing`, `3 pending`)