### PR TITLE
Fix xvlog work library artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept `xvlog` linting enabled while directing Vivado's work library to a temporary directory outside the workspace unless the user configures `-work` or `--work`.
+
 ## [1.27.2] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ All linters expect the executable binary (`iverilog`, `verilator`, and so on) to
 
 On Windows, Vivado `xvlog` can be discovered when it is provided as `xvlog.bat` or `xvlog.cmd` on `PATH` or under `verilog.linting.path`.
 
-Set `verilog.linting.linter` to `none` to disable automatic linting without warnings. Automatic linting runs for Verilog/SystemVerilog files when they are opened or saved and a linter other than `none` is configured. Use `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` to control these triggers independently. For example, users of `xvlog` can disable lint-on-open to avoid Vivado-generated workspace artifacts while keeping lint-on-save or manual linting enabled.
+Set `verilog.linting.linter` to `none` to disable automatic linting without warnings. Automatic linting runs for Verilog/SystemVerilog files when they are opened or saved and a linter other than `none` is configured. Use `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` to control these triggers independently.
+
+When `xvlog` is used as the linter, Vivado may create simulator/compiler artifacts such as `xsim.dir` and `xvlog.pb`. The extension directs xvlog's temporary work library outside the workspace, so grammar checking can remain enabled without writing the work library into the workspace. If `verilog.linting.xvlog.arguments` includes `-work` or `--work`, the extension leaves that user-managed work library unchanged instead of adding its own temporary work library. `verilog.linting.runOnOpen` and `verilog.linting.runOnSave` can still be used to control automatic lint triggers independently.
 
 While using `` `include`` directives, the path to the files should be relative to the workspace directory, unless `runAtFileLocation` is enabled (not supported by all linters).
 

--- a/package.json
+++ b/package.json
@@ -398,7 +398,7 @@
             "scope": "window",
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Run the configured linter automatically when Verilog/SystemVerilog files are opened. Disable this to avoid linter side effects such as generated tool files on file open."
+            "markdownDescription": "Run the configured linter automatically when Verilog/SystemVerilog files are opened."
           },
           "verilog.linting.runOnSave": {
             "scope": "window",

--- a/src/linter/XvlogLinter.ts
+++ b/src/linter/XvlogLinter.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import BaseLinter from './BaseLinter';
 import type { ProjectService } from '../project/ProjectService';
@@ -16,6 +18,7 @@ export interface BuildXvlogArgsOptions {
   defineArgs?: string[];
   customArguments: string;
   documentPath: string;
+  workLibrary?: string;
 }
 
 export function buildXvlogArgs(options: BuildXvlogArgsOptions): string[] {
@@ -29,9 +32,18 @@ export function buildXvlogArgs(options: BuildXvlogArgsOptions): string[] {
   for (const defineArg of options.defineArgs ?? []) {
     args.push('--define', defineArg);
   }
+  if (options.workLibrary) {
+    args.push('-work', options.workLibrary);
+  }
   args.push(...splitCommandLineArgs(options.customArguments));
   args.push(options.documentPath);
   return args;
+}
+
+export function hasXvlogWorkArgument(customArguments: string): boolean {
+  return splitCommandLineArgs(customArguments).some((arg) =>
+    arg === '-work' || arg === '--work' || arg.startsWith('-work=') || arg.startsWith('--work=')
+  );
 }
 
 function convertXvlogSeverity(severityString: string): vscode.DiagnosticSeverity {
@@ -89,6 +101,15 @@ export default class XvlogLinter extends BaseLinter {
   protected async lint(doc: vscode.TextDocument, run: LintRunHandle, options: LintRunOptions): Promise<void> {
     this.warnUnsupportedCompileUnitMode(options);
     const binPath: string = path.join(this.config.linterInstalledPath, 'xvlog');
+    const cwd = this.getWorkingDirectory(doc);
+    const userManagedWorkLibrary = hasXvlogWorkArgument(this.config.arguments);
+    const tempDir = userManagedWorkLibrary
+      ? undefined
+      : fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-verilog-xvlog-'));
+    const tempWorkDir = tempDir ? path.join(tempDir, 'work') : undefined;
+    if (tempWorkDir) {
+      fs.mkdirSync(tempWorkDir, { recursive: true });
+    }
 
     const args = buildXvlogArgs({
       languageId: doc.languageId,
@@ -96,12 +117,29 @@ export default class XvlogLinter extends BaseLinter {
       defineArgs: this.getProjectContext(doc).defineArgs,
       customArguments: this.config.arguments,
       documentPath: doc.fileName,
+      workLibrary: tempWorkDir ? `work=${tempWorkDir}` : undefined,
     });
-    const cwd = this.getWorkingDirectory(doc);
 
-    this.logger.info("Executing", { command: binPath, args, cwd });
+    try {
+      this.logger.info("Executing", { command: binPath, args, cwd, tempDir });
 
-    await this.runXvlog(binPath, args, cwd, doc, run);
+      await this.runXvlog(binPath, args, cwd, doc, run);
+    } finally {
+      if (tempDir) {
+        this.cleanupTempDir(tempDir);
+      }
+    }
+  }
+
+  private cleanupTempDir(tempDir: string): void {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (err) {
+      this.logger.warn('Failed to clean xvlog temporary directory', {
+        tempDir,
+        error: String(err),
+      });
+    }
   }
 
   private async runXvlog(

--- a/src/test/xvlog.test.ts
+++ b/src/test/xvlog.test.ts
@@ -4,19 +4,32 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { buildXvlogArgs, parseXvlogDiagnostics } from '../linter/XvlogLinter';
+import XvlogLinter, {
+  buildXvlogArgs,
+  hasXvlogWorkArgument,
+  parseXvlogDiagnostics,
+} from '../linter/XvlogLinter';
+import LinterDiagnosticManager from '../linter/LinterDiagnosticManager';
+import LintRunManager from '../linter/LintRunManager';
+
+interface XvlogCleanupInternals {
+  cleanupTempDir(tempDir: string): void;
+  dispose(): void;
+}
 
 suite('Xvlog Linter', () => {
   test('builds args with automatic flags and split custom args', () => {
     const includePath = path.join(os.tmpdir(), 'xvlog include');
     const projectIncludePath = path.join(os.tmpdir(), 'xvlog project include');
     const documentPath = path.join(os.tmpdir(), 'xvlog source', 'top file.sv');
+    const workLibrary = `work=${path.join(os.tmpdir(), 'xvlog work', 'work')}`;
     const args = buildXvlogArgs({
       languageId: 'systemverilog',
       includePaths: [includePath, projectIncludePath],
       defineArgs: ['SIM', 'WIDTH=32'],
       customArguments: '--define FOO="bar baz"',
       documentPath,
+      workLibrary,
     });
 
     assert.deepStrictEqual(args, [
@@ -30,11 +43,72 @@ suite('Xvlog Linter', () => {
       'SIM',
       '--define',
       'WIDTH=32',
+      '-work',
+      workLibrary,
       '--define',
       'FOO=bar baz',
       documentPath,
     ]);
     assert.ok(!args.some((arg) => arg.includes('"')), 'Args must not contain manual quotes');
+  });
+
+  test('builds args without work library when not provided', () => {
+    const documentPath = path.join(os.tmpdir(), 'top.v');
+    const args = buildXvlogArgs({
+      languageId: 'verilog',
+      includePaths: [],
+      customArguments: '-Wall',
+      documentPath,
+    });
+
+    assert.deepStrictEqual(args, [
+      '-nolog',
+      '-Wall',
+      documentPath,
+    ]);
+  });
+
+  test('preserves user-provided work library arguments when managed work library is omitted', () => {
+    const documentPath = path.join(os.tmpdir(), 'top.v');
+    const customWorkLibrary = `work=${path.join(os.tmpdir(), 'user-xvlog-work')}`;
+    const args = buildXvlogArgs({
+      languageId: 'verilog',
+      includePaths: [],
+      customArguments: `-work ${customWorkLibrary}`,
+      documentPath,
+    });
+
+    assert.deepStrictEqual(args, [
+      '-nolog',
+      '-work',
+      customWorkLibrary,
+      documentPath,
+    ]);
+  });
+
+  test('places work library before custom arguments and document path', () => {
+    const workLibrary = `work=${path.join(os.tmpdir(), 'xvlog-work')}`;
+    const documentPath = path.join(os.tmpdir(), 'top.v');
+    const args = buildXvlogArgs({
+      languageId: 'verilog',
+      includePaths: [],
+      customArguments: '-f files.f',
+      documentPath,
+      workLibrary,
+    });
+
+    assert.strictEqual(args.indexOf('-work') + 1, args.indexOf(workLibrary));
+    assert.ok(args.indexOf(workLibrary) < args.indexOf('-f'));
+    assert.ok(args.indexOf(workLibrary) < args.indexOf(documentPath));
+  });
+
+  test('detects user-managed work library arguments', () => {
+    assert.strictEqual(hasXvlogWorkArgument('-work work=/tmp/user-work'), true);
+    assert.strictEqual(hasXvlogWorkArgument('--work work=/tmp/user-work'), true);
+    assert.strictEqual(hasXvlogWorkArgument('-work=work=/tmp/user-work'), true);
+    assert.strictEqual(hasXvlogWorkArgument('--work=work=/tmp/user-work'), true);
+    assert.strictEqual(hasXvlogWorkArgument('--define WORK="-work"'), false);
+    assert.strictEqual(hasXvlogWorkArgument('--workaround enabled'), false);
   });
 
   test('parses diagnostics with paths containing spaces', () => {
@@ -67,4 +141,31 @@ suite('Xvlog Linter', () => {
     assert.ok(!source.includes('child.exec'), 'XvlogLinter must not call child_process.exec');
     assert.ok(!source.includes('exec(command'), 'XvlogLinter must not call exec(command)');
   });
+
+  test('cleans xvlog temp directory best-effort', () => {
+    const linter = createXvlogLinterInternals();
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xvlog-temp-cleanup-'));
+    try {
+      const workDir = path.join(tempRoot, 'work');
+      fs.mkdirSync(workDir);
+
+      linter.cleanupTempDir(tempRoot);
+
+      assert.ok(!fs.existsSync(tempRoot));
+      assert.doesNotThrow(() => linter.cleanupTempDir(String.fromCharCode(0)));
+    } finally {
+      linter.dispose();
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
+
+function createXvlogLinterInternals(): XvlogCleanupInternals {
+  const diagnosticManager = new LinterDiagnosticManager({
+    set() {},
+    delete() {},
+    clear() {},
+    dispose() {},
+  });
+  return new XvlogLinter(diagnosticManager, new LintRunManager()) as unknown as XvlogCleanupInternals;
+}

--- a/src/test/xvlog.test.ts
+++ b/src/test/xvlog.test.ts
@@ -70,7 +70,7 @@ suite('Xvlog Linter', () => {
 
   test('preserves user-provided work library arguments when managed work library is omitted', () => {
     const documentPath = path.join(os.tmpdir(), 'top.v');
-    const customWorkLibrary = `work=${path.join(os.tmpdir(), 'user-xvlog-work')}`;
+    const customWorkLibrary = 'work=/tmp/user-xvlog-work';
     const args = buildXvlogArgs({
       languageId: 'verilog',
       includePaths: [],


### PR DESCRIPTION
## Summary

- run xvlog with an extension-managed temporary work library by default
- skip the managed `-work` argument when users provide `-work` or `--work` in `verilog.linting.xvlog.arguments`
- update README, settings text, changelog, and xvlog tests for the new behavior

## Why

Vivado `xvlog` can write simulator/compiler library artifacts into the current working directory. Disabling lint-on-open avoids that side effect but also disables automatic grammar checking. This keeps xvlog diagnostics enabled while moving the default work library outside the workspace, and preserves explicit user-managed work library configuration.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` (`346 passing`, `3 pending`)