### PR TITLE
Use slang-server inactive preprocessor regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ While using ``include` directives, the path to included files should be relative
 
 ## Inactive Preprocessor Regions
 
-Inactive Verilog/SystemVerilog preprocessor branches controlled by ``ifdef`, ``ifndef`, ``elsif`, ``else`, and ``endif` are highlighted in the editor. The decoration helper uses macros defined in the current document plus workspace-wide macros configured in `verilog.preprocessor.defines`.
+Inactive Verilog/SystemVerilog preprocessor branches controlled by ``ifdef`, ``ifndef`, ``elsif`, ``else`, and ``endif` are highlighted in the editor. When slang-server is running, its project-aware inactive-region analysis reflects the active `.slang/server.json`, filelists, includes, and `-D` defines. If slang-server is unavailable or does not support inactive-region notifications, the decoration helper falls back to macros defined in the current document plus workspace-wide macros configured in `verilog.preprocessor.defines`.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ While using ``include` directives, the path to included files should be relative
 
 ## Inactive Preprocessor Regions
 
-Inactive Verilog/SystemVerilog preprocessor branches controlled by ``ifdef`, ``ifndef`, ``elsif`, ``else`, and ``endif` are highlighted in the editor. When slang-server is running, its project-aware inactive-region analysis reflects the active `.slang/server.json`, filelists, includes, and `-D` defines. If slang-server is unavailable or does not support inactive-region notifications, the decoration helper falls back to macros defined in the current document plus workspace-wide macros configured in `verilog.preprocessor.defines`.
+Inactive Verilog/SystemVerilog preprocessor branches controlled by `` `ifdef``, `` `ifndef``, `` `elsif``, `` `else``, and `` `endif`` are highlighted in the editor. When slang-server is running, its project-aware inactive-region analysis reflects the active `.slang/server.json`, filelists, includes, and `-D` defines. If slang-server is unavailable or does not support inactive-region notifications, the decoration helper falls back to macros defined in the current document plus workspace-wide macros configured in `verilog.preprocessor.defines`.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -715,7 +715,7 @@
               "type": "string"
             },
             "default": [],
-            "markdownDescription": "Macro names to treat as predefined for Verilog/SystemVerilog preprocessor inactive-code highlighting."
+            "markdownDescription": "Macro names to treat as predefined for fallback Verilog/SystemVerilog inactive-code highlighting when slang-server regions are unavailable."
           },
           "verilog.preprocessor.inactiveCode.enabled": {
             "scope": "window",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  context.subscriptions.push(new InactivePreprocessorDecorationProvider());
+  context.subscriptions.push(new InactivePreprocessorDecorationProvider(slangServerManager));
 
   lintManager = new LintManager();
   context.subscriptions.push(lintManager);

--- a/src/providers/InactivePreprocessorDecorationProvider.ts
+++ b/src/providers/InactivePreprocessorDecorationProvider.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import * as vscode from 'vscode';
+import type { SlangServerManager } from '../slangServer/SlangServerManager';
 
 interface InactivePreprocessorRange {
   startLine: number;
@@ -199,11 +200,19 @@ export function mergePreprocessorDefines(configuredDefines: readonly string[]): 
   return [...new Set(configuredDefines)];
 }
 
+export function selectInactivePreprocessorRanges<T>(
+  serverRanges: readonly T[] | undefined,
+  computeFallback: () => readonly T[]
+): readonly T[] {
+  return serverRanges ?? computeFallback();
+}
+
 export class InactivePreprocessorDecorationProvider implements vscode.Disposable {
   private readonly subscriptions: vscode.Disposable[] = [];
+  private readonly serverRanges = new Map<string, readonly vscode.Range[]>();
   private decorationType: vscode.TextEditorDecorationType | undefined;
 
-  constructor() {
+  constructor(slangServerManager?: SlangServerManager) {
     this.recreateDecorationType();
     this.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(() => {
@@ -224,6 +233,24 @@ export class InactivePreprocessorDecorationProvider implements vscode.Disposable
         this.updateVisibleEditors();
       })
     );
+    if (slangServerManager) {
+      this.subscriptions.push(
+        slangServerManager.onDidChangeInactiveRegions((event) => {
+          if (event === undefined) {
+            this.serverRanges.clear();
+            this.updateVisibleEditors();
+            return;
+          }
+          const key = event.uri.toString();
+          this.serverRanges.set(key, event.ranges);
+          for (const editor of vscode.window.visibleTextEditors) {
+            if (editor.document.uri.toString() === key) {
+              this.updateEditor(editor);
+            }
+          }
+        })
+      );
+    }
     this.updateVisibleEditors();
   }
 
@@ -267,11 +294,12 @@ export class InactivePreprocessorDecorationProvider implements vscode.Disposable
       return;
     }
 
-    const config = vscode.workspace.getConfiguration('verilog.preprocessor');
-    const ranges = computeInactivePreprocessorRanges(
-      editor.document.getText(),
-      mergePreprocessorDefines(config.get<string[]>('defines', []))
-    ).map((range) => this.toVscodeRange(editor.document, range));
+    const key = editor.document.uri.toString();
+    const serverRanges = this.serverRanges.get(key);
+    const ranges = selectInactivePreprocessorRanges(
+      serverRanges,
+      () => this.computeFallbackRanges(editor.document)
+    );
     editor.setDecorations(this.decorationType, ranges);
   }
 
