### PR TITLE
Harden HDL Explorer refresh and WASI paths

### DIFF
--- a/src/slangServer/SlangServerApi.ts
+++ b/src/slangServer/SlangServerApi.ts
@@ -409,6 +409,9 @@ export class SlangServerApi {
 
   private toWorkspaceWasiPath(value: string): string | undefined {
     const normalized = value.replace(/\\/g, '/');
+    if (hasParentPathSegment(normalized)) {
+      return undefined;
+    }
     if (this.isWasiWorkspacePath(normalized)) {
       return normalized;
     }
@@ -424,9 +427,7 @@ export class SlangServerApi {
     const relativePath = normalized.replace(/^\/+/, '');
     if (
       !relativePath
-      || relativePath === '..'
-      || relativePath.startsWith('../')
-      || relativePath.includes('/../')
+      || hasParentPathSegment(relativePath)
     ) {
       return undefined;
     }
@@ -502,4 +503,8 @@ function looksLikeHostAbsolutePath(value: string): boolean {
     '/usr',
     '/var',
   ].some((root) => normalized === root || normalized.startsWith(`${root}/`));
+}
+
+function hasParentPathSegment(value: string): boolean {
+  return value.split('/').some((segment) => segment === '..');
 }

--- a/src/slangServer/WasiFileSystemMapper.ts
+++ b/src/slangServer/WasiFileSystemMapper.ts
@@ -38,7 +38,7 @@ export class WasiFileSystemMapper {
     if (relative === '') {
       return mountRoot;
     }
-    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    if (hasParentPathSegment(relative) || path.isAbsolute(relative)) {
       return undefined;
     }
     return `${mountRoot}/${relative.replace(/\\/g, '/')}`;
@@ -51,6 +51,14 @@ export class WasiFileSystemMapper {
     if (!wasiPath.startsWith(`${mountRoot}/`)) {
       return undefined;
     }
-    return path.join(hostRoot, wasiPath.slice(mountRoot.length + 1));
+    const relative = wasiPath.slice(mountRoot.length + 1);
+    if (hasParentPathSegment(relative)) {
+      return undefined;
+    }
+    return path.join(hostRoot, relative);
   }
+}
+
+function hasParentPathSegment(value: string): boolean {
+  return value.replace(/\\/g, '/').split('/').some((segment) => segment === '..');
 }

--- a/src/test/hdlExplorerProvider.test.ts
+++ b/src/test/hdlExplorerProvider.test.ts
@@ -65,21 +65,65 @@ suite('Slang-backed HDL Explorer', () => {
     assert.strictEqual(children.length, 1);
     assert.strictEqual(children[0].label, 'u_child : child');
   });
+
+  test('refreshes when slang-server status changes', () => {
+    const fixture = createProviderFixture();
+    let refreshCount = 0;
+    const subscription = fixture.provider.onDidChangeTreeData(() => {
+      refreshCount += 1;
+    });
+
+    fixture.fireStatus();
+
+    assert.strictEqual(refreshCount, 1);
+    subscription.dispose();
+    fixture.provider.dispose();
+    fixture.statusEmitter.dispose();
+  });
+
+  test('stops refreshing after dispose', () => {
+    const fixture = createProviderFixture();
+    let refreshCount = 0;
+    const subscription = fixture.provider.onDidChangeTreeData(() => {
+      refreshCount += 1;
+    });
+
+    fixture.provider.dispose();
+    fixture.fireStatus();
+
+    assert.strictEqual(refreshCount, 0);
+    subscription.dispose();
+    fixture.statusEmitter.dispose();
+  });
 });
 
 function createProvider(input: {
   modules?: Awaited<ReturnType<SlangServerApi['getScopesByModule']>>;
   scope?: Awaited<ReturnType<SlangServerApi['getScope']>>;
 } = {}): HdlExplorerProvider {
+  return createProviderFixture(input).provider;
+}
+
+function createProviderFixture(input: {
+  modules?: Awaited<ReturnType<SlangServerApi['getScopesByModule']>>;
+  scope?: Awaited<ReturnType<SlangServerApi['getScope']>>;
+} = {}): {
+  provider: HdlExplorerProvider;
+  fireStatus: () => void;
+  statusEmitter: vscode.EventEmitter<ReturnType<SlangServerManager['getStatus']>>;
+} {
+  const status = {
+    enabled: true,
+    configuredRuntime: 'native',
+    resolvedRuntime: 'native',
+    state: 'running',
+    path: '/usr/bin/slang-server',
+    args: [],
+  } as ReturnType<SlangServerManager['getStatus']>;
+  const statusEmitter = new vscode.EventEmitter<ReturnType<SlangServerManager['getStatus']>>();
   const manager = {
-    getStatus: () => ({
-      enabled: true,
-      configuredRuntime: 'native',
-      resolvedRuntime: 'native',
-      state: 'running',
-      path: '/usr/bin/slang-server',
-      args: [],
-    }),
+    getStatus: () => status,
+    onDidChangeStatus: statusEmitter.event,
     executeCommand: async <T,>(command: string): Promise<T> => {
       if (command === 'slang.getScopesByModule') {
         return (input.modules ?? []) as T;
@@ -97,5 +141,9 @@ function createProvider(input: {
       workspaceConfig: vscode.Uri.file('/tmp/.slang/server.json'),
     }),
   } as unknown as SlangConfigService;
-  return new HdlExplorerProvider(api, manager, configService);
+  return {
+    provider: new HdlExplorerProvider(api, manager, configService),
+    fireStatus: () => statusEmitter.fire(status),
+    statusEmitter,
+  };
 }

--- a/src/test/slangServerApi.test.ts
+++ b/src/test/slangServerApi.test.ts
@@ -51,11 +51,28 @@ suite('SlangServerApi', () => {
 
     await api.setTopLevel('/rtl/top.sv');
     await api.setTopLevel('rtl/top.sv');
+    await api.setTopLevel('/workspace/rtl/top.sv');
 
     assert.deepStrictEqual(calls, [
       { command: 'slang.setTopLevel', args: ['/workspace/rtl/top.sv'] },
       { command: 'slang.setTopLevel', args: ['/workspace/rtl/top.sv'] },
+      { command: 'slang.setTopLevel', args: ['/workspace/rtl/top.sv'] },
     ]);
+  });
+
+  test('rejects bundled WASM command paths with parent segments', async () => {
+    const workspaceRoot = path.join(process.cwd(), 'tmp', 'slang-api-workspace');
+    const calls: ExecuteCall[] = [];
+    const api = createApi('bundled-wasm', workspaceRoot, calls);
+
+    for (const pathValue of ['rtl/..', 'rtl/../top.sv', '/workspace/../outside.sv']) {
+      await assert.rejects(
+        () => api.setTopLevel(pathValue),
+        /outside the WASI workspace/,
+        pathValue
+      );
+    }
+    assert.deepStrictEqual(calls, []);
   });
 
   test('rejects bundled WASM command paths outside the mounted workspace', async () => {
@@ -94,6 +111,18 @@ suite('SlangServerApi', () => {
 
     assert.ok(location);
     assertFsPathEqual(location.uri.fsPath, path.join(workspaceRoot, 'rtl', 'top.sv'));
+  });
+
+  test('does not map WASI locations with parent segments back to host files', () => {
+    const workspaceRoot = path.join(process.cwd(), 'tmp', 'slang-api-workspace');
+    const api = createApi('bundled-wasm', workspaceRoot, []);
+
+    const location = api.toLocation({
+      path: '/workspace/../outside.sv',
+      range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+    });
+
+    assert.strictEqual(location, undefined);
   });
 
   test('does not treat host absolute paths under tmp as workspace-relative WASI paths', async () => {

--- a/src/views/HdlExplorerProvider.ts
+++ b/src/views/HdlExplorerProvider.ts
@@ -16,6 +16,7 @@ import {
 
 export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerItem>, vscode.Disposable {
   private readonly emitter = new vscode.EventEmitter<HdlExplorerItem | undefined>();
+  private readonly statusSubscription: vscode.Disposable;
   private focusedHierarchyPath = '';
   readonly onDidChangeTreeData = this.emitter.event;
 
@@ -23,7 +24,9 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
     private readonly api: SlangServerApi,
     private readonly manager: SlangServerManager,
     private readonly configService: SlangConfigService
-  ) {}
+  ) {
+    this.statusSubscription = this.manager.onDidChangeStatus(() => this.refresh());
+  }
 
   refresh(): void {
     this.emitter.fire(undefined);
@@ -63,6 +66,7 @@ export class HdlExplorerProvider implements vscode.TreeDataProvider<HdlExplorerI
   }
 
   dispose(): void {
+    this.statusSubscription.dispose();
     this.emitter.dispose();
   }
 


### PR DESCRIPTION
## Summary

- Refresh HDL Explorer when slang-server status changes so server state does not stay stale in the tree.
- Dispose the HDL Explorer status subscription with the tree provider.
- Reject parent path segments in WASM/WASI path mapping so `/workspace` paths cannot resolve outside the mounted workspace.
- Add regression coverage for status refresh disposal and WASI parent-segment rejection.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` (`176 passing / 4 pending`)