### PR TITLE
Fix slang-server initialize compatibility

### DIFF
--- a/scripts/patch-slang-server-wasi.mjs
+++ b/scripts/patch-slang-server-wasi.mjs
@@ -35,53 +35,6 @@ patchFile('include/lsp/LspServer.h', [
   [
     '        std::cerr << "Registered command: " << name << "\\n";\n',
     '#ifndef __wasi__\n        std::cerr << "Registered command: " << name << "\\n";\n#endif\n'
-  ],
-  [
-    '    void registerInitialize() {\n        this->template registerMethod<InitializeParams, InitializeResult, &Impl::getInitialize>(\n            "initialize");\n    };\n',
-    `    void registerInitialize() {
-#ifdef __wasi__
-        this->requests["initialize"] = [this](std::optional<rfl::Generic> paramsJson) -> rfl::Generic {
-            InitializeParams params{};
-            if (paramsJson) {
-                auto root = paramsJson->to_object();
-                if (root) {
-                    auto rootPath = (*root)["rootPath"].to_string();
-                    if (rootPath)
-                        params.rootPath = rootPath.value();
-
-                    auto rootUri = (*root)["rootUri"].to_string();
-                    if (rootUri)
-                        params.rootUri = URI(rootUri.value());
-
-                    auto folders = (*root)["workspaceFolders"].to_array();
-                    if (folders && !folders->empty()) {
-                        std::vector<WorkspaceFolder> parsedFolders;
-                        auto first = folders->front().to_object();
-                        if (first) {
-                            WorkspaceFolder folder;
-                            auto uri = (*first)["uri"].to_string();
-                            auto name = (*first)["name"].to_string();
-                            if (uri)
-                                folder.uri = URI(uri.value());
-                            if (name)
-                                folder.name = name.value();
-                            else
-                                folder.name = "workspace";
-                            parsedFolders.push_back(folder);
-                            params.workspaceFolders = parsedFolders;
-                        }
-                    }
-                }
-            }
-            return rfl::to_generic<rfl::UnderlyingEnums>(
-                (static_cast<Impl*>(this)->getInitialize(params)));
-        };
-#else
-        this->template registerMethod<InitializeParams, InitializeResult, &Impl::getInitialize>(
-            "initialize");
-#endif
-    };
-`
   ]
 ]);
 

--- a/src/slangServer/NativeSlangServerRuntime.ts
+++ b/src/slangServer/NativeSlangServerRuntime.ts
@@ -8,6 +8,7 @@ import {
   type ServerOptions,
 } from 'vscode-languageclient/node';
 import { runTool } from '../tools/ToolRunner';
+import { SlangLanguageClient } from './SlangLanguageClientCompat';
 import type { SlangServerConfig } from './SlangServerConfig';
 import type { SlangServerRuntime, SlangServerStatus, SlangServerState } from './SlangServerRuntime';
 import { toLanguageClientTrace } from './SlangServerTrace';
@@ -64,7 +65,7 @@ export class NativeSlangServerRuntime implements SlangServerRuntime {
       traceOutputChannel: this.options.outputChannel,
     };
 