@@ -285,6 +313,14 @@ export class InactivePreprocessorDecorationProvider implements vscode.Disposable
     return vscode.workspace
       .getConfiguration('verilog.preprocessor.inactiveCode')
       .get('enabled', true);
+  }
+
+  private computeFallbackRanges(document: vscode.TextDocument): vscode.Range[] {
+    const config = vscode.workspace.getConfiguration('verilog.preprocessor');
+    return computeInactivePreprocessorRanges(
+      document.getText(),
+      mergePreprocessorDefines(config.get<string[]>('defines', []))
+    ).map((range) => this.toVscodeRange(document, range));
   }
 
   private toVscodeRange(

--- a/src/slangServer/NativeSlangServerRuntime.ts
+++ b/src/slangServer/NativeSlangServerRuntime.ts
@@ -10,13 +10,14 @@ import {
 import { runTool } from '../tools/ToolRunner';
 import { SlangLanguageClient } from './SlangLanguageClientCompat';
 import type { SlangServerConfig } from './SlangServerConfig';
-import type { SlangServerRuntime, SlangServerStatus, SlangServerState } from './SlangServerRuntime';
+import type { SlangInactiveRegions, SlangServerRuntime, SlangServerStatus, SlangServerState } from './SlangServerRuntime';
 import { toLanguageClientTrace } from './SlangServerTrace';
 
 export interface NativeSlangServerRuntimeOptions {
   outputChannel: vscode.LogOutputChannel;
   onStatusChange?: () => void;
   onCrash?: (reason: string) => void;
+  onInactiveRegions?: (regions: SlangInactiveRegions) => void;
 }
 
 export class NativeSlangServerRuntime implements SlangServerRuntime {
@@ -69,7 +70,8 @@ export class NativeSlangServerRuntime implements SlangServerRuntime {
       'verilog-slang-server',
       'Verilog slang-server',
       serverOptions,
-      clientOptions
+      clientOptions,
+      this.options.onInactiveRegions
     );
     this.client.onDidChangeState((event) => {
       if (!this.stopping && event.newState === State.Stopped && this.state === 'running') {

--- a/src/slangServer/SlangLanguageClientCompat.ts
+++ b/src/slangServer/SlangLanguageClientCompat.ts
@@ -3,10 +3,24 @@ import {
   LanguageClient,
   type InitializeParams,
   type LanguageClientOptions,
+  type Range as ProtocolRange,
   type ServerOptions,
 } from 'vscode-languageclient/node';
+import type { SlangInactiveRegions } from './SlangServerRuntime';
 
 const UNSUPPORTED_SLANG_CODE_ACTION_KIND = 'refactor.move';
+const INACTIVE_REGIONS_NOTIFICATION = 'textDocument/inactiveRegions';
+
+interface InactiveRegionsParams {
+  uri: string;
+  regions: ProtocolRange[];
+}
+
+export function enableSlangInactiveRegions(params: InitializeParams): void {
+  const experimental = (params.capabilities.experimental ?? {}) as Record<string, unknown>;
+  experimental.inactiveRegions = { inactiveRegions: true };
+  params.capabilities.experimental = experimental;
+}
 
 export function removeUnsupportedSlangCodeActionKinds(params: InitializeParams): void {
   const codeActionKind =
@@ -28,13 +42,23 @@ export class SlangLanguageClient extends LanguageClient {
     name: string,
     serverOptions: ServerOptions,
     clientOptions: LanguageClientOptions,
+    onInactiveRegions?: (regions: SlangInactiveRegions) => void,
     forceDebug?: boolean
   ) {
     super(id, name, serverOptions, clientOptions, forceDebug);
+    if (onInactiveRegions) {
+      this.onNotification(INACTIVE_REGIONS_NOTIFICATION, (params: InactiveRegionsParams) => {
+        onInactiveRegions({
+          uri: this.protocol2CodeConverter.asUri(params.uri),
+          ranges: params.regions.map((range) => this.protocol2CodeConverter.asRange(range)),
+        });
+      });
+    }
   }
 
   protected override fillInitializeParams(params: InitializeParams): void {
     super.fillInitializeParams(params);
     removeUnsupportedSlangCodeActionKinds(params);
+    enableSlangInactiveRegions(params);
   }
 }

--- a/src/slangServer/SlangServerManager.ts
+++ b/src/slangServer/SlangServerManager.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { readSlangServerConfig } from './SlangServerConfig';
 import { NativeSlangServerRuntime } from './NativeSlangServerRuntime';
 import { selectSlangServerRuntime } from './SlangServerRuntimeSelector';
-import type { SlangServerRuntime, SlangServerStatus } from './SlangServerRuntime';
+import type { SlangInactiveRegions, SlangServerRuntime, SlangServerStatus } from './SlangServerRuntime';
 import { VsCodeWasmSlangServerRuntime } from './VsCodeWasmSlangServerRuntime';
 import { WasmSlangServerRuntime } from './WasmSlangServerRuntime';
 
@@ -12,15 +12,18 @@ export class SlangServerManager implements vscode.Disposable {
   private readonly outputChannel = vscode.window.createOutputChannel('Verilog slang-server', { log: true });
   private readonly disposables: vscode.Disposable[] = [];
   private readonly statusEmitter = new vscode.EventEmitter<SlangServerStatus>();
+  private readonly inactiveRegionsEmitter = new vscode.EventEmitter<SlangInactiveRegions | undefined>();
   private lastCrashReason: string | undefined;
   private lastCrashAt: string | undefined;
   private crashNotificationShown = false;
 
   readonly onDidChangeStatus = this.statusEmitter.event;
+  readonly onDidChangeInactiveRegions = this.inactiveRegionsEmitter.event;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.disposables.push(
       this.statusEmitter,
+      this.inactiveRegionsEmitter,
       vscode.workspace.onDidChangeConfiguration((event) => {
         if (event.affectsConfiguration('verilog.slangServer')) {
           void this.restart();
@@ -30,6 +33,7 @@ export class SlangServerManager implements vscode.Disposable {
   }
 
   async start(): Promise<void> {
+    this.inactiveRegionsEmitter.fire(undefined);
     const config = readSlangServerConfig();
     await this.runtime?.stop();
     this.runtime = undefined;
@@ -46,6 +50,7 @@ export class SlangServerManager implements vscode.Disposable {
           outputChannel: this.outputChannel,
           onStatusChange: () => this.emitStatus(),
           onCrash: (reason) => this.recordCrash(reason),
+          onInactiveRegions: (regions) => this.inactiveRegionsEmitter.fire(regions),
         })
       : this.createBundledWasmRuntime(config);
     await this.runtime.start();
@@ -56,6 +61,7 @@ export class SlangServerManager implements vscode.Disposable {
   }
 
   async stop(): Promise<void> {
+    this.inactiveRegionsEmitter.fire(undefined);
     await this.runtime?.stop();
     this.emitStatus();
   }
@@ -112,6 +118,7 @@ export class SlangServerManager implements vscode.Disposable {
   }
 
   private recordCrash(reason: string): void {
+    this.inactiveRegionsEmitter.fire(undefined);
     this.lastCrashReason = reason;
     this.lastCrashAt = new Date().toISOString();
     if (this.crashNotificationShown) {
@@ -141,6 +148,7 @@ export class SlangServerManager implements vscode.Disposable {
       outputChannel: this.outputChannel,
       onStatusChange: () => this.emitStatus(),
       onCrash: (reason: string) => this.recordCrash(reason),
+      onInactiveRegions: (regions: SlangInactiveRegions) => this.inactiveRegionsEmitter.fire(regions),
     };
     if (process.env.VERILOGHDL_SLANG_WASM_RUNTIME === 'node') {
       this.outputChannel.info('Using legacy node:wasi helper slang-server runtime provider.');

--- a/src/slangServer/SlangServerRuntime.ts
+++ b/src/slangServer/SlangServerRuntime.ts
@@ -4,6 +4,11 @@ import * as vscode from 'vscode';
 export type SlangServerState = 'stopped' | 'starting' | 'running' | 'error';
 export type SlangServerResolvedRuntime = 'native' | 'bundled-wasm';
 
+export interface SlangInactiveRegions {
+  uri: vscode.Uri;
+  ranges: vscode.Range[];
+}
+
 export interface SlangServerWasmMetadata {
   slangServerCommit?: string;
   slangCommit?: string;

--- a/src/slangServer/VsCodeWasmSlangServerRuntime.ts
+++ b/src/slangServer/VsCodeWasmSlangServerRuntime.ts
@@ -15,6 +15,7 @@ import {
 import type { SlangServerConfig } from './SlangServerConfig';
 import type {
   SlangServerRuntime,
+  SlangInactiveRegions,
   SlangServerState,
   SlangServerStatus,
   SlangServerWasmMetadata,
@@ -30,6 +31,7 @@ export interface VsCodeWasmSlangServerRuntimeOptions {
   outputChannel: vscode.LogOutputChannel;
   onStatusChange?: () => void;
   onCrash?: (reason: string) => void;
+  onInactiveRegions?: (regions: SlangInactiveRegions) => void;
 }
 
 export class VsCodeWasmSlangServerRuntime implements SlangServerRuntime {
@@ -137,7 +139,8 @@ export class VsCodeWasmSlangServerRuntime implements SlangServerRuntime {
         'verilog-slang-server-vscode-wasm',
         'Verilog slang-server VS Code WASM',
         serverOptions,
-        clientOptions
+        clientOptions,
+        this.options.onInactiveRegions
       );
       this.client.onDidChangeState((event) => {
         if (!this.stopping && event.newState === State.Stopped && this.state === 'running') {

--- a/src/slangServer/WasmSlangServerRuntime.ts
+++ b/src/slangServer/WasmSlangServerRuntime.ts
@@ -14,6 +14,7 @@ import {
 import type { SlangServerConfig } from './SlangServerConfig';
 import type {
   SlangServerRuntime,
+  SlangInactiveRegions,
   SlangServerStatus,
   SlangServerState,
   SlangServerWasmMetadata,
@@ -35,6 +36,7 @@ export interface WasmSlangServerRuntimeOptions {
   outputChannel: vscode.LogOutputChannel;
   onStatusChange?: () => void;
   onCrash?: (reason: string) => void;
+  onInactiveRegions?: (regions: SlangInactiveRegions) => void;
 }
 
 export class WasmSlangServerRuntime implements SlangServerRuntime {
@@ -134,7 +136,8 @@ export class WasmSlangServerRuntime implements SlangServerRuntime {
       'verilog-slang-server-wasm',
       'Verilog slang-server WASM',
       serverOptions,
-      clientOptions
+      clientOptions,
+      this.options.onInactiveRegions
     );
     this.client.onDidChangeState((event) => {
       if (!this.stopping && event.newState === State.Stopped && this.state === 'running') {

--- a/src/test/inactivePreprocessor.test.ts
+++ b/src/test/inactivePreprocessor.test.ts
@@ -3,9 +3,32 @@ import * as assert from 'assert';
 import {
   computeInactivePreprocessorRanges,
   mergePreprocessorDefines,
+  selectInactivePreprocessorRanges,
 } from '../providers/InactivePreprocessorDecorationProvider';
 
 suite('Inactive Preprocessor Ranges', () => {
+  test('prefers server ranges without evaluating the fallback', () => {
+    const serverRanges = [{ startLine: 2, endLine: 4 }];
+    const ranges = selectInactivePreprocessorRanges(serverRanges, () => {
+      assert.fail('fallback should not be evaluated');
+    });
+
+    assert.strictEqual(ranges, serverRanges);
+  });
+
+  test('treats an empty server result as authoritative', () => {
+    const ranges = selectInactivePreprocessorRanges([], () => [{ startLine: 1, endLine: 1 }]);
+
+    assert.deepStrictEqual(ranges, []);
+  });
+
+  test('uses local analysis before a server result is available', () => {
+    const fallback = [{ startLine: 1, endLine: 1 }];
+    const ranges = selectInactivePreprocessorRanges(undefined, () => fallback);
+
+    assert.strictEqual(ranges, fallback);
+  });
+
   test('undefined macro makes ifdef body inactive', () => {
     const ranges = computeInactivePreprocessorRanges(
       ['`ifdef FOO', 'assign a = 1;', '`endif'].join('\n'),

--- a/src/test/slangLanguageClientCompat.test.ts
+++ b/src/test/slangLanguageClientCompat.test.ts
@@ -3,10 +3,36 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { InitializeParams } from 'vscode-languageclient/node';
-import { removeUnsupportedSlangCodeActionKinds } from '../slangServer/SlangLanguageClientCompat';
+import {
+  enableSlangInactiveRegions,
+  removeUnsupportedSlangCodeActionKinds,
+} from '../slangServer/SlangLanguageClientCompat';
 import { getRepositoryRoot } from './pathTestUtils';
 
 suite('SlangLanguageClient compatibility', () => {
+  test('advertises inactive region notification support', () => {
+    const params = { capabilities: {} } as InitializeParams;
+
+    enableSlangInactiveRegions(params);
+
+    assert.deepStrictEqual(params.capabilities.experimental, {
+      inactiveRegions: { inactiveRegions: true },
+    });
+  });
+
+  test('preserves other experimental capabilities', () => {
+    const params = {
+      capabilities: { experimental: { existing: true } },
+    } as unknown as InitializeParams;
+
+    enableSlangInactiveRegions(params);
+
+    assert.deepStrictEqual(params.capabilities.experimental, {
+      existing: true,
+      inactiveRegions: { inactiveRegions: true },
+    });
+  });
+
   test('removes only refactor.move from initialize code action kind values', () => {
     const valueSet = [
       '',


### PR DESCRIPTION
## Summary

- advertise slang-server inactive-region support and consume `textDocument/inactiveRegions` notifications
- use project-aware slang-server ranges across native and bundled WASM runtimes
- retain the existing local preprocessor analysis as a fallback when server ranges are unavailable
- clear cached server ranges on stop, restart, or crash and document the updated behavior

## Why

The existing inactive-region decoration only considered document-local macros and `verilog.preprocessor.defines`. It could not reflect the active slang project configuration, filelists, includes, or command-line `-D` defines. slang-server already computes and publishes the authoritative inactive ranges, so the extension can use those directly.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run compile-tests`
- `npm test` — 189 passing, 3 pending
- `npm run test:slang-wasm-indexing` — 1 passing
- `git diff --check`