### PR TITLE
Fix deferred workspace indexing for bundled slang-server

### DIFF
--- a/.vscode-test.slang-wasm-indexing.mjs
+++ b/.vscode-test.slang-wasm-indexing.mjs
@@ -1,0 +1,24 @@
+import { defineConfig } from '@vscode/test-cli';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const tempRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
+const workspaceRoot = fs.mkdtempSync(path.join(tempRoot, 'vh-slang-index-'));
+const userDataRoot = fs.mkdtempSync(path.join(tempRoot, 'vh-slang-user-'));
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+fs.cpSync(
+  path.join(repoRoot, 'src', 'test', 'fixtures', 'slang-wasm-indexing'),
+  workspaceRoot,
+  { recursive: true }
+);
+
+export default defineConfig({
+  files: 'out/src/test/integration/slangWasmIndexing.test.js',
+  installExtensions: ['ms-vscode.wasm-wasi-core'],
+  launchArgs: [
+    workspaceRoot,
+    `--user-data-dir=${userDataRoot}`,
+  ],
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Restored deferred workspace indexing for bundled WASM `slang-server`, including explicit indexes used for cross-file navigation, while limiting automatic whole-workspace indexing in large projects.
+
 ## [1.28.1] - 2026-07-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -601,6 +601,13 @@
             "default": true,
             "markdownDescription": "Route bundled WASM slang-server stderr to the Verilog slang-server output channel."
           },
+          "verilog.slangServer.wasm.maxAutoIndexedFiles": {
+            "scope": "window",
+            "type": "number",
+            "default": 5000,
+            "minimum": 1,
+            "markdownDescription": "Maximum number of HDL files that bundled WASM slang-server will automatically index when `.slang/server.json` has no explicit `index`. Explicit index configuration is not limited."
+          },
           "verilog.slangServer.wasm.memoryLimitMb": {
             "scope": "window",
             "type": "number",
@@ -914,7 +921,8 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
-    "test": "vscode-test",
+    "test": "vscode-test && npm run test:slang-wasm-indexing",
+    "test:slang-wasm-indexing": "vscode-test --config .vscode-test.slang-wasm-indexing.mjs",
     "test:windows": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows]\"",
     "test:windows-wsl2": "vscode-test --config .vscode-test.windows.mjs --fgrep \"[windows-wsl2]\"",
     "syntax": "js-yaml ./syntaxes/systemverilog.tmLanguage.yaml >./syntaxes/systemverilog.tmLanguage.json"

--- a/scripts/patch-slang-server-wasi.mjs
+++ b/scripts/patch-slang-server-wasi.mjs
@@ -186,7 +186,7 @@ patchFile('src/SlangServer.cpp', [
   ],
   [
     '    loadConfig();\n\n    if (params.capabilities.experimental) {\n',
-    '#ifdef __wasi__\n    if (std::getenv("SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING") == nullptr) {\n        loadConfig();\n    }\n    else if (std::getenv("SLANG_SERVER_WASI_TRACE_INIT")) {\n        std::cerr << "WASI initialize checkpoint: skipping startup config load" << std::endl;\n    }\n#else\n    loadConfig();\n#endif\n\n    if (params.capabilities.experimental) {\n'
+    '#ifdef __wasi__\n    if (std::getenv("SLANG_SERVER_WASI_DEFER_CONFIG_LOAD") == nullptr) {\n        loadConfig();\n    }\n    else if (std::getenv("SLANG_SERVER_WASI_TRACE_INIT")) {\n        std::cerr << "WASI initialize checkpoint: deferring startup config load" << std::endl;\n    }\n#else\n    loadConfig();\n#endif\n\n    if (params.capabilities.experimental) {\n'
   ],
   [
     '    auto result =\n        lsp::InitializeResult{\n',
@@ -198,15 +198,15 @@ patchFile('src/SlangServer.cpp', [
   ],
   [
     'void SlangServer::onInitialized(const lsp::InitializedParams&) {\n    INFO("Server initialized at {}", m_workspaceFolder ? m_workspaceFolder->uri.getPath() : "none");\n    m_client.setConfig(m_config);\n',
-    'void SlangServer::onInitialized(const lsp::InitializedParams&) {\n    INFO("Server initialized at {}", m_workspaceFolder ? m_workspaceFolder->uri.getPath() : "none");\n#ifdef __wasi__\n    if (std::getenv("SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING") != nullptr) {\n        loadConfig();\n    }\n    else {\n        m_client.setConfig(m_config);\n    }\n#else\n    m_client.setConfig(m_config);\n#endif\n'
+    'void SlangServer::onInitialized(const lsp::InitializedParams&) {\n    INFO("Server initialized at {}", m_workspaceFolder ? m_workspaceFolder->uri.getPath() : "none");\n#ifdef __wasi__\n    if (std::getenv("SLANG_SERVER_WASI_DEFER_CONFIG_LOAD") != nullptr) {\n        loadConfig();\n    }\n    else {\n        m_client.setConfig(m_config);\n    }\n#else\n    m_client.setConfig(m_config);\n#endif\n'
   ],
   [
     'void SlangServer::loadConfig(const Config& config, bool forceIndexing) {\n    auto old_config = m_config;\n    m_config = Config(config);\n',
     'void SlangServer::loadConfig(const Config& config, bool forceIndexing) {\n    auto old_config = m_config;\n    m_config = Config(config);\n#ifdef __wasi__\n    if (m_config.build.value().has_value()) {\n        m_config.build = makeWasiWorkspaceAbsolute(*m_config.build.value(), m_workspaceFolder);\n    }\n#endif\n'
   ],
   [
-    '    loadConfig(Config::fromFiles(workspaceConf, userConf, localConf, m_client), true);\n',
-    '    bool forceIndexing = true;\n#ifdef __wasi__\n    forceIndexing = std::getenv("SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING") == nullptr;\n#endif\n    loadConfig(Config::fromFiles(workspaceConf, userConf, localConf, m_client), forceIndexing);\n'
+    '    else if (forceIndexing) {\n        auto maybePath = m_workspaceFolder.has_value()\n                             ? std::optional<std::string_view>(m_workspaceFolder->uri.getPath())\n                             : std::nullopt;\n\n        m_indexer.setNumThreads(m_config.indexingThreads.value());\n        m_indexer.startIndexing(m_config.index.value(), maybePath);\n    }\n',
+    '    else if (forceIndexing) {\n#ifdef __wasi__\n        if (m_config.index.value().empty() &&\n            std::getenv("SLANG_SERVER_WASI_SKIP_AUTO_INDEXING") != nullptr) {\n            WARN("Skipping automatic workspace indexing because the client file limit was exceeded; "\n                 "configure an explicit index or increase the client limit");\n        }\n        else\n#endif\n        {\n            auto maybePath = m_workspaceFolder.has_value()\n                                 ? std::optional<std::string_view>(m_workspaceFolder->uri.getPath())\n                                 : std::nullopt;\n\n            m_indexer.setNumThreads(m_config.indexingThreads.value());\n            m_indexer.startIndexing(m_config.index.value(), maybePath);\n        }\n    }\n'
   ]
 ]);
 

--- a/src/slangServer/SlangServerConfig.ts
+++ b/src/slangServer/SlangServerConfig.ts
@@ -19,6 +19,7 @@ export interface SlangServerConfig {
 export interface SlangServerWasmConfig {
   allowUserConfig: boolean;
   logStderr: boolean;
+  maxAutoIndexedFiles: number;
   memoryLimitMb: number;
 }
 
@@ -37,6 +38,7 @@ export function readSlangServerConfig(): SlangServerConfig {
     wasm: {
       allowUserConfig: config.get<boolean>('wasm.allowUserConfig', false),
       logStderr: config.get<boolean>('wasm.logStderr', true),
+      maxAutoIndexedFiles: config.get<number>('wasm.maxAutoIndexedFiles', 5000),
       memoryLimitMb: config.get<number>('wasm.memoryLimitMb', 2048),
     },
   };

--- a/src/slangServer/SlangServerTrace.ts
+++ b/src/slangServer/SlangServerTrace.ts
@@ -13,15 +13,3 @@ export function toLanguageClientTrace(traceServer: SlangServerConfig['traceServe
       return Trace.Off;
   }
 }
-
-export function createWasmServerEnv(traceServer: SlangServerConfig['traceServer']): Record<string, string> {
-  const env: Record<string, string> = {
-    SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING: '1',
-  };
-
-  if (traceServer !== 'off') {
-    env.SLANG_SERVER_TESTS = '1';
-  }
-
-  return env;
-}

--- a/src/slangServer/SlangWasmStartupPolicy.ts
+++ b/src/slangServer/SlangWasmStartupPolicy.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+import * as vscode from 'vscode';
+import type { SlangServerConfig } from './SlangServerConfig';
+
+const HDL_GLOB = '**/*.{v,vh,sv,svh}';
+
+export interface SlangWasmStartupPolicy {
+  env: Record<string, string>;
+  skipAutoIndexing: boolean;
+}
+
+export interface SlangWasmStartupPolicyOptions {
+  workspaceFolder: vscode.WorkspaceFolder;
+  maxAutoIndexedFiles: number;
+  traceServer: SlangServerConfig['traceServer'];
+  outputChannel: Pick<vscode.LogOutputChannel, 'warn'>;
+  findFiles?: typeof vscode.workspace.findFiles;
+}
+
+export async function resolveSlangWasmStartupPolicy(
+  options: SlangWasmStartupPolicyOptions
+): Promise<SlangWasmStartupPolicy> {
+  const findFiles = options.findFiles ?? vscode.workspace.findFiles;
+  let skipAutoIndexing: boolean;
+
+  try {
+    const files = await findFiles(
+      new vscode.RelativePattern(options.workspaceFolder, HDL_GLOB),
+      null,
+      options.maxAutoIndexedFiles + 1
+    );
+    skipAutoIndexing = files.length > options.maxAutoIndexedFiles;
+    if (skipAutoIndexing) {
+      options.outputChannel.warn(
+        `Automatic slang-server workspace indexing was skipped because more than ${options.maxAutoIndexedFiles} HDL files were found. `
+        + 'Configure .slang/server.json "index" or increase verilog.slangServer.wasm.maxAutoIndexedFiles.'
+      );
+    }
+  } catch (err) {
+    skipAutoIndexing = true;
+    options.outputChannel.warn(
+      `Automatic slang-server workspace indexing was skipped because HDL files could not be counted: ${
+        err instanceof Error ? err.message : String(err)
+      }. Configure .slang/server.json "index" or increase verilog.slangServer.wasm.maxAutoIndexedFiles.`
+    );
+  }
+
+  return {
+    env: createWasmServerEnv(options.traceServer, skipAutoIndexing),
+    skipAutoIndexing,
+  };
+}
+
+export function createWasmServerEnv(
+  traceServer: SlangServerConfig['traceServer'],
+  skipAutoIndexing: boolean
+): Record<string, string> {
+  const env: Record<string, string> = {
+    SLANG_SERVER_WASI_DEFER_CONFIG_LOAD: '1',
+  };
+
+  if (skipAutoIndexing) {
+    env.SLANG_SERVER_WASI_SKIP_AUTO_INDEXING = '1';
+  }
+  if (traceServer !== 'off') {
+    env.SLANG_SERVER_TESTS = '1';
+  }
+
+  return env;
+}

--- a/src/slangServer/VsCodeWasmSlangServerRuntime.ts
+++ b/src/slangServer/VsCodeWasmSlangServerRuntime.ts
@@ -20,7 +20,8 @@ import type {
   SlangServerWasmMetadata,
 } from './SlangServerRuntime';
 import { SlangLanguageClient } from './SlangLanguageClientCompat';
-import { createWasmServerEnv, toLanguageClientTrace } from './SlangServerTrace';
+import { toLanguageClientTrace } from './SlangServerTrace';
+import { resolveSlangWasmStartupPolicy } from './SlangWasmStartupPolicy';
 import { WasiFileSystemMapper } from './WasiFileSystemMapper';
 import { readWasmMetadata, type WasmRuntimePaths } from './WasmSlangServerRuntime';
 
@@ -75,6 +76,12 @@ export class VsCodeWasmSlangServerRuntime implements SlangServerRuntime {
     }
 
     try {
+      const startupPolicy = await resolveSlangWasmStartupPolicy({
+        workspaceFolder,
+        maxAutoIndexedFiles: this.config.wasm.maxAutoIndexedFiles,
+        traceServer: this.config.traceServer,
+        outputChannel: this.options.outputChannel,
+      });
       await fs.promises.mkdir(paths.tmpRoot, { recursive: true });
       this.metadata = await readWasmMetadata(paths.metadataPath);
       this.mapper = new WasiFileSystemMapper({
@@ -88,7 +95,7 @@ export class VsCodeWasmSlangServerRuntime implements SlangServerRuntime {
         const wasm = await Wasm.load();
         const processOptions: ProcessOptions = {
           args: this.config.args,
-          env: createWasmServerEnv(this.config.traceServer),
+          env: startupPolicy.env,
           stdio: createStdioOptions(),
           mountPoints: [
             { kind: 'vscodeFileSystem', uri: workspaceRoot, mountPoint: '/workspace' },

--- a/src/slangServer/WasmSlangServerRuntime.ts
+++ b/src/slangServer/WasmSlangServerRuntime.ts
@@ -20,6 +20,7 @@ import type {
 } from './SlangServerRuntime';
 import { SlangLanguageClient } from './SlangLanguageClientCompat';
 import { toLanguageClientTrace } from './SlangServerTrace';
+import { resolveSlangWasmStartupPolicy } from './SlangWasmStartupPolicy';
 import { WasiFileSystemMapper } from './WasiFileSystemMapper';
 
 export interface WasmRuntimePaths {
@@ -75,6 +76,13 @@ export class WasmSlangServerRuntime implements SlangServerRuntime {
       return;
     }
 
+    const startupPolicy = await resolveSlangWasmStartupPolicy({
+      workspaceFolder,
+      maxAutoIndexedFiles: this.config.wasm.maxAutoIndexedFiles,
+      traceServer: this.config.traceServer,
+      outputChannel: this.options.outputChannel,
+    });
+
     await fs.promises.mkdir(paths.tmpRoot, { recursive: true });
     this.metadata = await readWasmMetadata(paths.metadataPath);
     this.mapper = new WasiFileSystemMapper({
@@ -95,6 +103,7 @@ export class WasmSlangServerRuntime implements SlangServerRuntime {
         }),
       ], {
         stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, ...startupPolicy.env },
       });
       this.helper.stderr.setEncoding('utf8');
       this.helper.stderr.on('data', (chunk: string) => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -183,6 +183,12 @@ suite('Extension Test Suite', () => {
     assert.ok(properties['verilog.slangServer.trace.server']);
     assert.ok(properties['verilog.slangServer.wasm.allowUserConfig']);
     assert.ok(properties['verilog.slangServer.wasm.logStderr']);
+    const maxAutoIndexedFiles = properties['verilog.slangServer.wasm.maxAutoIndexedFiles'] as {
+      default?: unknown;
+      minimum?: unknown;
+    };
+    assert.strictEqual(maxAutoIndexedFiles.default, 5000);
+    assert.strictEqual(maxAutoIndexedFiles.minimum, 1);
     assert.ok(properties['verilog.slangServer.wasm.memoryLimitMb']);
     assert.ok(properties['verilog.hdlExplorer.enabled']);
     const runOnOpen = properties['verilog.linting.runOnOpen'] as { default?: unknown };

--- a/src/test/fixtures/slang-wasm-indexing/.vscode/settings.json
+++ b/src/test/fixtures/slang-wasm-indexing/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "verilog.linting.linter": "none",
+  "verilog.slangServer.enabled": true,
+  "verilog.slangServer.runtime": "bundled-wasm",
+  "verilog.slangServer.trace.server": "off",
+  "verilog.slangServer.wasm.maxAutoIndexedFiles": 2
+}

--- a/src/test/fixtures/slang-wasm-indexing/filelists/top_only.f
+++ b/src/test/fixtures/slang-wasm-indexing/filelists/top_only.f
@@ -1,0 +1,1 @@
+rtl/top.v

--- a/src/test/fixtures/slang-wasm-indexing/rtl/auto_child.v
+++ b/src/test/fixtures/slang-wasm-indexing/rtl/auto_child.v
@@ -1,0 +1,2 @@
+module veriloghdl_wasm_auto_child;
+endmodule

--- a/src/test/fixtures/slang-wasm-indexing/rtl/top.v
+++ b/src/test/fixtures/slang-wasm-indexing/rtl/top.v
@@ -1,0 +1,4 @@
+module veriloghdl_wasm_index_top;
+  veriloghdl_wasm_auto_child u_auto();
+  veriloghdl_wasm_explicit_child u_indexed();
+endmodule

--- a/src/test/integration/slangWasmIndexing.test.ts
+++ b/src/test/integration/slangWasmIndexing.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getRepositoryRoot, sameFsPath } from '../pathTestUtils';
+
+suite('bundled WASM slang-server workspace indexing', () => {
+  test('resolves default and explicit-index definitions after deferred startup', async function () {
+    this.timeout(90000);
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder || !vscode.extensions.getExtension('ms-vscode.wasm-wasi-core')) {
+      this.skip();
+    }
+    if (!await fileExists(path.join(getRepositoryRoot(), 'resources', 'wasm', 'slang-server.wasm'))) {
+      this.skip();
+    }
+
+    const extension = vscode.extensions.getExtension('mshr-h.veriloghdl');
+    assert.ok(extension);
+    await extension.activate();
+
+    const topUri = vscode.Uri.joinPath(folder.uri, 'rtl', 'top.v');
+    const document = await vscode.workspace.openTextDocument(topUri);
+    await vscode.window.showTextDocument(document);
+
+    const autoTarget = vscode.Uri.joinPath(folder.uri, 'rtl', 'auto_child.v');
+    await waitForDefinition(document, 'veriloghdl_wasm_auto_child', autoTarget, 30000);
+
+    const slangDir = vscode.Uri.joinPath(folder.uri, '.slang');
+    await vscode.workspace.fs.createDirectory(slangDir);
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.joinPath(slangDir, 'server.json'),
+      Buffer.from(JSON.stringify({
+        flags: '-f filelists/top_only.f',
+        build: 'filelists/top_only.f',
+        index: [{ dirs: ['rtl'] }],
+      }, null, 2))
+    );
+    const explicitTarget = vscode.Uri.joinPath(folder.uri, 'rtl', 'indexed_child.v');
+    await vscode.workspace.fs.writeFile(
+      explicitTarget,
+      Buffer.from('module veriloghdl_wasm_explicit_child;\nendmodule\n')
+    );
+    await vscode.commands.executeCommand('verilog.restartSlangServer');
+
+    await waitForDefinition(document, 'veriloghdl_wasm_explicit_child', explicitTarget, 30000);
+  });
+});
+
+async function waitForDefinition(
+  document: vscode.TextDocument,
+  symbol: string,
+  expectedUri: vscode.Uri,
+  timeoutMs: number
+): Promise<void> {
+  const offset = document.getText().indexOf(symbol);
+  assert.ok(offset >= 0, `Symbol ${symbol} was not found in ${document.uri.fsPath}`);
+  const position = document.positionAt(offset + 1);
+  const startedAt = Date.now();
+  let lastResult: unknown;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await vscode.commands.executeCommand<Array<vscode.Location | vscode.LocationLink>>(
+      'vscode.executeDefinitionProvider',
+      document.uri,
+      position
+    );
+    lastResult = result;
+    if (result?.some((location) => sameFsPath(definitionUri(location).fsPath, expectedUri.fsPath))) {
+      return;
+    }
+    await delay(200);
+  }
+
+  assert.fail(`Definition for ${symbol} did not resolve to ${expectedUri.fsPath}: ${JSON.stringify(lastResult)}`);
+}
+
+function definitionUri(location: vscode.Location | vscode.LocationLink): vscode.Uri {
+  return 'targetUri' in location ? location.targetUri : location.uri;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/test/slangRuntimeUx.test.ts
+++ b/src/test/slangRuntimeUx.test.ts
@@ -5,8 +5,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { selectSlangServerRuntime } from '../slangServer/SlangServerRuntimeSelector';
 import { formatSlangServerStatusBarText } from '../slangServer/SlangServerStatusBar';
-import type { SlangServerConfig } from '../slangServer/SlangServerConfig';
-import { createWasmServerEnv, toLanguageClientTrace } from '../slangServer/SlangServerTrace';
+import { readSlangServerConfig, type SlangServerConfig } from '../slangServer/SlangServerConfig';
+import { toLanguageClientTrace } from '../slangServer/SlangServerTrace';
+import {
+  createWasmServerEnv,
+  resolveSlangWasmStartupPolicy,
+} from '../slangServer/SlangWasmStartupPolicy';
 import {
   createSlangWasmUriConverters,
   createWasmMemoryDescriptor,
@@ -83,17 +87,87 @@ suite('slang-server runtime UX', () => {
   });
 
   test('VS Code WASM runtime only enables server trace env when configured', () => {
-    assert.deepStrictEqual(createWasmServerEnv('off'), {
-      SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING: '1',
+    assert.deepStrictEqual(createWasmServerEnv('off', false), {
+      SLANG_SERVER_WASI_DEFER_CONFIG_LOAD: '1',
     });
-    assert.deepStrictEqual(createWasmServerEnv('messages'), {
-      SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING: '1',
+    assert.deepStrictEqual(createWasmServerEnv('messages', false), {
+      SLANG_SERVER_WASI_DEFER_CONFIG_LOAD: '1',
       SLANG_SERVER_TESTS: '1',
     });
-    assert.deepStrictEqual(createWasmServerEnv('verbose'), {
-      SLANG_SERVER_WASI_SKIP_STARTUP_INDEXING: '1',
+    assert.deepStrictEqual(createWasmServerEnv('verbose', true), {
+      SLANG_SERVER_WASI_DEFER_CONFIG_LOAD: '1',
+      SLANG_SERVER_WASI_SKIP_AUTO_INDEXING: '1',
       SLANG_SERVER_TESTS: '1',
     });
+  });
+
+  test('WASM auto-index file limit is read from configuration', async () => {
+    const settings = vscode.workspace.getConfiguration('verilog.slangServer');
+    const previous = settings.inspect<number>('wasm.maxAutoIndexedFiles')?.globalValue;
+    try {
+      await settings.update('wasm.maxAutoIndexedFiles', 1234, vscode.ConfigurationTarget.Global);
+      assert.strictEqual(readSlangServerConfig().wasm.maxAutoIndexedFiles, 1234);
+    } finally {
+      await settings.update('wasm.maxAutoIndexedFiles', previous, vscode.ConfigurationTarget.Global);
+    }
+  });
+
+  test('WASM startup policy bounds file discovery and skips only above the limit', async () => {
+    const folder = workspaceFolderFixture();
+    const warnings: string[] = [];
+    let requestedMaxResults: number | undefined;
+    let requestedPattern: string | undefined;
+    let requestedExclude: vscode.GlobPattern | null | undefined;
+    const findFiles = (async (
+      include: vscode.GlobPattern,
+      exclude?: vscode.GlobPattern | null,
+      maxResults?: number
+    ) => {
+      requestedMaxResults = maxResults;
+      requestedPattern = include instanceof vscode.RelativePattern ? include.pattern : String(include);
+      requestedExclude = exclude;
+      return Array.from({ length: 6 }, (_, index) => vscode.Uri.file(path.join(folder.uri.fsPath, `${index}.sv`)));
+    }) as typeof vscode.workspace.findFiles;
+
+    const policy = await resolveSlangWasmStartupPolicy({
+      workspaceFolder: folder,
+      maxAutoIndexedFiles: 5,
+      traceServer: 'off',
+      outputChannel: { warn: (message) => warnings.push(message) },
+      findFiles,
+    });
+
+    assert.strictEqual(requestedPattern, '**/*.{v,vh,sv,svh}');
+    assert.strictEqual(requestedExclude, null);
+    assert.strictEqual(requestedMaxResults, 6);
+    assert.strictEqual(policy.skipAutoIndexing, true);
+    assert.strictEqual(policy.env.SLANG_SERVER_WASI_SKIP_AUTO_INDEXING, '1');
+    assert.match(warnings[0], /more than 5 HDL files/);
+
+    const allowed = await resolveSlangWasmStartupPolicy({
+      workspaceFolder: folder,
+      maxAutoIndexedFiles: 6,
+      traceServer: 'off',
+      outputChannel: { warn: (message) => warnings.push(message) },
+      findFiles,
+    });
+    assert.strictEqual(allowed.skipAutoIndexing, false);
+    assert.ok(!('SLANG_SERVER_WASI_SKIP_AUTO_INDEXING' in allowed.env));
+  });
+
+  test('WASM startup policy safely skips automatic indexing when file discovery fails', async () => {
+    const warnings: string[] = [];
+    const policy = await resolveSlangWasmStartupPolicy({
+      workspaceFolder: workspaceFolderFixture(),
+      maxAutoIndexedFiles: 5000,
+      traceServer: 'off',
+      outputChannel: { warn: (message) => warnings.push(message) },
+      findFiles: (async () => { throw new Error('search failed'); }) as typeof vscode.workspace.findFiles,
+    });
+
+    assert.strictEqual(policy.skipAutoIndexing, true);
+    assert.strictEqual(policy.env.SLANG_SERVER_WASI_SKIP_AUTO_INDEXING, '1');
+    assert.match(warnings[0], /search failed/);
   });
 
   test('VS Code WASM URI converters map workspace diagnostics back to host files', () => {
@@ -162,8 +236,17 @@ function config(input: { runtime: SlangServerConfig['runtime']; path: string }):
     wasm: {
       allowUserConfig: false,
       logStderr: true,
+      maxAutoIndexedFiles: 5000,
       memoryLimitMb: 2048,
     },
+  };
+}
+
+function workspaceFolderFixture(): vscode.WorkspaceFolder {
+  return {
+    uri: vscode.Uri.file(path.join(os.tmpdir(), 'slang-startup-policy-workspace')),
+    name: 'slang-startup-policy-workspace',
+    index: 0,
   };
 }
 


### PR DESCRIPTION
## Summary

- defer bundled WASM slang-server config loading until after the initialize response
- restore default workspace indexing and explicit modern / legacy index handling
- skip only implicit whole-workspace indexing when the configurable HDL file limit is exceeded
- share the startup policy across the VS Code WASI runtime and legacy Node WASI helper

## Root cause

The bundled runtime always set a single WASI environment variable that both deferred startup config loading and forced the later config reload to disable indexing. As a result, neither the default workspace index nor an explicit modern index was populated.

This change separates those states. Config loading remains deferred until the initialized notification, while indexing runs normally unless only the automatic whole-workspace fallback exceeds the configured limit. Native slang-server behavior is unchanged.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` — 184 passing, 4 pending; WASM Definition integration 1 passing
- `npm run build:slang-wasm`
- `npm run verify:wasm-bundle`