-    this.client = new LanguageClient(
+    this.client = new SlangLanguageClient(
       'verilog-slang-server',
       'Verilog slang-server',
       serverOptions,

--- a/src/slangServer/SlangLanguageClientCompat.ts
+++ b/src/slangServer/SlangLanguageClientCompat.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+import {
+  LanguageClient,
+  type InitializeParams,
+  type LanguageClientOptions,
+  type ServerOptions,
+} from 'vscode-languageclient/node';
+
+const UNSUPPORTED_SLANG_CODE_ACTION_KIND = 'refactor.move';
+
+export function removeUnsupportedSlangCodeActionKinds(params: InitializeParams): void {
+  const codeActionKind =
+    params.capabilities.textDocument?.codeAction
+      ?.codeActionLiteralSupport?.codeActionKind;
+
+  if (!codeActionKind || !Array.isArray(codeActionKind.valueSet)) {
+    return;
+  }
+
+  codeActionKind.valueSet = codeActionKind.valueSet.filter(
+    (kind) => kind !== UNSUPPORTED_SLANG_CODE_ACTION_KIND
+  );
+}
+
+export class SlangLanguageClient extends LanguageClient {
+  constructor(
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+    forceDebug?: boolean
+  ) {
+    super(id, name, serverOptions, clientOptions, forceDebug);
+  }
+
+  protected override fillInitializeParams(params: InitializeParams): void {
+    super.fillInitializeParams(params);
+    removeUnsupportedSlangCodeActionKinds(params);
+  }
+}

--- a/src/slangServer/VsCodeWasmSlangServerRuntime.ts
+++ b/src/slangServer/VsCodeWasmSlangServerRuntime.ts
@@ -19,6 +19,7 @@ import type {
   SlangServerStatus,
   SlangServerWasmMetadata,
 } from './SlangServerRuntime';
+import { SlangLanguageClient } from './SlangLanguageClientCompat';
 import { createWasmServerEnv, toLanguageClientTrace } from './SlangServerTrace';
 import { WasiFileSystemMapper } from './WasiFileSystemMapper';
 import { readWasmMetadata, type WasmRuntimePaths } from './WasmSlangServerRuntime';
@@ -125,7 +126,7 @@ export class VsCodeWasmSlangServerRuntime implements SlangServerRuntime {
         uriConverters: createSlangWasmUriConverters(this.mapper),
       };
 
-      this.client = new LanguageClient(
+      this.client = new SlangLanguageClient(
         'verilog-slang-server-vscode-wasm',
         'Verilog slang-server VS Code WASM',
         serverOptions,

--- a/src/slangServer/WasmSlangServerRuntime.ts
+++ b/src/slangServer/WasmSlangServerRuntime.ts
@@ -18,6 +18,7 @@ import type {
   SlangServerState,
   SlangServerWasmMetadata,
 } from './SlangServerRuntime';
+import { SlangLanguageClient } from './SlangLanguageClientCompat';
 import { toLanguageClientTrace } from './SlangServerTrace';
 import { WasiFileSystemMapper } from './WasiFileSystemMapper';
 
@@ -120,7 +121,7 @@ export class WasmSlangServerRuntime implements SlangServerRuntime {
       traceOutputChannel: this.options.outputChannel,
     };
 
-    this.client = new LanguageClient(
+    this.client = new SlangLanguageClient(
       'verilog-slang-server-wasm',
       'Verilog slang-server WASM',
       serverOptions,

--- a/src/test/slangLanguageClientCompat.test.ts
+++ b/src/test/slangLanguageClientCompat.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { InitializeParams } from 'vscode-languageclient/node';
+import { removeUnsupportedSlangCodeActionKinds } from '../slangServer/SlangLanguageClientCompat';
+import { getRepositoryRoot } from './pathTestUtils';
+
+suite('SlangLanguageClient compatibility', () => {
+  test('removes only refactor.move from initialize code action kind values', () => {
+    const valueSet = [
+      '',
+      'quickfix',
+      'refactor',
+      'refactor.extract',
+      'refactor.inline',
+      'refactor.move',
+      'refactor.rewrite',
+      'source',
+      'source.organizeImports',
+      'source.fixAll',
+      'notebook',
+    ];
+    const params = createInitializeParams(valueSet);
+
+    removeUnsupportedSlangCodeActionKinds(params);
+
+    assert.deepStrictEqual(
+      params.capabilities.textDocument?.codeAction
+        ?.codeActionLiteralSupport?.codeActionKind.valueSet,
+      [
+        '',
+        'quickfix',
+        'refactor',
+        'refactor.extract',
+        'refactor.inline',
+        'refactor.rewrite',
+        'source',
+        'source.organizeImports',
+        'source.fixAll',
+        'notebook',
+      ]
+    );
+  });
+
+  test('does not mutate initialize params when code action capability is absent', () => {
+    const params = { capabilities: {} } as InitializeParams;
+
+    removeUnsupportedSlangCodeActionKinds(params);
+
+    assert.deepStrictEqual(params, { capabilities: {} });
+  });
+
+  test('does not mutate initialize params when valueSet is absent', () => {
+    const codeActionKind = {};
+    const params = {
+      capabilities: {
+        textDocument: {
+          codeAction: {
+            codeActionLiteralSupport: {
+              codeActionKind,
+            },
+          },
+        },
+      },
+    } as unknown as InitializeParams;
+
+    removeUnsupportedSlangCodeActionKinds(params);
+
+    assert.deepStrictEqual(codeActionKind, {});
+  });
+
+  test('does not mutate initialize params when valueSet is not an array', () => {
+    const codeActionKind = { valueSet: 'refactor.move' };
+    const params = {
+      capabilities: {
+        textDocument: {
+          codeAction: {
+            codeActionLiteralSupport: {
+              codeActionKind,
+            },
+          },
+        },
+      },
+    } as unknown as InitializeParams;
+
+    removeUnsupportedSlangCodeActionKinds(params);
+
+    assert.deepStrictEqual(codeActionKind, { valueSet: 'refactor.move' });
+  });
+
+  test('slang runtimes construct the compatibility language client', () => {
+    for (const relativePath of [
+      path.join('src', 'slangServer', 'NativeSlangServerRuntime.ts'),
+      path.join('src', 'slangServer', 'VsCodeWasmSlangServerRuntime.ts'),
+      path.join('src', 'slangServer', 'WasmSlangServerRuntime.ts'),
+    ]) {
+      const source = fs.readFileSync(path.join(getRepositoryRoot(), relativePath), 'utf8');
+
+      assert.ok(
+        source.includes('new SlangLanguageClient('),
+        `${relativePath} should construct SlangLanguageClient`
+      );
+      assert.ok(
+        !source.includes('new LanguageClient('),
+        `${relativePath} should not construct raw LanguageClient`
+      );
+    }
+  });
+});
+
+function createInitializeParams(valueSet: string[]): InitializeParams {
+  return {
+    capabilities: {
+      textDocument: {
+        codeAction: {
+          codeActionLiteralSupport: {
+            codeActionKind: {
+              valueSet,
+            },
+          },
+        },
+      },
+    },
+  } as InitializeParams;
+}


### PR DESCRIPTION
## Summary

- Add a slang-server-only LanguageClient compatibility layer that removes unsupported `refactor.move` from initialize code action kind capabilities.
- Use the compatibility client for native, VS Code WASM, and legacy node WASI slang-server runtimes.
- Remove the WASI-only manual initialize parser patch so bundled WASM follows the upstream typed initialize path.

## Why

Newer VS Code language client capabilities can advertise `textDocument.codeAction.codeActionLiteralSupport.codeActionKind.valueSet` with `refactor.move`. Current slang-server versions parse code action kinds as a closed set during initialize and can fail before language features start. Filtering only this unsupported value in the extension keeps slang-server initialization working without disabling code actions or affecting non-slang language clients.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm test`
- `npm run build:slang-wasm`
- `npm run verify:wasm-bundle`

The rebuilt WASM matched the tracked bundle contents, so no `resources/wasm` files changed.